### PR TITLE
Add configuration form enabling content types for the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-16: Added custom theme with Pattern Lab repo dependency.
 - RIG-37: Added the Admin Toolbar module.
 - RIG-55: Added the ecms_api_recipient custom module.
+- RIG-56: Added a configuration form to toggle content types for the eCMS API. 
 
 ### Changed
 - RIG-23: Changed from OIDC generic to Windows AAD for authentication.

--- a/ecms_base/modules/custom/ecms_api_recipient/README.md
+++ b/ecms_base/modules/custom/ecms_api_recipient/README.md
@@ -40,5 +40,5 @@ by the publishing site to gain an access token with which to create content.
 Content types can be toggled with the configuration form at: 
 `admin/config/ecms_api/ecms_api_recipient/settings`. This will allow an admin
 to select the content types to allow JSON API publishing. Once submitted, the
-`ecms_api_recipient` role permissions are update to allow the creation of the
+`ecms_api_recipient` role permissions are updated to allow the creation of the
 selected nodes.

--- a/ecms_base/modules/custom/ecms_api_recipient/README.md
+++ b/ecms_base/modules/custom/ecms_api_recipient/README.md
@@ -35,3 +35,10 @@ is treated as a password with plenty of length and randomness.
 
 The Client ID and the Client Secret above will be passed to `oauth/token` route
 by the publishing site to gain an access token with which to create content.
+
+## Allowing JSON API Content Creation
+Content types can be toggled with the configuration form at: 
+`admin/config/ecms_api/ecms_api_recipient/settings`. This will allow an admin
+to select the content types to allow JSON API publishing. Once submitted, the
+`ecms_api_recipient` role permissions are update to allow the creation of the
+selected nodes.

--- a/ecms_base/modules/custom/ecms_api_recipient/config/schema/ecms_api_recipient.schema.yml
+++ b/ecms_base/modules/custom/ecms_api_recipient/config/schema/ecms_api_recipient.schema.yml
@@ -1,4 +1,4 @@
-ecms_recipient.settings:
+ecms_api_recipient.settings:
   type: config_object
   mapping:
     oauth_client_id:

--- a/ecms_base/modules/custom/ecms_api_recipient/ecms_api_recipient.links.menu.yml
+++ b/ecms_base/modules/custom/ecms_api_recipient/ecms_api_recipient.links.menu.yml
@@ -1,0 +1,6 @@
+ecms_api_recipient.settings_form:
+  title: 'eCMS API Allowed Recipients'
+  description: 'Configure the allowed content types to receive syndicated content.'
+  route_name: ecms_api_recipient.settings_form
+  parent: system.admin_config_services
+  weight: 10

--- a/ecms_base/modules/custom/ecms_api_recipient/ecms_api_recipient.routing.yml
+++ b/ecms_base/modules/custom/ecms_api_recipient/ecms_api_recipient.routing.yml
@@ -1,0 +1,7 @@
+ecms_api_recipient.settings_form:
+  path: 'admin/config/ecms_api/ecms_api_recipient/settings'
+  defaults:
+    _form: '\Drupal\ecms_api_recipient\Form\EcmsApiRecipientConfigForm'
+    _title: 'eCMS API Recipient Configuration'
+  requirements:
+    _permission: 'administer site configuration'

