### PR TITLE
Add the Event content type as a feature module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-34: Added the Person content type as a feature.
 - RIG-15: Added 5 custom roles to standard install profile.
 - RIG-15: Added the Publish Content module and installed by default.
+- RIG-40: Added the Event content type as a feature.
 
 ### Changed
 - RIG-23: Changed from OIDC generic to Windows AAD for authentication.

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,9 @@
       },
       "drupal/publishcontent": {
         "3170248 - Configuration Schema Errors": "https://www.drupal.org/files/issues/2020-09-10/publishcontent-schema-3170248-2.patch"
+      },
+      "drupal/smart_date": {
+        "3170288 - Configuration schema errors": "https://www.drupal.org/files/issues/2020-09-10/smart_date-schema-3170288-2.patch"
       }
     },
     "preserve-paths": [],

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
     "drupal/openid_connect_windows_aad": "^1.3",
     "drupal/publishcontent": "^1.2",
     "drupal/scheduler": "^1.3",
+    "drupal/smart_date": "^3.0",
     "drupal/token": "^1.7",
     "drupal/webform": "^6.0",
     "drush/drush": "^10.0",

--- a/docs/features.md
+++ b/docs/features.md
@@ -22,6 +22,9 @@ This contains the notification content type and the related field configuration.
 ### ecms_press_release
 This contains the press_release content type and the related field configuration.
 
+### ecms_event
+This contains the event content type and the related field and taxonomy configuration.
+
 ## Development Notes
 Developing with features can be tricky. A few items to remember:
 

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -29,6 +29,7 @@ dependencies:
   - menu_link_content
   - menu_ui
   - node
+  - openid_connect_windows_aad
   - options
   - path
   - page_cache
@@ -45,14 +46,14 @@ dependencies:
   - views_ui
   - webform
   - webform_ui
-  - openid_connect_windows_aad
 
 # Install the required features.
 install:
-  - ecms_notification
-  - ecms_press_release
+  - ecms_event
   - ecms_location
+  - ecms_notification
   - ecms_person
+  - ecms_press_release
   - ecms_authentication
 
 # Theme dependencies for the distribution.

