### PR TITLE
Add the press release content type as a feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - Added required modules/configuration based on the standard installation profile.
 - RIG-32: Added the webform requirement and installed by default.
 - RIG-15: Added the Notification content type as a feature and the editorial workflow.
+- RIG-33: Added the press release content type as a feature.
 
 ### Changed
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -76,3 +76,7 @@ With the distribution site now fully installed, you can make your code updates
 from within the main "ecms_profile" repository directory.
 Changes will show in your demo site "develop-ecms-profile" 
 as the distro is symlinked. 
+
+## Features
+Certain configuration should be managed with the Features module. 
+[Additional features documentation is available here](./features.md).

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,41 @@
+# Features
+
+Certain site configuration and functionality will be provided by the [Features module].
+This is done to segment certain configuration to allow for some control over the configuration of the sites
+that are installed with the profile.
+
+Currently, the content types and their related configuration (fields, display modes, etc.)
+will be maintained with Features.
+
+Features will be stored within the following directory: 
+
+```bash
+./ecms_profile/*/features/custom
+```
+
+## Current Features list
+The current list of features is:
+
+### ecms_notification
+This contains the notification content type and the related field configuration.
+
+### ecms_press_release
+This containe the press_release content type and the related field configuration.
+
+## Development Notes
+Developing with features can be tricky. A few items to remember:
+
+- Features should only contain configuration that belong together and _should not_ share configuration with other features.
+For example, if all content types share the same editorial workflow, that workflow will _NOT_ be able to be packaged
+into one or each feature. Instead, that configuration needs to be left out of the feature and a helper module will need to connect
+that configuration to each content type.
+
+[Online Documentation on Features] is available and gives a good overview of how to use it effectively.
+    
+## Deployment
+On deployment an existing site will revert all features to what is in the codebase. So, if a site admin changes the field of a specific
+content type, on the next update, those changes will revert to what is in the feature module.
+
+
+[Features module]: https://www.drupal.org/project/features
+[Online Documentation on Features]: https://www.drupal.org/docs/contributed-modules/features

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,7 +20,7 @@ The current list of features is:
 This contains the notification content type and the related field configuration.
 
 ### ecms_press_release
-This containe the press_release content type and the related field configuration.
+This contains the press_release content type and the related field configuration.
 
 ## Development Notes
 Developing with features can be tricky. A few items to remember:

--- a/docs/features.md
+++ b/docs/features.md
@@ -30,6 +30,9 @@ For example, if all content types share the same editorial workflow, that workfl
 into one or each feature. Instead, that configuration needs to be left out of the feature and a helper module will need to connect
 that configuration to each content type.
 
+- Features should not share fields. If two content types both contain a `body` field. That field _MUST_ be created for each content type. Typically, the field should prefix or relate
+to the content type to which it belongs. In this example, a Notification and a Press release content type, two fields would be created `field_notification_body` and `field_press_release_body`.
+
 [Online Documentation on Features] is available and gives a good overview of how to use it effectively.
     
 ## Deployment

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -53,6 +53,7 @@ install:
 # Install the required features.
 install:
   - ecms_notification
+  - ecms_press_release
 
 # Theme dependencies for the distribution.
 themes:

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -50,6 +50,10 @@ dependencies:
 install:
   - ecms_notification
 
+# Install the required features.
+install:
+  - ecms_notification
+
 # Theme dependencies for the distribution.
 themes:
   - bartik

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -49,10 +49,6 @@ dependencies:
 # Install the required features.
 install:
   - ecms_notification