--- a/ecms_base/modules/custom/ecms_api_recipient/src/Form/EcmsApiRecipientConfigForm.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/src/Form/EcmsApiRecipientConfigForm.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types =1);
+
+namespace Drupal\ecms_api_recipient\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\user\RoleInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class EcmsApiRecipientConfigForm.
+ *
+ * @package Drupal\ecms_api_recipient\Form
+ */
+class EcmsApiRecipientConfigForm extends ConfigFormBase {
+
+  /**
+   * The role id to assign to the oauth user account.
+   */
+  const RECIPIENT_ROLE = 'ecms_api_recipient';
+
+  /**
+   * The entity_type.manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private $entityTypeManager;
+
+  /**
+   * The entity_type.bundle.info service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  private $entityTypeBundleInfo;
+
+  /**
+   * EcmsApiRecipientConfigForm constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config.factory service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity_type.manager service.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entityTypeBundleInfo
+   *   The entity_type.bundle.info service.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entityTypeManager, EntityTypeBundleInfoInterface $entityTypeBundleInfo) {
+    parent::__construct($config_factory);
+
+    $this->entityTypeManager = $entityTypeManager;
+    $this->entityTypeBundleInfo = $entityTypeBundleInfo;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('entity_type.manager'),
+      $container->get('entity_type.bundle.info')
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function getEditableConfigNames(): array {
+    return [
+      'ecms_api_recipient.settings',
+    ];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getFormId(): string {
+    return 'ecms_api_recipient_settings_form';
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildForm($form, $form_state);
+
+    // Load the available nodes.
+    $nodes = $this->entityTypeBundleInfo->getBundleInfo('node');
+    $nodes = array_map(function ($bundle_info) {
+      return $bundle_info['label'];
+    }, $nodes);
+
+    // List of all available content types as checkboxes.
+    $form['allowed_content_types'] = [
+      '#title' => $this->t('Content types'),
+      '#description' => $this->t('Select the content types that are allowed to receive syndicated content with the eCMS API.'),
+      '#type' => 'checkboxes',
+      '#options' => $nodes,
+      '#default_value' => $this->config('ecms_api_recipient.settings')->get('allowed_content_types'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    // Get the allowed content types from the user.
+    $contentTypes = $form_state->getValue('allowed_content_types');
+
+    // Filter the array.
+    $contentTypes = array_filter($contentTypes);
+
+    // Save the allowed content types to the configuration object.
+    $this->config('ecms_api_recipient.settings')
+      ->set('allowed_content_types', $contentTypes)
+      ->save();
+
+    parent::submitForm($form, $form_state);
+
+    // Save the permissions of the selected content types to the api role.
+    $this->setRecipientRolePermissions($contentTypes);
+  }
+
+  /**
+   * Set the correct API permissions to the role.
+   *
+   * @param array $contentTypes
+   *   Array of content types selected on the configuration form.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  private function setRecipientRolePermissions(array $contentTypes): void {
+    // Load the role entity.
+    $role = $this->getRole();
+
+    // Guard against a null entity.
+    if (empty($role)) {
+      return;
+    }
+
+    // Revoke all existing permissions.
+    $existingPermissions = $role->getPermissions();
+    foreach ($existingPermissions as $permission) {
+      $role->revokePermission($permission);
+    }
+
+    // Grant create and edit own permissions for the selected content types.
+    foreach ($contentTypes as $key => $type) {
+      $role->grantPermission("create {$key} content");
+      $role->grantPermission("edit own {$key} content");
+    }
+
+    try {
+      $role->save();
+    }
+    catch (EntityStorageException $e) {
+      return;
+    }
+  }
+
+  /**
+   * Load the user role entity.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface|null
+   *   The role entity or null if it doesn't exist.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  private function getRole(): ?RoleInterface {
+    return $this->entityTypeManager
+      ->getStorage('user_role')
+      ->load(self::RECIPIENT_ROLE);
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_api_recipient/src/Form/EcmsApiRecipientConfigForm.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/src/Form/EcmsApiRecipientConfigForm.php
@@ -70,7 +70,7 @@ class EcmsApiRecipientConfigForm extends ConfigFormBase {
   /**
    * {@inheritDoc}
    */
-  protected function getEditableConfigNames(): array {
+  public function getEditableConfigNames(): array {
     return [
       'ecms_api_recipient.settings',
     ];

--- a/ecms_base/modules/custom/ecms_api_recipient/tests/src/Functional/InstallationTest.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/tests/src/Functional/InstallationTest.php
@@ -102,6 +102,10 @@ class InstallationTest extends AllProfileInstallationTestsAbstract {
     $this->assertSession()->checkboxNotChecked('edit-ecms-api-recipient-create-basic-page-content');
     $this->assertSession()->checkboxNotChecked('edit-ecms-api-recipient-edit-own-basic-page-content');
 
+    $this->drupalGet('admin/config/services/');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkExists('eCMS API Allowed Recipients');
+
   }
 
 }

--- a/ecms_base/modules/custom/ecms_api_recipient/tests/src/Functional/InstallationTest.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/tests/src/Functional/InstallationTest.php
@@ -45,6 +45,7 @@ class InstallationTest extends AllProfileInstallationTestsAbstract {
       'administer consumer entities',
       'administer users',
       'administer site configuration',
+      'access administration pages',
     ]);
     $this->drupalLogin($account);
 
@@ -102,7 +103,8 @@ class InstallationTest extends AllProfileInstallationTestsAbstract {
     $this->assertSession()->checkboxNotChecked('edit-ecms-api-recipient-create-basic-page-content');
     $this->assertSession()->checkboxNotChecked('edit-ecms-api-recipient-edit-own-basic-page-content');
 
-    $this->drupalGet('admin/config/services/');
+    // Ensure the menu link is available.
+    $this->drupalGet('admin/config/services');
     $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->linkExists('eCMS API Allowed Recipients');
 

--- a/ecms_base/modules/custom/ecms_api_recipient/tests/src/Functional/InstallationTest.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/tests/src/Functional/InstallationTest.php
@@ -44,6 +44,7 @@ class InstallationTest extends AllProfileInstallationTestsAbstract {
       'administer permissions',
       'administer consumer entities',
       'administer users',
+      'administer site configuration',
     ]);
     $this->drupalLogin($account);
 
@@ -85,6 +86,22 @@ class InstallationTest extends AllProfileInstallationTestsAbstract {
     $this->assertSession()->fieldValueEquals('edit-user-id-0-target-id', "ecms_api_recipient ({$accountId})");
     // Ensure the correct role is set.
     $this->assertSession()->checkboxChecked('edit-roles-ecms-api-recipient');
+
+    $this->drupalGet('admin/config/ecms_api/ecms_api_recipient/settings');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->fieldExists('edit-allowed-content-types-notification');
+    $configFormSubmission = [
+      'edit-allowed-content-types-notification' => 1,
+    ];
+    $this->drupalPostForm('admin/config/ecms_api/ecms_api_recipient/settings', $configFormSubmission, 'Save configuration');
+    $this->drupalGet('admin/people/permissions/ecms_api_recipient');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->checkboxChecked('edit-ecms-api-recipient-create-notification-content');
+    $this->assertSession()->checkboxChecked('edit-ecms-api-recipient-edit-own-notification-content');
+
+    $this->assertSession()->checkboxNotChecked('edit-ecms-api-recipient-create-basic-page-content');
+    $this->assertSession()->checkboxNotChecked('edit-ecms-api-recipient-edit-own-basic-page-content');
+
   }
 
 }

