### PR TITLE
Add the Person content type as a feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-33: Added the press release content type as a feature.
 - RIG-35: Added the Location content type as a feature.
 
+- RIG-34: Added the Person content type as a feature.
 ### Changed
 
 ### Deprecated

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
     "cweagans/composer-patches": "^1.6",
     "drupal/acsf": "^2.67",
     "drupal/address": "^1.8",
+    "drupal/auto_entitylabel": "^3.0@beta",
     "drupal/core-recommended": "^9",
     "drupal/features": "^3.11",
     "drupal/moderation_dashboard": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
     "drupal/office_hours": "^1.3",
     "drupal/openid_connect": "1.x-dev",
     "drupal/scheduler": "^1.3",
+    "drupal/token": "^1.7",
     "drupal/webform": "^6.0",
     "drush/drush": "^10.0",
     "zaporylie/composer-drupal-optimizations": "^1.0"

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -51,6 +51,7 @@ install:
   - ecms_notification
   - ecms_press_release
   - ecms_location
+  - ecms_person
 
 # Theme dependencies for the distribution.
 themes:

--- a/ecms_base/features/custom/ecms_person/config/install/auto_entitylabel.settings.node.person.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/auto_entitylabel.settings.node.person.yml
@@ -1,0 +1,6 @@
+status: 1
+pattern: '[node:field_person_first_name] [node:field_person_last_name]'
+escape: false
+dependencies:
+  config:
+    - node.type.person

--- a/ecms_base/features/custom/ecms_person/config/install/core.base_field_override.node.person.promote.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.base_field_override.node.person.promote.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.person
+id: node.person.promote
+field_name: promote
+entity_type: node
+bundle: person
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/ecms_base/features/custom/ecms_person/config/install/core.base_field_override.node.person.title.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.base_field_override.node.person.title.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.person
+id: node.person.title
+field_name: title
+entity_type: node
+bundle: person
+label: 'Full Name'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_person/config/install/core.entity_form_display.media.person_headshot.default.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.entity_form_display.media.person_headshot.default.yml
@@ -1,0 +1,61 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.person_headshot.field_media_image
+    - image.style.thumbnail
+    - media.type.person_headshot
+  module:
+    - image
+    - path
+id: media.person_headshot.default
+targetEntityType: media
+bundle: person_headshot
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_media_image:
+    weight: 0
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 100
+    region: content
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/ecms_base/features/custom/ecms_person/config/install/core.entity_form_display.media.person_headshot.media_library.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.entity_form_display.media.person_headshot.media_library.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.person_headshot.field_media_image
+    - image.style.thumbnail
+    - media.type.person_headshot
+  module:
+    - image
+id: media.person_headshot.media_library
+targetEntityType: media
+bundle: person_headshot
+mode: media_library
+content:
+  field_media_image:
+    weight: 5
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  path: true
+  status: true
+  uid: true