-
-# Install the required features.
-install:
-  - ecms_notification
   - ecms_press_release
 
 # Theme dependencies for the distribution.

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.base_field_override.node.press_release.promote.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.base_field_override.node.press_release.promote.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.press_release
+id: node.press_release.promote
+field_name: promote
+entity_type: node
+bundle: press_release
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.entity_form_display.node.press_release.default.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.entity_form_display.node.press_release.default.yml
@@ -1,0 +1,103 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.press_release.field_press_release_body
+    - field.field.node.press_release.field_press_release_date
+    - field.field.node.press_release.field_press_release_links
+    - field.field.node.press_release.field_press_release_source
+    - node.type.press_release
+  module:
+    - datetime
+    - link
+    - path
+    - text
+id: node.press_release.default
+targetEntityType: node
+bundle: press_release
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_press_release_body:
+    weight: 121
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+    type: text_textarea_with_summary
+    region: content
+  field_press_release_date:
+    weight: 122
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_press_release_links:
+    weight: 123
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_press_release_source:
+    weight: 124
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.entity_view_display.node.press_release.default.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.entity_view_display.node.press_release.default.yml
@@ -1,0 +1,60 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.press_release.field_press_release_body
+    - field.field.node.press_release.field_press_release_date
+    - field.field.node.press_release.field_press_release_links
+    - field.field.node.press_release.field_press_release_source
+    - node.type.press_release
+  module:
+    - datetime
+    - link
+    - text
+    - user
+id: node.press_release.default
+targetEntityType: node
+bundle: press_release
+mode: default
+content:
+  field_press_release_body:
+    weight: 101
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_press_release_date:
+    weight: 102
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_press_release_links:
+    weight: 103
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_press_release_source:
+    weight: 104
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.entity_view_display.node.press_release.teaser.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.entity_view_display.node.press_release.teaser.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.press_release.field_press_release_body
+    - field.field.node.press_release.field_press_release_date
+    - field.field.node.press_release.field_press_release_links
+    - field.field.node.press_release.field_press_release_source
+    - node.type.press_release
+  module:
+    - user
+id: node.press_release.teaser
+targetEntityType: node
+bundle: press_release
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_press_release_body: true
+  field_press_release_date: true
+  field_press_release_links: true
+  field_press_release_source: true

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_body.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_press_release_body
+    - node.type.press_release
+  module:
+    - text
+id: node.press_release.field_press_release_body
+field_name: field_press_release_body
+entity_type: node
+bundle: press_release
+label: Body
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+field_type: text_with_summary

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_date.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_date.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_press_release_date
+    - node.type.press_release
+  module:
+    - datetime
+id: node.press_release.field_press_release_date
+field_name: field_press_release_date
+entity_type: node
+bundle: press_release
+label: Date
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    default_date_type: now
+    default_date: now
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_links.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_links.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_press_release_links
+    - node.type.press_release
+  module:
+    - link
+id: node.press_release.field_press_release_links
+field_name: field_press_release_links
+entity_type: node
+bundle: press_release
+label: Links
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_source.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_source.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_press_release_source
+    - node.type.press_release
+  module:
+    - text
+id: node.press_release.field_press_release_source
+field_name: field_press_release_source
+entity_type: node
+bundle: press_release
+label: Source
+description: 'Optional agency and press contact information.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_press_release_body.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_press_release_body.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_press_release_body
+field_name: field_press_release_body
+entity_type: node
+type: text_with_summary
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_press_release_date.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_press_release_date.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_press_release_date
+field_name: field_press_release_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_press_release_links.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_press_release_links.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_press_release_links
+field_name: field_press_release_links
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_press_release_source.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_press_release_source.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_press_release_source
+field_name: field_press_release_source
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_press_release/config/install/node.type.press_release.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/node.type.press_release.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: 'Press release'
+type: press_release
+description: ''
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/ecms_base/features/custom/ecms_press_release/ecms_press_release.features.yml
+++ b/ecms_base/features/custom/ecms_press_release/ecms_press_release.features.yml
@@ -1,0 +1,1 @@
+bundle: ecms

--- a/ecms_base/features/custom/ecms_press_release/ecms_press_release.info.yml
+++ b/ecms_base/features/custom/ecms_press_release/ecms_press_release.info.yml
@@ -12,3 +12,4 @@ dependencies:
   - text
   - user
 package: eCMS
+version: 9.x-1.0

--- a/ecms_base/features/custom/ecms_press_release/ecms_press_release.info.yml
+++ b/ecms_base/features/custom/ecms_press_release/ecms_press_release.info.yml
@@ -1,0 +1,14 @@
+name: 'Press release'
+description: 'Provides Press release content type and related configuration.'
+type: module
+core_version_requirement: ^9
+dependencies:
+  - datetime
+  - field
+  - link
+  - menu_ui
+  - node
+  - path
+  - text
+  - user
+package: eCMS

--- a/ecms_base/tests/src/Functional/InstallationTest.php
+++ b/ecms_base/tests/src/Functional/InstallationTest.php
@@ -61,7 +61,6 @@ class InstallationTest extends AllProfileInstallationTestsAbstract {
     $this->assertSession()->checkboxNotChecked('edit-modules-acsf-theme-enable');
     $this->assertSession()->checkboxNotChecked('edit-modules-acsf-variables-enable');
     $this->drupalLogout($account);
-
   }
 
 }

--- a/tests/src/Functional/AllProfileInstallationTestsAbstract.php
+++ b/tests/src/Functional/AllProfileInstallationTestsAbstract.php
@@ -156,7 +156,7 @@ abstract class AllProfileInstallationTestsAbstract extends BrowserTestBase {
     $account = $this->drupalCreateUser(['create press_release content']);
     $this->drupalLogin($account);
 
-    // Ensure the notification entity add formis available.
+    // Ensure the press release entity add form is available.
     $this->drupalGet('node/add/press_release');
     $this->assertSession()->statusCodeEquals(200);
     $this->drupalLogout();

--- a/tests/src/Functional/AllProfileInstallationTestsAbstract.php
+++ b/tests/src/Functional/AllProfileInstallationTestsAbstract.php
@@ -94,6 +94,7 @@ abstract class AllProfileInstallationTestsAbstract extends BrowserTestBase {
   public function globalTests(): void {
     $this->ensureOpenIdConnect();
     $this->ensureNotificationFeatureInstalled();
+    $this->ensurePressReleaseFeatureInstalled();
     $this->ensureConfigInstall();
   }
 
@@ -145,7 +146,20 @@ abstract class AllProfileInstallationTestsAbstract extends BrowserTestBase {
     // Ensure the notification entity add form is available.
     $this->drupalGet('node/add/notification');
     $this->assertSession()->statusCodeEquals(200);
-    $this->drupalLogout($account);
+    $this->drupalLogout();
+  }
+
+  /**
+   * Test whether the ecms_press_release feature installed properly.
+   */
+  private function ensurePressReleaseFeatureInstalled(): void {
+    $account = $this->drupalCreateUser(['create press_release content']);
+    $this->drupalLogin($account);
+
+    // Ensure the notification entity add formis available.
+    $this->drupalGet('node/add/press_release');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->drupalLogout();
   }
 
   /**


### PR DESCRIPTION
## Summary
This expands upon the PR in #7 and adds the press release content type as a feature and installs the feature module on profile installation.

Additional documentation was added to explain the use of features in this process. 

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-33](https://thinkoomph.jira.com/browse/rig-33)