--- a/ecms_base/features/custom/ecms_event/config/install/core.base_field_override.node.event.promote.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.base_field_override.node.event.promote.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.event
+id: node.event.promote
+field_name: promote
+entity_type: node
+bundle: event
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_form_display.media.event_image.default.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_form_display.media.event_image.default.yml
@@ -1,0 +1,61 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.event_image.field_media_image_1
+    - image.style.thumbnail
+    - media.type.event_image
+  module:
+    - image
+    - path
+id: media.event_image.default
+targetEntityType: media
+bundle: event_image
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_media_image_1:
+    weight: 0
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 100
+    region: content
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_form_display.media.event_image.media_library.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_form_display.media.event_image.media_library.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.event_image.field_media_image_1
+    - image.style.thumbnail
+    - media.type.event_image
+  module:
+    - image
+id: media.event_image.media_library
+targetEntityType: media
+bundle: event_image
+mode: media_library
+content:
+  field_media_image_1:
+    weight: 5
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  path: true
+  status: true
+  uid: true

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_form_display.node.event.default.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_form_display.node.event.default.yml
@@ -1,0 +1,126 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.event.field_event_body
+    - field.field.node.event.field_event_contact
+    - field.field.node.event.field_event_date
+    - field.field.node.event.field_event_image
+    - field.field.node.event.field_event_location
+    - field.field.node.event.field_event_type
+    - node.type.event
+  module:
+    - media_library
+    - path
+    - smart_date
+    - text
+id: node.event.default
+targetEntityType: node
+bundle: event
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 8
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_event_body:
+    weight: 2
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+    type: text_textarea_with_summary
+    region: content
+  field_event_contact:
+    weight: 4
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_event_date:
+    weight: 1
+    settings:
+      modal: false
+      default_duration: 60
+      default_duration_increments: "30\n60|1 hour\n90\n120|2 hours\ncustom"
+      show_extra: true
+    third_party_settings: {  }
+    type: smartdate_default
+    region: content
+  field_event_image:
+    type: media_library_widget
+    weight: 6
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    region: content
+  field_event_location:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_event_type:
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete_tags
+    region: content
+  path:
+    type: path
+    weight: 11
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 9
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 12
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 10
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 7
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.media.event_image.default.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.media.event_image.default.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.event_image.field_media_image_1
+    - image.style.large
+    - media.type.event_image
+  module:
+    - image
+id: media.event_image.default
+targetEntityType: media
+bundle: event_image
+mode: default
+content:
+  field_media_image_1:
+    label: visually_hidden
+    weight: 0
+    settings:
+      image_style: large
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.media.event_image.media_library.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.media.event_image.media_library.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.event_image.field_media_image_1
+    - image.style.medium
+    - media.type.event_image
+  module:
+    - image
+id: media.event_image.media_library
+targetEntityType: media
+bundle: event_image
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_style: medium
+      image_link: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_media_image_1: true
+  name: true
+  uid: true

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.default.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.default.yml
@@ -1,0 +1,77 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.event.field_event_body
+    - field.field.node.event.field_event_contact
+    - field.field.node.event.field_event_date
+    - field.field.node.event.field_event_image
+    - field.field.node.event.field_event_location
+    - field.field.node.event.field_event_type
+    - node.type.event
+  module:
+    - smart_date
+    - text
+    - user
+id: node.event.default
+targetEntityType: node
+bundle: event
+mode: default
+content:
+  field_event_body:
+    weight: 101
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_event_contact:
+    weight: 103
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_event_date:
+    weight: 107
+    label: above
+    settings:
+      format: default
+      force_chronological: false
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: smartdate_default
+    region: content
+  field_event_image:
+    type: entity_reference_entity_view
+    weight: 106
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_event_location:
+    weight: 102
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_event_type:
+    weight: 105
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.teaser.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.teaser.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.event.field_event_body
+    - field.field.node.event.field_event_contact
+    - field.field.node.event.field_event_date
+    - field.field.node.event.field_event_image
+    - field.field.node.event.field_event_location
+    - field.field.node.event.field_event_type
+    - node.type.event
+  module:
+    - user
+id: node.event.teaser
+targetEntityType: node
+bundle: event
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_event_body: true
+  field_event_contact: true
+  field_event_date: true
+  field_event_image: true
+  field_event_location: true
+  field_event_type: true

--- a/ecms_base/features/custom/ecms_event/config/install/field.field.media.event_image.field_media_image_1.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.field.media.event_image.field_media_image_1.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_image_1
+    - media.type.event_image
+  module:
+    - image
+id: media.event_image.field_media_image_1
+field_name: field_media_image_1
+entity_type: media
+bundle: event_image
+label: Image
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'png gif jpg jpeg'
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.field_event_body.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.field_event_body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_body
+    - node.type.event
+  module:
+    - text
+id: node.event.field_event_body
+field_name: field_event_body
+entity_type: node
+bundle: event
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.field_event_contact.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.field_event_contact.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_contact
+    - node.type.event
+id: node.event.field_event_contact
+field_name: field_event_contact
+entity_type: node
+bundle: event
+label: Contact
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.field_event_date.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.field_event_date.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_date
+    - node.type.event
+  module:
+    - smart_date
+id: node.event.field_event_date
+field_name: field_event_date
+entity_type: node
+bundle: event
+label: Date
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    default_date_type: ''
+    default_date: ''
+    default_duration_increments: "30\r\n60|1 hour\r\n90\r\n120|2 hours\r\ncustom"
+    default_duration: 60
+default_value_callback: ''
+settings: {  }
+field_type: smartdate

