### PR TITLE
Added webform as a requirement for the ecms_base profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - Added the [ACSF module](https://www.drupal.org/project/acsf) as a required dependency.
 - Added the [openid_connect](https://www.drupal.org/project/openid_connect) module as a dependency.
 - Added required modules/configuration based on the standard installation profile.
+- RIG-32: Added the webform requirement and installed by default.
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
     "drupal/acsf": "^2.67",
     "drupal/core-recommended": "^9",
     "drupal/openid_connect": "1.x-dev",
+    "drupal/webform": "^6.0",
     "drush/drush": "^10.0",
     "zaporylie/composer-drupal-optimizations": "^1.0"
   },

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -42,6 +42,8 @@ dependencies:
   - tour
   - views
   - views_ui
+  - webform
+  - webform_ui
 
 # Theme dependencies for the distribution.
 themes:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,7 +14,7 @@
         <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
         <env name="SIMPLETEST_BASE_URL" value="http://appserver/"/>
         <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
-        <env name="SIMPLETEST_DB" value="sqlite://appserver/sites/default/files/db.sqlite"/>
+        <env name="SIMPLETEST_DB" value="sqlite://appserver/:memory:"/>
         <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
         <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
         <!-- To disable deprecation testing uncomment the next line. -->

--- a/tests/src/Functional/AllProfileInstallationTestsAbstract.php
+++ b/tests/src/Functional/AllProfileInstallationTestsAbstract.php
@@ -108,4 +108,17 @@ abstract class AllProfileInstallationTestsAbstract extends BrowserTestBase {
 
   }
 
+  /**
+   * Ensure the webform requirement installed properly.
+   */
+  public function testWebformInstall(): void {
+    $account = $this->drupalCreateUser(['administer webform']);
+    $this->drupalLogin($account);
+
+    // Ensure the form configuration page is available.
+    $this->drupalGet('admin/structure/webform');
+    $this->assertSession()->statusCodeEquals(200);
+
+  }
+
 }


### PR DESCRIPTION
## Summary
This will add the webform as a requirement and installs the webform and the webform_ui modules on installation.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-32](https://thinkoomph.jira.com/browse/rig-32)