### PR TITLE
Add the Basic page content feature to the profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-15: Added the Publish Content module and installed by default.
 - RIG-40: Added the Event content type as a feature.
 - RIG-41: Added the Promotions content type as a feature.
+- RIG-39: Added the Basic page content type as a feature.
 
 ### Changed
 - RIG-23: Changed from OIDC generic to Windows AAD for authentication.

--- a/docs/features.md
+++ b/docs/features.md
@@ -28,6 +28,9 @@ This contains the event content type and the related field and taxonomy configur
 ### ecms_promotions
 This contains the promotions content type and the related field configurations.
 
+### ecms_basic_page
+This contains the basic_page content type and the related field configurations.
+
 ## Development Notes
 Developing with features can be tricky. A few items to remember:
 

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -50,6 +50,7 @@ dependencies:
 # Install the required features.
 install:
   - ecms_authentication
+  - ecms_basic_page
   - ecms_event
   - ecms_location
   - ecms_notification

--- a/ecms_base/features/custom/ecms_basic_page/config/install/core.base_field_override.node.basic_page.promote.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/core.base_field_override.node.basic_page.promote.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.basic_page
+id: node.basic_page.promote
+field_name: promote
+entity_type: node
+bundle: basic_page
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_form_display.node.basic_page.default.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_form_display.node.basic_page.default.yml
@@ -1,0 +1,76 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.basic_page.field_basic_page_body
+    - node.type.basic_page
+  module:
+    - path
+    - text
+id: node.basic_page.default
+targetEntityType: node
+bundle: basic_page
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_basic_page_body:
+    weight: 121
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+    type: text_textarea_with_summary
+    region: content
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_view_display.node.basic_page.default.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_view_display.node.basic_page.default.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.basic_page.field_basic_page_body
+    - node.type.basic_page
+  module:
+    - text
+    - user
+id: node.basic_page.default
+targetEntityType: node
+bundle: basic_page
+mode: default
+content:
+  field_basic_page_body:
+    weight: 101
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_view_display.node.basic_page.teaser.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_view_display.node.basic_page.teaser.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.basic_page.field_basic_page_body
+    - node.type.basic_page
+  module:
+    - user
+id: node.basic_page.teaser
+targetEntityType: node
+bundle: basic_page
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_basic_page_body: true

--- a/ecms_base/features/custom/ecms_basic_page/config/install/field.field.node.basic_page.field_basic_page_body.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/field.field.node.basic_page.field_basic_page_body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_basic_page_body
+    - node.type.basic_page
+  module:
+    - text
+id: node.basic_page.field_basic_page_body
+field_name: field_basic_page_body
+entity_type: node
+bundle: basic_page
+label: 'Intro text'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/ecms_base/features/custom/ecms_basic_page/config/install/field.storage.node.field_basic_page_body.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/field.storage.node.field_basic_page_body.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_basic_page_body
+field_name: field_basic_page_body
+entity_type: node
+type: text_with_summary
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_basic_page/config/install/node.type.basic_page.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/node.type.basic_page.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+name: 'Basic page'
+type: basic_page
+description: 'Add a basic page to the site.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/ecms_base/features/custom/ecms_basic_page/ecms_basic_page.features.yml
+++ b/ecms_base/features/custom/ecms_basic_page/ecms_basic_page.features.yml
@@ -1,0 +1,1 @@
+bundle: ecms

--- a/ecms_base/features/custom/ecms_basic_page/ecms_basic_page.info.yml
+++ b/ecms_base/features/custom/ecms_basic_page/ecms_basic_page.info.yml
@@ -1,0 +1,13 @@
+name: 'Basic page'
+description: 'Provides Basic page content type and related configuration. Add a basic page to the site.'
+type: module
+core_version_requirement: ^9
+dependencies:
+  - field
+  - menu_ui
+  - node
+  - path
+  - text
+  - user
+package: eCMS
+version: 9.x-1.0

--- a/tests/src/Functional/AllProfileInstallationTestsAbstract.php
+++ b/tests/src/Functional/AllProfileInstallationTestsAbstract.php
@@ -314,7 +314,7 @@ abstract class AllProfileInstallationTestsAbstract extends BrowserTestBase {
     ]);
     $this->drupalLogin($account);
 
-    // Ensure the promotions entity add form is available.
+    // Ensure the basic_page entity add form is available.
     $this->drupalGet('node/add/basic_page');
     $this->assertSession()->statusCodeEquals(200);
 

--- a/tests/src/Functional/AllProfileInstallationTestsAbstract.php
+++ b/tests/src/Functional/AllProfileInstallationTestsAbstract.php
@@ -105,6 +105,7 @@ abstract class AllProfileInstallationTestsAbstract extends BrowserTestBase {
     $this->ensurePublishContentInstalled();
     $this->ensureEventFeatureInstalled();
     $this->ensurePromotionsFeatureInstalled();
+    $this->ensureBasicPageFeatureInstalled();
   }
 
   /**
@@ -299,6 +300,22 @@ abstract class AllProfileInstallationTestsAbstract extends BrowserTestBase {
 
     // Ensure the promotions entity add form is available.
     $this->drupalGet('node/add/promotions');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $this->drupalLogout();
+  }
+
+  /**
+   * Test whether the ecms_basic_page feature installed properly.
+   */
+  private function ensureBasicPageFeatureInstalled(): void {
+    $account = $this->drupalCreateUser([
+      'create basic_page content',
+    ]);
+    $this->drupalLogin($account);
+
+    // Ensure the promotions entity add form is available.
+    $this->drupalGet('node/add/basic_page');
     $this->assertSession()->statusCodeEquals(200);
 
     $this->drupalLogout();


### PR DESCRIPTION
## Summary
This adds the basic page content type as a feature module to the code base and installs it by default. The Flexible Content field was purposely left off as those need to be defined yet.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-39](https://thinkoomph.jira.com/browse/rig-39)