--- a/ecms_base/features/custom/ecms_person/config/install/core.entity_form_display.node.person.default.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.entity_form_display.node.person.default.yml
@@ -1,0 +1,164 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.person.field_person_category
+    - field.field.node.person.field_person_email
+    - field.field.node.person.field_person_fax
+    - field.field.node.person.field_person_first_name
+    - field.field.node.person.field_person_job_title
+    - field.field.node.person.field_person_last_name
+    - field.field.node.person.field_person_middle_initial
+    - field.field.node.person.field_person_phone
+    - field.field.node.person.field_person_photo
+    - field.field.node.person.field_person_prefix
+    - field.field.node.person.field_person_suffix
+    - node.type.person
+  module:
+    - media_library
+    - path
+    - telephone
+id: node.person.default
+targetEntityType: node
+bundle: person
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 13
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_person_category:
+    weight: 11
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete_tags
+    region: content
+  field_person_email:
+    weight: 7
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: email_default
+    region: content
+  field_person_fax:
+    weight: 9
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: telephone_default
+    region: content
+  field_person_first_name:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_person_job_title:
+    weight: 6
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_person_last_name:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_person_middle_initial:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_person_phone:
+    weight: 8
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: telephone_default
+    region: content
+  field_person_photo:
+    type: media_library_widget
+    weight: 10
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    region: content
+  field_person_prefix:
+    weight: 4
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_person_suffix:
+    weight: 5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  path:
+    type: path
+    weight: 16
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 14
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 17
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 12
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/ecms_base/features/custom/ecms_person/config/install/core.entity_view_display.media.person_headshot.default.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.entity_view_display.media.person_headshot.default.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.person_headshot.field_media_image
+    - image.style.large
+    - media.type.person_headshot
+  module:
+    - image
+id: media.person_headshot.default
+targetEntityType: media
+bundle: person_headshot
+mode: default
+content:
+  field_media_image:
+    label: visually_hidden
+    weight: 0
+    settings:
+      image_style: large
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/ecms_base/features/custom/ecms_person/config/install/core.entity_view_display.media.person_headshot.media_library.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.entity_view_display.media.person_headshot.media_library.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.person_headshot.field_media_image
+    - image.style.medium
+    - media.type.person_headshot
+  module:
+    - image
+id: media.person_headshot.media_library
+targetEntityType: media
+bundle: person_headshot
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_style: medium
+      image_link: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_media_image: true
+  name: true
+  uid: true