--- a/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.field_event_image.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.field_event_image.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_image
+    - media.type.event_image
+    - node.type.event
+id: node.event.field_event_image
+field_name: field_event_image
+entity_type: node
+bundle: event
+label: Image
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      event_image: event_image
+    sort:
+      field: _none
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.field_event_location.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.field_event_location.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_location
+    - node.type.event
+id: node.event.field_event_location
+field_name: field_event_location
+entity_type: node
+bundle: event
+label: Location
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.field_event_type.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.field_event_type.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_type
+    - node.type.event
+    - taxonomy.vocabulary.event_categories
+id: node.event.field_event_type
+field_name: field_event_type
+entity_type: node
+bundle: event
+label: 'Event type'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      event_categories: event_categories
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.field_event_type.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.field_event_type.yml
@@ -4,7 +4,7 @@ dependencies:
   config:
     - field.storage.node.field_event_type
     - node.type.event
-    - taxonomy.vocabulary.event_categories
+    - taxonomy.vocabulary.event_taxonomy
 id: node.event.field_event_type
 field_name: field_event_type
 entity_type: node
@@ -19,7 +19,7 @@ settings:
   handler: 'default:taxonomy_term'
   handler_settings:
     target_bundles:
-      event_categories: event_categories
+      event_taxonomy: event_taxonomy
     sort:
       field: name
       direction: asc

--- a/ecms_base/features/custom/ecms_event/config/install/field.storage.media.field_media_image_1.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.storage.media.field_media_image_1.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - media
+id: media.field_media_image_1
+field_name: field_media_image_1
+entity_type: media
+type: image
+settings:
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_event/config/install/field.storage.node.field_event_body.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.storage.node.field_event_body.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_event_body
+field_name: field_event_body
+entity_type: node
+type: text_with_summary
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_event/config/install/field.storage.node.field_event_contact.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.storage.node.field_event_contact.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_event_contact
+field_name: field_event_contact
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_event/config/install/field.storage.node.field_event_date.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.storage.node.field_event_date.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - smart_date
+id: node.field_event_date
+field_name: field_event_date
+entity_type: node
+type: smartdate
+settings: {  }
+module: smart_date
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_event/config/install/field.storage.node.field_event_image.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.storage.node.field_event_image.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_event_image
+field_name: field_event_image
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_event/config/install/field.storage.node.field_event_location.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.storage.node.field_event_location.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_event_location
+field_name: field_event_location
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_event/config/install/field.storage.node.field_event_type.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.storage.node.field_event_type.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_event_type
+field_name: field_event_type
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_event/config/install/media.type.event_image.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/media.type.event_image.yml
@@ -1,0 +1,12 @@
+langcode: en
+status: true
+dependencies: {  }
+id: event_image
+label: 'Event image'
+description: 'Images for events.'
+source: image
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  source_field: field_media_image_1
+field_map: {  }

--- a/ecms_base/features/custom/ecms_event/config/install/node.type.event.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/node.type.event.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: Event
+type: event
+description: 'Add a new event.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/ecms_base/features/custom/ecms_event/config/install/taxonomy.vocabulary.event_categories.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/taxonomy.vocabulary.event_categories.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Event Categories'
+vid: event_categories
+description: 'Categories for events.'
+weight: 0

--- a/ecms_base/features/custom/ecms_event/config/install/taxonomy.vocabulary.event_categories.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/taxonomy.vocabulary.event_categories.yml
@@ -1,7 +1,0 @@
-langcode: en
-status: true
-dependencies: {  }
-name: 'Event Categories'
-vid: event_categories
-description: 'Categories for events.'
-weight: 0

--- a/ecms_base/features/custom/ecms_event/config/install/taxonomy.vocabulary.event_taxonomy.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/taxonomy.vocabulary.event_taxonomy.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Event categories'
+vid: event_taxonomy
+description: 'Group events by categories.'
+weight: 0