--- a/ecms_base/modules/custom/ecms_api_recipient/tests/src/Unit/Form/EcmsApiRecipientConfigFormTest.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/tests/src/Unit/Form/EcmsApiRecipientConfigFormTest.php
@@ -1,0 +1,347 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\ecms_api_recipient\Unit;
+
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\ecms_api_recipient\Form\EcmsApiRecipientConfigForm;
+use Drupal\Tests\UnitTestCase;
+use Drupal\user\RoleInterface;
+
+/**
+ * Class EcmsApiRecipientConfigFormTest.
+ *
+ * @package Drupal\Tests\ecms_api_recipient\Unit
+ * @covers \Drupal\ecms_api_recipient\Form\EcmsApiRecipientConfigForm
+ * @group ecms
+ * @group ecms_api
+ * @group ecms_api_recipient
+ */
+class EcmsApiRecipientConfigFormTest extends UnitTestCase {
+
+  /**
+   * The expected role entity id.
+   */
+  const RECIPIENT_ROLE = 'ecms_api_recipient';
+
+  /**
+   * The expected form id.
+   */
+  const FORM_ID = 'ecms_api_recipient_settings_form';
+
+  /**
+   * The expected configuration names.
+   */
+  const CONFIG_NAMES = [
+    'ecms_api_recipient.settings',
+  ];
+
+  /**
+   * The expected node types.
+   */
+  const NODE_TYPES = [
+    'type_one' => ['label' => 'Type 1'],
+    'type_two' => ['label' => 'Type 2'],
+    'type_three' => ['label' => 'Type 3'],
+  ];
+
+  /**
+   * The expected selected nodes.
+   */
+  const SELECTED_NODE_TYPES = [
+    'type_two' => 'Type 2',
+  ];
+
+  /**
+   * The existing permissions.
+   */
+  const EXISTING_PERMISSIONS = [
+    'permission one',
+    'permission two',
+    'administer site',
+  ];
+
+  /**
+   * Mock of the entity_type.manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $entityTypeManager;
+
+  /**
+   * Mock of the entity_type.bundle.info service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $entityBundleInfo;
+
+  /**
+   * Mock of the config.factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $configFactory;
+
+  /**
+   * Mock of the form state interface used in the form.
+   *
+   * @var \Drupal\Core\Form\FormStateInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $formState;
+
+  /**
+   * The configuration form being tested.
+   *
+   * @var \Drupal\Core\Form\ConfigFormBase|\Drupal\ecms_api_recipient\Form\EcmsApiRecipientConfigForm
+   */
+  private $configForm;
+
+  /**
+   * Mock of the container.
+   *
+   * @var \Drupal\Core\DependencyInjection\ContainerBuilder
+   */
+  private $container;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->formState = $this->createMock(FormStateInterface::class);
+    $this->entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $this->entityBundleInfo = $this->createMock(EntityTypeBundleInfoInterface::class);
+    $this->configFactory = $this->createMock(ConfigFactoryInterface::class);
+
+    $messenger = $this->createMock(MessengerInterface::class);
+    $this->container = new ContainerBuilder();
+    $this->container->set('config.factory', $this->configFactory);
+    $this->container->set('entity_type.manager', $this->entityTypeManager);
+    $this->container->set('entity_type.bundle.info', $this->entityBundleInfo);
+    $this->container->set('string_translation', $this->getStringTranslationStub());
+    $this->container->set('messenger', $messenger);
+    \Drupal::setContainer($this->container);
+
+    // Test the create method.
+    $this->configForm = EcmsApiRecipientConfigForm::create($this->container);
+  }
+
+  /**
+   * Test the getFormId method.
+   */
+  public function testGetFormId(): void {
+    $id = $this->configForm->getFormId();
+    $this->assertEquals(self::FORM_ID, $id);
+  }
+
+  /**
+   * Test the getEditableConfigNames method.
+   */
+  public function testGetEditableConfigNames(): void {
+    $configNames = $this->configForm->getEditableConfigNames();
+    $this->assertArrayEquals(self::CONFIG_NAMES, $configNames);
+  }
+
+  /**
+   * Test the buildForm method.
+   */
+  public function testBuildForm(): void {
+    $this->entityBundleInfo->expects($this->once())
+      ->method('getBundleInfo')
+      ->with('node')
+      ->willReturn(self::NODE_TYPES);
+
+    $settingsConfig = $this->createMock(Config::class);
+    $settingsConfig->expects($this->once())
+      ->method('get')
+      ->with('allowed_content_types')
+      ->willReturn(self::SELECTED_NODE_TYPES);
+
+    $this->configFactory->expects($this->once())
+      ->method('getEditable')
+      ->with('ecms_api_recipient.settings')
+      ->willReturn($settingsConfig);
+
+    $form = [];
+    $formArray = $this->configForm->buildForm($form, $this->formState);
+
+    $this->assertArrayHasKey('allowed_content_types', $formArray);
+    $this->assertArrayHasKey('#options', $formArray['allowed_content_types']);
+
+    foreach (self::NODE_TYPES as $key => $value) {
+      $this->assertArrayHasKey($key, $formArray['allowed_content_types']['#options']);
+    }
+
+    foreach (self::SELECTED_NODE_TYPES as $key => $value) {
+      $this->assertArrayHasKey($key, $formArray['allowed_content_types']['#default_value']);
+    }
+  }
+
+  /**
+   * Successfully test the submit form.
+   */
+  public function testSubmitForm(): void {
+    $this->formState->expects($this->once())
+      ->method('getValue')
+      ->with('allowed_content_types')
+      ->willReturn(self::SELECTED_NODE_TYPES);
+
+    $settingsConfig = $this->createMock(Config::class);
+    $settingsConfig->expects($this->once())
+      ->method('set')
+      ->with('allowed_content_types', self::SELECTED_NODE_TYPES)
+      ->willReturnSelf();
+
+    $this->configFactory->expects($this->once())
+      ->method('getEditable')
+      ->with('ecms_api_recipient.settings')
+      ->willReturn($settingsConfig);
+
+    $roleEntity = $this->createMock(RoleInterface::class);
+    $roleEntity->expects($this->once())
+      ->method('getPermissions')
+      ->willReturn(self::EXISTING_PERMISSIONS);
+
+    $roleEntity->expects($this->exactly(count(self::EXISTING_PERMISSIONS)))
+      ->method('revokePermission')
+      ->willReturnSelf();
+
+    $roleEntity->expects($this->exactly(count(self::SELECTED_NODE_TYPES) * 2))
+      ->method('grantPermission')
+      ->willReturnSelf();
+
+    $roleEntity->expects($this->once())
+      ->method('save')
+      ->willReturnSelf();
+
+    $roleStorage = $this->createMock(EntityStorageInterface::class);
+    $roleStorage->expects($this->once())
+      ->method('load')
+      ->with(self::RECIPIENT_ROLE)
+      ->willReturn($roleEntity);
+
+    $this->entityTypeManager->expects($this->once())
+      ->method('getStorage')
+      ->with('user_role')
+      ->willReturn($roleStorage);
+
+    $form = [];
+    $this->configForm->submitForm($form, $this->formState);
+  }
+
+  /**
+   * Test the submit form with an empty role.
+   */
+  public function testSubmitFormEntityException(): void {
+    $this->formState->expects($this->once())
+      ->method('getValue')
+      ->with('allowed_content_types')
+      ->willReturn(self::SELECTED_NODE_TYPES);
+
+    $settingsConfig = $this->createMock(Config::class);
+    $settingsConfig->expects($this->once())
+      ->method('set')
+      ->with('allowed_content_types', self::SELECTED_NODE_TYPES)
+      ->willReturnSelf();
+
+    $this->configFactory->expects($this->once())
+      ->method('getEditable')
+      ->with('ecms_api_recipient.settings')
+      ->willReturn($settingsConfig);
+
+    $roleEntity = $this->createMock(RoleInterface::class);
+    $roleEntity->expects($this->never())
+      ->method('getPermissions')
+      ->willReturn(self::EXISTING_PERMISSIONS);
+
+    $roleEntity->expects($this->never())
+      ->method('revokePermission')
+      ->willReturnSelf();
+
+    $roleEntity->expects($this->never())
+      ->method('grantPermission')
+      ->willReturnSelf();
+
+    $roleEntity->expects($this->never())
+      ->method('save')
+      ->willReturnSelf();
+
+    $roleStorage = $this->createMock(EntityStorageInterface::class);
+    $roleStorage->expects($this->once())
+      ->method('load')
+      ->with(self::RECIPIENT_ROLE)
+      ->willReturn(NULL);
+
+    $this->entityTypeManager->expects($this->once())
+      ->method('getStorage')
+      ->with('user_role')
+      ->willReturn($roleStorage);
+
+    $form = [];
+    $this->configForm->submitForm($form, $this->formState);
+  }
+
+  /**
+   * Test the submit form with a storage exception.
+   */
+  public function testSubmitFormEntityStorageException(): void {
+    $this->formState->expects($this->once())
+      ->method('getValue')
+      ->with('allowed_content_types')
+      ->willReturn(self::SELECTED_NODE_TYPES);
+
+    $settingsConfig = $this->createMock(Config::class);
+    $settingsConfig->expects($this->once())
+      ->method('set')
+      ->with('allowed_content_types', self::SELECTED_NODE_TYPES)
+      ->willReturnSelf();
+
+    $this->configFactory->expects($this->once())
+      ->method('getEditable')
+      ->with('ecms_api_recipient.settings')
+      ->willReturn($settingsConfig);
+
+    $roleEntity = $this->createMock(RoleInterface::class);
+    $roleEntity->expects($this->once())
+      ->method('getPermissions')
+      ->willReturn(self::EXISTING_PERMISSIONS);
+
+    $roleEntity->expects($this->exactly(count(self::EXISTING_PERMISSIONS)))
+      ->method('revokePermission')
+      ->willReturnSelf();
+
+    $roleEntity->expects($this->exactly(count(self::SELECTED_NODE_TYPES) * 2))
+      ->method('grantPermission')
+      ->willReturnSelf();
+
+    $exception = $this->createMock(EntityStorageException::class);
+    $roleEntity->expects($this->once())
+      ->method('save')
+      ->willThrowException($exception);
+
+    $roleStorage = $this->createMock(EntityStorageInterface::class);
+    $roleStorage->expects($this->once())
+      ->method('load')
+      ->with(self::RECIPIENT_ROLE)
+      ->willReturn($roleEntity);
+
+    $this->entityTypeManager->expects($this->once())
+      ->method('getStorage')
+      ->with('user_role')
+      ->willReturn($roleStorage);
+
+    $form = [];
+    $this->configForm->submitForm($form, $this->formState);
+  }
+
+}


### PR DESCRIPTION
## Summary
This is a continuation of #21 and adds a new configuration form that allows an administrator to select the content types they would like to receive content syndication for. This will save the configuration and will update the ecms_api_recipient role permissions and provide the ceate node type and edit own node type permissions for the selected content types. This will then allow syndication to publish these content types.

## Metadata

| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Medium
| Relevant links | [RIG-56](https://thinkoomph.jira.com/browse/rig-56)