### PR TITLE
Install components and connect pattern lab assets to theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-22: Added the ecms_workflow module to automatically assign content types to default workflow and set permissions.
 - RIG-61: Added the base class to authenticate and syndicate entities with Json API.
 - RIG-51: Added the ecms_projects content type as a feature.
+- RIG-37: Added components module to the standard installation profile.
+- RIG-37: Added ecms.libraries.yml file and included a global styling library.
 
 ### Changed
 - RIG-23: Changed from OIDC generic to Windows AAD for authentication.

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
     "drupal/address": "^1.8",
     "drupal/admin_toolbar": "^2.3",
     "drupal/auto_entitylabel": "^3.0@beta",
+    "drupal/components": "^2.0",
     "drupal/content_moderation_notifications": "^3.2",
     "drupal/core-recommended": "^9",
     "drupal/features": "^3.11",

--- a/docs/development.md
+++ b/docs/development.md
@@ -104,13 +104,23 @@ as the distro is symlinked.
 When making changes to the "ecms_profile" repository in a feature branch, you may
 have to update the composer.json package version in the "develop-ecms-profile" to
 point to your feature branch.
+
 ```json
 "require": {
-        "rhodeislandecms/ecms_profile": "dev-feature-branch-name",
+        "rhodeislandecms/ecms_profile": "dev-[feature-branch-name]",
     },
 ```
+
 This will be the case if you update any requirements, such as a new module. Composer
 won't be aware of the changes unless it's looking at the updated dependencies.
+
+Example: A feature branch named `RIG-37/pattern-lab-integration`
+
+```json
+"require": {
+        "rhodeislandecms/ecms_profile": "dev-RIG-37/pattern-lab-integration",
+    },
+```
 
 #### Steps to update local environment
  * Pull down ecms_profile master branch, ensure your feature branch is rebased.

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -13,6 +13,7 @@ dependencies:
   - breakpoint
   - ckeditor
   - color
+  - components
   - config
   - content_moderation
   - content_moderation_notifications

--- a/ecms_base/themes/custom/ecms/ecms.info.yml
+++ b/ecms_base/themes/custom/ecms/ecms.info.yml
@@ -6,6 +6,10 @@ base theme: bartik
 
 version: 1.x
 
+# Libraries
+libraries:
+  - ecms/global-styling
+
 regions:
   header: Header
   primary_menu: 'Primary menu'

--- a/ecms_base/themes/custom/ecms/ecms.info.yml
+++ b/ecms_base/themes/custom/ecms/ecms.info.yml
@@ -26,3 +26,21 @@ regions:
   footer_third: 'Footer third'
   footer_fourth: 'Footer fourth'
   footer_fifth: 'Footer fifth'
+
+component-libraries:
+  atoms:
+    paths:
+      - ecms_patternlab/source/_patterns/00-atoms
+  molecules:
+    paths:
+      - ecms_patternlab/source/_patterns/01-molecules
+  organisms:
+    paths:
+      - ecms_patternlab/source/_patterns/02-organisms
+  templates:
+    paths:
+      - ecms_patternlab/source/_patterns/03-templates
+  pages:
+    paths:
+      - ecms_patternlab/source/_patterns/04-pages
+

--- a/ecms_base/themes/custom/ecms/ecms.libraries.yml
+++ b/ecms_base/themes/custom/ecms/ecms.libraries.yml
@@ -1,0 +1,10 @@
+global-styling:
+  version: 1
+  css:
+    theme:
+      ecms_patternlab/dist/css/pattern-lab-compiled.css: {}
+  js:
+    ecms_patternlab/dist/js/pattern-lab-compiled-min.js: {}
+  dependencies:
+    - core/drupal
+    - core/jquery


### PR DESCRIPTION
## Summary
This PR adds the components module to the default install. The components module is required to integrate Pattern Lab with Drupal. Some additional changes are included that connect the Drupal theme to the ECMS pattern lab repository. 

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIG-37