### PR TITLE
Update the develop script to allow for Pattern Lab development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - Disabled xdebug by default in the develop.sh script.
 - RIG-37: Made ECMS custom theme the default.
 - RIG-22: Enable Moderation Dashboard module by default.
+- RIG-37: Updated the development script to allow for pattern lab development.
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
     "drupal/simple_oauth": "^4.5",
     "drupal/smart_date": "^3.0",
     "drupal/token": "^1.7",
-    "drupal/webform": "6.17",
+    "drupal/webform": "6.0.0-alpha17",
     "drush/drush": "^10.0",
     "oomphinc/composer-installers-extender": "^1.1",
     "zaporylie/composer-drupal-optimizations": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -20,19 +20,6 @@
     {
       "type": "composer",
       "url": "https://asset-packagist.org"
-    },
-    {
-      "type": "package",
-      "package": {
-        "name": "state-of-rhode-island-ecms/ecms_patternlab",
-        "version": "1.0.0",
-        "type": "pattern-lab",
-        "source": {
-          "url": "https://github.com/State-of-Rhode-Island-eCMS/ecms_patternlab",
-          "type": "git",
-          "reference": "master"
-        }
-      }
     }
   ],
   "extra": {
@@ -54,10 +41,6 @@
       "drupal/webform": {
         "3173864 - Website Error after update to latest 6 alpha release / tippyjs/6.x": ",https://www.drupal.org/files/issues/2020-09-29/3173864-10.patch"
       }
-    },
-    "installer-types": ["pattern-lab"],
-    "installer-paths": {
-      "ecms_base/themes/custom/ecms/{$name}": ["state-of-rhode-island-ecms/ecms_patternlab"]
     },
     "preserve-paths": [],
     "drupal-scaffold": {}
@@ -100,7 +83,6 @@
     "drupal/webform": "^6.0",
     "drush/drush": "^10.0",
     "oomphinc/composer-installers-extender": "^1.1",
-    "state-of-rhode-island-ecms/ecms_patternlab": "^1.0",
     "zaporylie/composer-drupal-optimizations": "^1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -37,9 +37,6 @@
       },
       "drupal/content_moderation_notifications": {
         "3170503 - Core requirement error during Functional test": "https://www.drupal.org/files/issues/2020-09-11/3170503-2.patch"
-      },
-      "drupal/webform": {
-        "3173864 - Website Error after update to latest 6 alpha release / tippyjs/6.x": "https://www.drupal.org/files/issues/2020-09-29/3173864-10.patch"
       }
     },
     "preserve-paths": [],
@@ -80,7 +77,7 @@
     "drupal/simple_oauth": "^4.5",
     "drupal/smart_date": "^3.0",
     "drupal/token": "^1.7",
-    "drupal/webform": "^6.0",
+    "drupal/webform": "6.17",
     "drush/drush": "^10.0",
     "oomphinc/composer-installers-extender": "^1.1",
     "zaporylie/composer-drupal-optimizations": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "3170503 - Core requirement error during Functional test": "https://www.drupal.org/files/issues/2020-09-11/3170503-2.patch"
       },
       "drupal/webform": {
-        "3173864 - Website Error after update to latest 6 alpha release / tippyjs/6.x": ",https://www.drupal.org/files/issues/2020-09-29/3173864-10.patch"
+        "3173864 - Website Error after update to latest 6 alpha release / tippyjs/6.x": "https://www.drupal.org/files/issues/2020-09-29/3173864-10.patch"
       }
     },
     "preserve-paths": [],

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,4 +1,8 @@
 # Development for the custom ecms_profile
+
+Before starting development, ensure that you have composer installed globally
+on your system. [Instructions can be found here](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-macos).
+ 
 Development of the ecms_profile can be started by cloning this repository and
 running the following script:
 ```bash
@@ -15,6 +19,25 @@ repository directory like this:
 - ecms_profile/
 - develop-ecms-profile/
 ```
+
+## Pattern Lab & Profile Development
+If you are developing with Pattern Lab and the Ecms Profile, you can develop
+both simultaneously by cloning the `ecms_patternlab` repository to a directory
+on the same level as the `ecms_profile` repository. Then, run your `develop.sh`
+script. The develop.sh script will detect the `ecms_patternlab` directory as a
+git repository and will symlink the directory in the lando environment.
+
+The directory structure should look like this:
+```
+- ecms_patternlab/
+- ecms_profile/
+- develop-ecms-profile/
+```
+
+If you do not have the `ecms_patternlab` repository cloned locally, the 
+develop.sh script will download the repository as a dependency 
+and place it in the `ecms_profile/ecms_base/themes/custom/ecms/ecms_patternlab`
+directory. 
 
 ## Adding dependencies
 This is the installation profile and does not contain Lando, therefore, you 


### PR DESCRIPTION
## Summary
This updates the develop script to symlink the `ecms_patternlab` git repository if one exists on the same directory hierarchy as the `ecms_profile` directory. This will allow for simultaneous development of both the theme and the patterns within the Drupal environment.

In order to get this working, I needed to remove the dependency on the pattern lab repository to allow local requirements. We will need to update the `ecms_distribution` to require the pattern lab repository before the next deployment.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-37](https://thinkoomph.jira.com/browse/rig-37)