--- a/ecms_base/features/custom/ecms_person/config/install/core.entity_view_display.node.person.default.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.entity_view_display.node.person.default.yml
@@ -1,0 +1,115 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.person.field_person_category
+    - field.field.node.person.field_person_email
+    - field.field.node.person.field_person_fax
+    - field.field.node.person.field_person_first_name
+    - field.field.node.person.field_person_job_title
+    - field.field.node.person.field_person_last_name
+    - field.field.node.person.field_person_middle_initial
+    - field.field.node.person.field_person_phone
+    - field.field.node.person.field_person_photo
+    - field.field.node.person.field_person_prefix
+    - field.field.node.person.field_person_suffix
+    - node.type.person
+  module:
+    - user
+id: node.person.default
+targetEntityType: node
+bundle: person
+mode: default
+content:
+  field_person_category:
+    weight: 111
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_person_email:
+    weight: 101
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_person_fax:
+    weight: 103
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_person_first_name:
+    weight: 104
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_person_job_title:
+    weight: 109
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_person_last_name:
+    weight: 105
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_person_middle_initial:
+    weight: 106
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_person_phone:
+    weight: 102
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_person_photo:
+    type: entity_reference_entity_view
+    weight: 110
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_person_prefix:
+    weight: 107
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_person_suffix:
+    weight: 108
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/ecms_base/features/custom/ecms_person/config/install/core.entity_view_display.node.person.teaser.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.entity_view_display.node.person.teaser.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.person.field_person_category
+    - field.field.node.person.field_person_email
+    - field.field.node.person.field_person_fax
+    - field.field.node.person.field_person_first_name
+    - field.field.node.person.field_person_job_title
+    - field.field.node.person.field_person_last_name
+    - field.field.node.person.field_person_middle_initial
+    - field.field.node.person.field_person_phone
+    - field.field.node.person.field_person_photo
+    - field.field.node.person.field_person_prefix
+    - field.field.node.person.field_person_suffix
+    - node.type.person
+  module:
+    - user
+id: node.person.teaser
+targetEntityType: node
+bundle: person
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_person_category: true
+  field_person_email: true
+  field_person_fax: true
+  field_person_first_name: true
+  field_person_job_title: true
+  field_person_last_name: true
+  field_person_middle_initial: true
+  field_person_phone: true
+  field_person_photo: true
+  field_person_prefix: true
+  field_person_suffix: true

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.media.person_headshot.field_media_image.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.media.person_headshot.field_media_image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_image
+    - media.type.person_headshot
+  module:
+    - image
+id: media.person_headshot.field_media_image
+field_name: field_media_image
+entity_type: media
+bundle: person_headshot
+label: Image
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'png gif jpg jpeg'
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_category.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_category.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_person_category
+    - node.type.person
+    - taxonomy.vocabulary.person_taxonomy
+id: node.person.field_person_category
+field_name: field_person_category
+entity_type: node
+bundle: person
+label: Category
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      person_taxonomy: person_taxonomy
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_email.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_email.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_person_email
+    - node.type.person
+id: node.person.field_person_email
+field_name: field_person_email
+entity_type: node
+bundle: person
+label: Email
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: email

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_fax.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_fax.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_person_fax
+    - node.type.person
+  module:
+    - telephone
+id: node.person.field_person_fax
+field_name: field_person_fax
+entity_type: node
+bundle: person
+label: 'Fax Number'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: telephone

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_first_name.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_first_name.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_person_first_name
+    - node.type.person
+id: node.person.field_person_first_name
+field_name: field_person_first_name
+entity_type: node
+bundle: person
+label: 'First name'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_job_title.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_job_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_person_job_title
+    - node.type.person
+id: node.person.field_person_job_title
+field_name: field_person_job_title
+entity_type: node
+bundle: person
+label: 'Job title'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_last_name.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_last_name.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_person_last_name
+    - node.type.person
+id: node.person.field_person_last_name
+field_name: field_person_last_name
+entity_type: node
+bundle: person
+label: 'Last name'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_middle_initial.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_middle_initial.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_person_middle_initial
+    - node.type.person
+id: node.person.field_person_middle_initial
+field_name: field_person_middle_initial
+entity_type: node
+bundle: person
+label: 'Middle Initial'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_phone.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_phone.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_person_phone
+    - node.type.person
+  module:
+    - telephone
+id: node.person.field_person_phone
+field_name: field_person_phone
+entity_type: node
+bundle: person
+label: 'Phone numbers'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: telephone

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_photo.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_photo.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_person_photo
+    - media.type.person_headshot
+    - node.type.person
+id: node.person.field_person_photo
+field_name: field_person_photo
+entity_type: node
+bundle: person
+label: Photo
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      person_headshot: person_headshot
+    sort:
+      field: _none
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_prefix.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_prefix.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_person_prefix
+    - node.type.person
+id: node.person.field_person_prefix
+field_name: field_person_prefix
+entity_type: node
+bundle: person
+label: Prefix
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_suffix.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.node.person.field_person_suffix.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_person_suffix
+    - node.type.person
+id: node.person.field_person_suffix
+field_name: field_person_suffix
+entity_type: node
+bundle: person
+label: Suffix
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_person/config/install/field.storage.media.field_media_image.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.storage.media.field_media_image.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - media
+id: media.field_media_image
+field_name: field_media_image
+entity_type: media
+type: image
+settings:
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_category.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_category.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_person_category
+field_name: field_person_category
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_email.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_email.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_person_email
+field_name: field_person_email
+entity_type: node
+type: email
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_fax.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_fax.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - telephone
+id: node.field_person_fax
+field_name: field_person_fax
+entity_type: node
+type: telephone
+settings: {  }
+module: telephone
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_first_name.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_first_name.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_person_first_name
+field_name: field_person_first_name
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_job_title.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_job_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_person_job_title
+field_name: field_person_job_title
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_last_name.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_last_name.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_person_last_name
+field_name: field_person_last_name
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_middle_initial.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_middle_initial.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_person_middle_initial
+field_name: field_person_middle_initial
+entity_type: node
+type: string
+settings:
+  max_length: 1
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_phone.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_phone.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - telephone
+id: node.field_person_phone
+field_name: field_person_phone
+entity_type: node
+type: telephone
+settings: {  }
+module: telephone
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_photo.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_photo.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_person_photo
+field_name: field_person_photo
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_prefix.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_prefix.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_person_prefix
+field_name: field_person_prefix
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_suffix.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.storage.node.field_person_suffix.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_person_suffix
+field_name: field_person_suffix
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_person/config/install/media.type.person_headshot.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/media.type.person_headshot.yml
@@ -1,0 +1,12 @@
+langcode: en
+status: true
+dependencies: {  }
+id: person_headshot
+label: 'Personal Photo'
+description: 'Photos of staff/employees/people.'
+source: image
+queue_thumbnail_downloads: false
+new_revision: true
+source_configuration:
+  source_field: field_media_image
+field_map: {  }

