### PR TITLE
Updated the ecms_base profile to install some basic modules & config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - Added the [ACSF module](https://www.drupal.org/project/acsf) as a required dependency.
 - Added the [openid_connect](https://www.drupal.org/project/openid_connect) module as a dependency.
+- Added required modules/configuration based on the standard installation profile.
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "cweagans/composer-patches": "^1.6",
     "drupal/acsf": "^2.67",
     "drupal/core-recommended": "^9",
-    "drupal/openid_connect": "^1.0@beta",
+    "drupal/openid_connect": "1.x-dev",
     "drush/drush": "^10.0",
     "zaporylie/composer-drupal-optimizations": "^1.0"
   },

--- a/ecms_base/config/install/block_content.type.basic.yml
+++ b/ecms_base/config/install/block_content.type.basic.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: basic
+label: 'Basic block'
+revision: 0
+description: 'A basic block contains a title and a body.'

--- a/ecms_base/config/install/editor.editor.basic_html.yml
+++ b/ecms_base/config/install/editor.editor.basic_html.yml
@@ -1,0 +1,52 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.basic_html
+  module:
+    - ckeditor
+format: basic_html
+editor: ckeditor
+settings:
+  toolbar:
+    rows:
+      -
+        -
+          name: Formatting
+          items:
+            - Bold
+            - Italic
+        -
+          name: Linking
+          items:
+            - DrupalLink
+            - DrupalUnlink
+        -
+          name: Lists
+          items:
+            - BulletedList
+            - NumberedList
+        -
+          name: Media
+          items:
+            - Blockquote
+            - DrupalImage
+        -
+          name: 'Block Formatting'
+          items:
+            - Format
+        -
+          name: Tools
+          items:
+            - Source
+  plugins:
+    stylescombo:
+      styles: ''
+image_upload:
+  status: true
+  scheme: public
+  directory: inline-images
+  max_size: ''
+  max_dimensions:
+    width: 0
+    height: 0

--- a/ecms_base/config/install/editor.editor.full_html.yml
+++ b/ecms_base/config/install/editor.editor.full_html.yml
@@ -1,0 +1,60 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.full_html
+  module:
+    - ckeditor
+format: full_html
+editor: ckeditor
+settings:
+  toolbar:
+    rows:
+      -
+        -
+          name: Formatting
+          items:
+            - Bold
+            - Italic
+            - Strike
+            - Superscript
+            - Subscript
+            - '-'
+            - RemoveFormat
+        -
+          name: Linking
+          items:
+            - DrupalLink
+            - DrupalUnlink
+        -
+          name: Lists
+          items:
+            - BulletedList
+            - NumberedList
+        -
+          name: Media
+          items:
+            - Blockquote
+            - DrupalImage
+            - Table
+            - HorizontalRule
+        -
+          name: 'Block Formatting'
+          items:
+            - Format
+        -
+          name: Tools
+          items:
+            - ShowBlocks
+            - Source
+  plugins:
+    stylescombo:
+      styles: ''
+image_upload:
+  status: true
+  scheme: public
+  directory: inline-images
+  max_size: ''
+  max_dimensions:
+    width: 0
+    height: 0

--- a/ecms_base/config/install/filter.format.basic_html.yml
+++ b/ecms_base/config/install/filter.format.basic_html.yml
@@ -1,0 +1,44 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - editor
+name: 'Basic HTML'
+format: basic_html
+weight: 0
+roles:
+  - authenticated
+filters:
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -10
+    settings:
+      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <br> <span> <img src alt height width data-entity-type data-entity-uuid data-align data-caption>'
+      filter_html_help: false
+      filter_html_nofollow: false
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: true
+    weight: 7
+    settings: {  }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: true
+    weight: 8
+    settings: {  }
+  filter_html_image_secure:
+    id: filter_html_image_secure
+    provider: filter
+    status: true
+    weight: 9
+    settings: {  }
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: true
+    weight: 11
+    settings: {  }

--- a/ecms_base/config/install/filter.format.full_html.yml
+++ b/ecms_base/config/install/filter.format.full_html.yml
@@ -1,0 +1,35 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - editor
+name: 'Full HTML'
+format: full_html
+weight: 2
+roles:
+  - administrator
+filters:
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: true
+    weight: 8
+    settings: {  }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: true
+    weight: 9
+    settings: {  }
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: 10
+    settings: {  }
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: true
+    weight: 11
+    settings: {  }

--- a/ecms_base/config/install/filter.format.restricted_html.yml
+++ b/ecms_base/config/install/filter.format.restricted_html.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Restricted HTML'
+format: restricted_html
+weight: 1
+roles:
+  - anonymous
+filters:
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -10
+    settings:
+      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id>'
+      filter_html_help: true
+      filter_html_nofollow: false
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: 0
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: true
+    weight: 0
+    settings:
+      filter_url_length: 72

--- a/ecms_base/config/install/node.settings.yml
+++ b/ecms_base/config/install/node.settings.yml
@@ -1,0 +1,1 @@
+use_admin_theme: true

--- a/ecms_base/config/install/system.cron.yml
+++ b/ecms_base/config/install/system.cron.yml
@@ -1,0 +1,4 @@
+threshold:
+  requirements_warning: 172800
+  requirements_error: 1209600
+logging: 1

--- a/ecms_base/config/install/system.site.yml
+++ b/ecms_base/config/install/system.site.yml
@@ -1,0 +1,11 @@
+name: ''
+mail: ''
+slogan: ''
+page:
+  403: ''
+  404: ''
+  front: /node
+admin_compact_mode: false
+weight_select_max: 100
+langcode: en
+default_langcode: en

--- a/ecms_base/config/install/system.theme.yml
+++ b/ecms_base/config/install/system.theme.yml
@@ -1,0 +1,2 @@
+admin: claro
+default: bartik

--- a/ecms_base/config/install/user.role.administrator.yml
+++ b/ecms_base/config/install/user.role.administrator.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: administrator
+label: Administrator
+weight: 2
+is_admin: true
+permissions: {  }

--- a/ecms_base/config/install/user.role.anonymous.yml
+++ b/ecms_base/config/install/user.role.anonymous.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: anonymous
+label: 'Anonymous user'
+weight: 0
+is_admin: false
+permissions:
+  - 'access content'

--- a/ecms_base/config/install/user.role.authenticated.yml
+++ b/ecms_base/config/install/user.role.authenticated.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies: {  }
+id: authenticated
+label: 'Authenticated user'
+weight: 1
+is_admin: false
+permissions:
+  - 'access content'
+  - 'access shortcuts'
+  - 'use text format basic_html'

--- a/ecms_base/config/install/user.settings.yml
+++ b/ecms_base/config/install/user.settings.yml
@@ -1,0 +1,16 @@
+anonymous: Anonymous
+verify_mail: true
+notify:
+  cancel_confirm: true
+  password_reset: true
+  status_activated: true
+  status_blocked: false
+  status_canceled: false
+  register_admin_created: true
+  register_no_approval_required: true
+  register_pending_approval: true
+register: admin_only
+cancel_method: user_cancel_block
+password_reset_timeout: 86400
+password_strength: true
+langcode: en

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -4,7 +4,7 @@ description: "Drupal installation profile for the State of Rhode Island's eCMS s
 core_version_requirement: ^9
 
 # Module dependencies for the distribution.
-# Modules that sub-profiles need should be listed here and _not_ in install.
+# Modules that sub-profiles need must be listed here and_not in install.
 dependencies:
   - big_pipe
   - block

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -3,7 +3,9 @@ type: profile
 description: "Drupal installation profile for the State of Rhode Island's eCMS system"
 core_version_requirement: ^9
 
-install:
+# Module dependencies for the distribution.
+# Modules that sub-profiles need should be listed here and _not_ in install.
+dependencies:
   - big_pipe
   - block
   - block_content
@@ -26,6 +28,7 @@ install:
   - menu_link_content
   - menu_ui
   - node
+  - openid_connect
   - options
   - path
   - page_cache
@@ -39,10 +42,6 @@ install:
   - tour
   - views
   - views_ui
-
-# Module dependencies for the distribution.
-dependencies:
-  - openid_connect
 
 # Theme dependencies for the distribution.
 themes:

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -3,10 +3,44 @@ type: profile
 description: "Drupal installation profile for the State of Rhode Island's eCMS system"
 core_version_requirement: ^9
 
+install:
+  - big_pipe
+  - block
+  - block_content
+  - breakpoint
+  - ckeditor
+  - color
+  - config
+  - contextual
+  - datetime
+  - dynamic_page_cache
+  - editor
+  - field_ui
+  - file
+  - help
+  - history
+  - image
+  - menu_link_content
+  - menu_ui
+  - node
+  - options
+  - path
+  - page_cache
+  - quickedit
+  - rdf
+  - search
+  - shortcut
+  - taxonomy
+  - toolbar
+  - tour
+  - views
+  - views_ui
+
 # Module dependencies for the distribution.
 dependencies:
   - openid_connect
 
 # Theme dependencies for the distribution.
 themes:
+  - bartik
   - claro

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -11,6 +11,7 @@ install:
   - ckeditor
   - color
   - config
+  - content_moderation
   - contextual
   - datetime
   - dynamic_page_cache
@@ -20,6 +21,8 @@ install:
   - help
   - history
   - image
+  - media
+  - media_library
   - menu_link_content
   - menu_ui
   - node
@@ -27,6 +30,7 @@ install:
   - path
   - page_cache
   - quickedit
+  - responsive_image
   - rdf
   - search
   - shortcut

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * @file
+ * Install, update and uninstall functions for the ecms_base profile.
+ */
+
+use Drupal\user\Entity\User;
+use Drupal\shortcut\Entity\Shortcut;
+
+/**
+ * Implements hook_install().
+ *
+ * Perform actions to set up the site for this profile.
+ *
+ * @see system_install()
+ */
+function standard_install() {
+  // Assign user 1 the "administrator" role.
+  $user = User::load(1);
+  $user->roles[] = 'administrator';
+  $user->save();
+
+  // We install some menu links, so we have to rebuild the router, to ensure the
+  // menu links are valid.
+  \Drupal::service('router.builder')->rebuildIfNeeded();
+
+  // Populate the default shortcut set.
+  $shortcut = Shortcut::create([
+    'shortcut_set' => 'default',
+    'title' => t('Add content'),
+    'weight' => -20,
+    'link' => ['uri' => 'internal:/node/add'],
+  ]);
+  $shortcut->save();
+
+  $shortcut = Shortcut::create([
+    'shortcut_set' => 'default',
+    'title' => t('All content'),
+    'weight' => -19,
+    'link' => ['uri' => 'internal:/admin/content'],
+  ]);
+
+  $shortcut->save();
+}

--- a/tests/src/Functional/AllProfileInstallationTestsAbstract.php
+++ b/tests/src/Functional/AllProfileInstallationTestsAbstract.php
@@ -8,6 +8,7 @@ use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\SchemaCheckTestTrait;
 
 /**
  * Class AllProfileInstallationTestsAbstract.
@@ -23,6 +24,8 @@ use Drupal\Tests\BrowserTestBase;
  * @package Drupal\Tests\ecms_profile\Functional
  */
 abstract class AllProfileInstallationTestsAbstract extends BrowserTestBase {
+
+  use SchemaCheckTestTrait;
 
   /**
    * Override the default drupalLogin method.
@@ -88,6 +91,20 @@ abstract class AllProfileInstallationTestsAbstract extends BrowserTestBase {
     $this->assertSession()->checkboxChecked('edit-always-save-userinfo');
     $this->assertSession()->checkboxChecked('edit-connect-existing-users');
     $this->assertSession()->checkboxChecked('edit-user-login-display-replace');
+  }
+
+  /**
+   * Ensure the configuration installed properly.
+   */
+  public function testConfigInstall(): void {
+    // Ensure all configuration imported.
+    $names = $this->container->get('config.storage')->listAll();
+    /** @var \Drupal\Core\Config\TypedConfigManagerInterface $typed_config */
+    $typed_config = $this->container->get('config.typed');
+    foreach ($names as $name) {
+      $config = $this->config($name);
+      $this->assertConfigSchema($typed_config, $name, $config->get());
+    }
 
   }
 


### PR DESCRIPTION
## Summary
This updates the ecms_base profile to install basic required modules and themes to get started. Most of the modules and configuration were borrowed from the standard installation profile. I purposely left out some that I thought were not necessary like the comments module. No fields were installed as these _should_ be managed through the features module. The user registration default configuration was set to disallow user registrations.

## Metadata

| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-29](https://thinkoomph.jira.com/browse/rig-29)