### PR TITLE
Testing performance fixes

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -35,12 +35,17 @@ jobs:
           cd ../develop-ecms-profile
           lando phpcs
 
-      - name: Run unit tests.
-        run: |
-          cd ../develop-ecms-profile
-          lando phpunit
-
       - name: Run gulp validate.
         run: |
           cd ../develop-ecms-profile
           lando gulp-distro validate
+
+      - name: Run unit tests.
+        run: |
+          cd ../develop-ecms-profile
+          lando phpunit --testsuite=unit
+
+      - name: Run functional tests.
+          run: |
+            cd ../develop-ecms-profile
+            lando phpunit --testsuite=functional

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -46,6 +46,6 @@ jobs:
           lando phpunit --testsuite=unit
 
       - name: Run functional tests.
-          run: |
-            cd ../develop-ecms-profile
-            lando phpunit --testsuite=functional
+        run: |
+          cd ../develop-ecms-profile
+          lando phpunit --testsuite=functional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Changed
 - RIG-23: Changed from OIDC generic to Windows AAD for authentication.
-
+- Disabled xdebug by default in the develop.sh script.
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Changed
 - RIG-23: Changed from OIDC generic to Windows AAD for authentication.
 - Disabled xdebug by default in the develop.sh script.
+
 ### Deprecated
 
 ### Removed

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -126,8 +126,18 @@ tooling:
   phpcs:
     service: appserver
     cmd: vendor/bin/phpcs --standard=/$INSTALL_PROFILE_DIRECTORY/phpcs.xml
+  xdebug-on:
+    service: appserver
+    description: Enable xdebug for apache.
+    cmd: 'docker-php-ext-enable xdebug && /etc/init.d/apache2 reload'
+    user: root
+  xdebug-off:
+    service: appserver
+    description: Disable xdebug for apache.
+    cmd: 'rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && /etc/init.d/apache2 reload'
+    user: root
 config:
-  xdebug: true" >> ${DEST_DIR}/.lando.local.yml
+  xdebug: false" >> ${DEST_DIR}/.lando.local.yml
 fi
 
 # Start the app with lando.


### PR DESCRIPTION
## Summary
Disable xdebug and break the testing out by group. This _seems_ to have improved functional testing performance from 30-40 minutes to ~5 minutes.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | n/a
| Risk level | Low
| Relevant links | JIRA issue, bug reports, security alerts, etc.