--- a/ecms_base/features/custom/ecms_person/config/install/node.type.person.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/node.type.person.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: Person
+type: person
+description: 'Manage people such as staff, departments, etc.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/ecms_base/features/custom/ecms_person/config/install/taxonomy.vocabulary.person_taxonomy.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/taxonomy.vocabulary.person_taxonomy.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Staff / Department'
+vid: person_taxonomy
+description: 'Categorize people by staff/department etc.'
+weight: 0

--- a/ecms_base/features/custom/ecms_person/ecms_person.features.yml
+++ b/ecms_base/features/custom/ecms_person/ecms_person.features.yml
@@ -1,0 +1,1 @@
+bundle: ecms

--- a/ecms_base/features/custom/ecms_person/ecms_person.info.yml
+++ b/ecms_base/features/custom/ecms_person/ecms_person.info.yml
@@ -1,0 +1,19 @@
+name: Person
+description: 'Provides Person content type and related configuration. Manage people such as staff, departments, etc.'
+type: module
+core_version_requirement: ^9
+dependencies:
+  - auto_entitylabel
+  - field
+  - file
+  - image
+  - media
+  - media_library
+  - menu_ui
+  - node
+  - path
+  - taxonomy
+  - telephone
+  - token
+  - user
+package: eCMS

--- a/tests/src/Functional/AllProfileInstallationTestsAbstract.php
+++ b/tests/src/Functional/AllProfileInstallationTestsAbstract.php
@@ -95,6 +95,7 @@ abstract class AllProfileInstallationTestsAbstract extends BrowserTestBase {
     $this->ensureOpenIdConnect();
     $this->ensureNotificationFeatureInstalled();
     $this->ensurePressReleaseFeatureInstalled();
+    $this->ensurePersonFeatureInstalled();
     $this->ensureLocationFeatureInstalled();
     $this->ensureConfigInstall();
   }
@@ -173,6 +174,43 @@ abstract class AllProfileInstallationTestsAbstract extends BrowserTestBase {
     // Ensure the location entity add form is available.
     $this->drupalGet('node/add/location');
     $this->assertSession()->statusCodeEquals(200);
+    $this->drupalLogout();
+  }
+
+  /**
+   * Test whether the ecms_person feature installed properly.
+   */
+  private function ensurePersonFeatureInstalled(): void {
+    $account = $this->drupalCreateUser([
+      'create person content',
+      'create terms in person_taxonomy',
+    ]);
+    $this->drupalLogin($account);
+
+    // Ensure the notification entity add formis available.
+    $this->drupalGet('node/add/person');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $fields = [
+      'field_person_first_name[0][value]' => 'Test',
+      'field_person_last_name[0][value]' => 'User',
+      'field_person_job_title[0][value]' => 'Developer',
+    ];
+
+    // Check that the required fields exist in the form.
+    foreach ($fields as $key => $value) {
+      $this->assertFieldByName($key);
+    }
+
+    $this->drupalPostForm('node/add/person', $fields, 'Save');
+
+    // Ensure the auto entity label tokens were applied.
+    $this->assertText('Person Test User has been created.');
+
+    // Ensure the taxonomy is accessible.
+    $this->drupalGet('admin/structure/taxonomy/manage/person_taxonomy/add');
+    $this->assertSession()->statusCodeEquals(200);
+
     $this->drupalLogout();
   }
 


### PR DESCRIPTION
## Summary
This expands upon #7  and adds the Person content type as a feature module and includes the content type, a media type and a taxonomy to support the content type.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-34](https://thinkoomph.jira.com/browse/rig-34)