--- a/ecms_base/features/custom/ecms_event/ecms_event.features.yml
+++ b/ecms_base/features/custom/ecms_event/ecms_event.features.yml
@@ -1,0 +1,1 @@
+bundle: ecms

--- a/ecms_base/features/custom/ecms_event/ecms_event.info.yml
+++ b/ecms_base/features/custom/ecms_event/ecms_event.info.yml
@@ -1,0 +1,19 @@
+name: Event
+description: 'Provides Event content type and related configuration.'
+type: module
+core_version_requirement: ^9
+dependencies:
+  - field
+  - file
+  - image
+  - media
+  - media_library
+  - menu_ui
+  - node
+  - path
+  - smart_date
+  - taxonomy
+  - text
+  - user
+package: eCMS
+version: 9.x-1.0

--- a/tests/src/Functional/AllProfileInstallationTestsAbstract.php
+++ b/tests/src/Functional/AllProfileInstallationTestsAbstract.php
@@ -251,7 +251,7 @@ abstract class AllProfileInstallationTestsAbstract extends BrowserTestBase {
     ]);
     $this->drupalLogin($account);
 
-    // Ensure the notification entity add formis available.
+    // Ensure the event entity add form is available.
     $this->drupalGet('node/add/event');
     $this->assertSession()->statusCodeEquals(200);
 

--- a/tests/src/Functional/AllProfileInstallationTestsAbstract.php
+++ b/tests/src/Functional/AllProfileInstallationTestsAbstract.php
@@ -96,6 +96,7 @@ abstract class AllProfileInstallationTestsAbstract extends BrowserTestBase {
     $this->ensureLocationFeatureInstalled();
     $this->ensureWebformInstall();
     $this->ensurePublishContentInstalled();
+    $this->ensureEventFeatureInstalled();
   }
 
   /**
@@ -216,7 +217,7 @@ abstract class AllProfileInstallationTestsAbstract extends BrowserTestBase {
   /**
    * Ensure the webform requirement installed properly.
    */
-  public function ensureWebformInstall(): void {
+  private function ensureWebformInstall(): void {
     $account = $this->drupalCreateUser(['administer webform']);
     $this->drupalLogin($account);
 
@@ -237,6 +238,45 @@ abstract class AllProfileInstallationTestsAbstract extends BrowserTestBase {
     $this->drupalGet('admin/people/permissions');
     $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->checkboxChecked('edit-site-admin-unpublish-any-content');
+    $this->drupalLogout();
+  }
+
+  /**
+   * Test whether the ecms_event feature installed properly.
+   */
+  private function ensureEventFeatureInstalled(): void {
+    $account = $this->drupalCreateUser([
+      'create event content',
+      'create terms in event_taxonomy',
+    ]);
+    $this->drupalLogin($account);
+
+    // Ensure the notification entity add formis available.
+    $this->drupalGet('node/add/event');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $fields = [
+      'title[0][value]' => 'Test event',
+      'field_event_date[0][value][date]' => '1980-11-09',
+      'field_event_date[0][end_value][date]' => '1980-11-09',
+      'field_event_date[0][value][time]' => '14:44:44',
+      'field_event_date[0][end_value][time]' => '15:44:44',
+    ];
+
+    // Check that the required fields exist in the form.
+    foreach ($fields as $key => $value) {
+      $this->assertFieldByName($key);
+    }
+
+    $this->drupalPostForm('node/add/event', $fields, 'Save');
+
+    // Ensure the auto entity label tokens were applied.
+    $this->assertText('Event Test event has been created.');
+
+    // Ensure the taxonomy is accessible.
+    $this->drupalGet('admin/structure/taxonomy/manage/event_taxonomy/add');
+    $this->assertSession()->statusCodeEquals(200);
+
     $this->drupalLogout();
   }
 


### PR DESCRIPTION
## Summary
This adds the Event content type and taxonomy as a feature module and enables it by default on installation of the profile.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-40](https://thinkoomph.jira.com/browse/rig-40)