### PR TITLE
Add functionality to post content to recipient sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-58: Added the automated site registration to the hub.
 - RIG-49: Added the hotel content type as a feature.
 - RIG-45: Added Executive Order content type as optional feature.
+- RIG-72: Added the queue and publish service to syndicate content to other sites.
 
 ### Changed
 - RIG-23: Changed from OIDC generic to Windows AAD for authentication.

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * ecms_base.install
+ */
+
 declare(strict_types = 1);
 
 /**

--- a/ecms_base/modules/custom/ecms_api/ecms_api.install
+++ b/ecms_base/modules/custom/ecms_api/ecms_api.install
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * ecms_api.install
+ */
+
 declare(strict_types = 1);
 
 /**

--- a/ecms_base/modules/custom/ecms_api_publisher/README.md
+++ b/ecms_base/modules/custom/ecms_api_publisher/README.md
@@ -32,6 +32,14 @@ $config['ecms_api_publisher.settings']['oauth_client_secret'] = 'SECURE-CLIENT-S
 $config['ecms_api_publisher.settings']['api_recipient_mail'] = 'automateduser@email.com';
 ```
 
+Additionally, the publisher module requires the following configuration values
+to connect to all sites that requested content to be syndicated
+
+```php
+$config['ecms_api_publisher.settings']['recipient_client_id'] = 'SECURE-CLIENT-ID';
+$config['ecms_api_publisher.settings']['recipient_client_secret'] = 'SECURE-CLIENT-SECRET';
+```
+
 #### oauth_client_id
 
 The OAuth client id is the UUID for the consumer entity and should follow normal
@@ -46,3 +54,14 @@ is treated as a password with plenty of length and randomness.
 The Client ID and the Client Secret above will be passed to oauth/token route
 by the registering site to gain an access token with which to 
 create an `ecms_api_site` entity.
+
+#### recipient_client_id
+This is the oauth client id that is used to connect to sites in order to post
+nodes to them.
+
+#### recipient_client_secret
+This is the oauth client secret to connect to the recipient sites to post 
+content with the json api.
+
+#### recipient_client_scope
+This is the scope to provide to the recipient site during json api requests.

--- a/ecms_base/modules/custom/ecms_api_publisher/config/install/ecms_api_publisher.settings.yml
+++ b/ecms_base/modules/custom/ecms_api_publisher/config/install/ecms_api_publisher.settings.yml
@@ -1,3 +1,6 @@
 oauth_client_id: 'REDACTED'
 oauth_client_secret: 'REDACTED'
 api_publisher_mail: 'ecms_api_publisher@ecms.com'
+recipient_client_id: 'REDACTED'
+recipient_client_secret: 'REDACTED'
+recipient_client_scope: 'ecms_api_recipient'

--- a/ecms_base/modules/custom/ecms_api_publisher/config/schema/ecms_api_publisher.schema.yml
+++ b/ecms_base/modules/custom/ecms_api_publisher/config/schema/ecms_api_publisher.schema.yml
@@ -10,3 +10,12 @@ ecms_api_publisher.settings:
     api_publisher_mail:
       type: string
       label: 'Publisher user email address'
+    recipient_client_id:
+      type: string
+      label: 'OAuth Client ID for the recipient site'
+    recipient_client_secret:
+      type: string
+      label: 'OAuth Client secret for the recipient site'
+    recipient_client_scope:
+      type: string
+      label: 'OAuth scope for the recipient site'

--- a/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.install
+++ b/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.install
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * ecms_api_publisher.install
+ */
+
 declare(strict_types = 1);
 
 /**

--- a/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.module
+++ b/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.module
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Implements hook_ENTITY_TYPE_insert() for the node entity.
+ */
+function ecms_api_publisher_node_insert(EntityInterface $entity) {
+  // Call the syndication service on node insert.
+  \Drupal::service('ecms_api_publisher.syndicate')->syndicateNode($entity, 'INSERT');
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update() for the node entity.
+ */
+function hook_node_update(EntityInterface $entity): void {
+  // Call the syndication service on node update.
+  \Drupal::service('ecms_api_publisher.syndicate')->syndicateNode($entity, 'UPDATE');
+}

--- a/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.module
+++ b/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.module
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * ecms_api_publisher.module
+ */
+
 declare(strict_types = 1);
 
 use Drupal\Core\Entity\EntityInterface;

--- a/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.permissions.yml
+++ b/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.permissions.yml
@@ -20,3 +20,6 @@ view own published ecms api site entities:
 
 view unpublished ecms api site entities:
   title: 'View unpublished ecms api site entities'
+
+manually clear ecms api publishing queue:
+  title: 'Manually clear the Ecms API queue'

--- a/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.routing.yml
+++ b/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.routing.yml
@@ -1,0 +1,7 @@
+ecms_api_publisher.batch_send_form:
+  path: '/ecms_api/syndicate/manual-process'
+  defaults:
+    _form: '\Drupal\ecms_api_publisher\Form\EcmsApiBatchSendUpdatesForm'
+    _title: 'Manually push content'
+  requirements:
+    _permission: 'manually clear ecms api publishing queue'

--- a/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.services.yml
+++ b/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.services.yml
@@ -3,6 +3,10 @@ services:
     class: Drupal\ecms_api_publisher\EcmsApiPublisherInstall
     arguments: ['@entity_type.manager', '@config.factory']
 
+  ecms_api_publisher.publisher:
+    class: Drupal\ecms_api_publisher\EcmsApiPublisher
+    arguments: ['@http_client', '@jsonapi_extras.entity.to_jsonapi']
+
   ecms_api_publisher.syndicate:
     class: Drupal\ecms_api_publisher\EcmsApiSyndicate
     arguments: ['@entity_type.manager', '@queue', '@messenger']

--- a/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.services.yml
+++ b/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.services.yml
@@ -5,7 +5,7 @@ services:
 
   ecms_api_publisher.publisher:
     class: Drupal\ecms_api_publisher\EcmsApiPublisher
-    arguments: ['@http_client', '@jsonapi_extras.entity.to_jsonapi']
+    arguments: ['@http_client', '@jsonapi_extras.entity.to_jsonapi', '@config.factory']
 
   ecms_api_publisher.syndicate:
     class: Drupal\ecms_api_publisher\EcmsApiSyndicate

--- a/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.services.yml
+++ b/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.services.yml
@@ -2,3 +2,7 @@ services:
   ecms_api_publisher.install:
     class: Drupal\ecms_api_publisher\EcmsApiPublisherInstall
     arguments: ['@entity_type.manager', '@config.factory']
+
+  ecms_api_publisher.syndicate:
+    class: Drupal\ecms_api_publisher\EcmsApiSyndicate
+    arguments: ['@entity_type.manager', '@queue', '@messenger']

--- a/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiPublisher.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiPublisher.php
@@ -81,8 +81,7 @@ class EcmsApiPublisher extends EcmsApiBase {
    *   The client id for the recipient site.
    */
   private function getClientId(): string {
-    // @todo: Load this from configuration.
-    return 'REDACTED';
+    return $this->configFactory->get('ecms_api_publisher.settings')->get('recipient_client_id');
   }
 
   /**
@@ -92,8 +91,7 @@ class EcmsApiPublisher extends EcmsApiBase {
    *   The client secret for the recipient site.
    */
   private function getClientSecret(): string {
-    // @todo: Load this from configuration.
-    return 'REDACTED';
+    return $this->configFactory->get('ecms_api_publisher.settings')->get('recipient_client_secret');
   }
 
   /**
@@ -103,8 +101,7 @@ class EcmsApiPublisher extends EcmsApiBase {
    *   The client scope for the recipient site.
    */
   private function getClientScope(): string {
-    // @todo: Load this from configuration.
-    return 'REDACTED';
+    return $this->configFactory->get('ecms_api_publisher.settings')->get('recipient_client_scope');
   }
 
 }

--- a/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiPublisher.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiPublisher.php
@@ -69,9 +69,7 @@ class EcmsApiPublisher extends EcmsApiBase {
     }
 
     // Submit the entity to the API.
-    $result = $this->submitEntity($method, $accessToken, $recipientUrl, $node);
-
-    return $result;
+    return $this->submitEntity($method, $accessToken, $recipientUrl, $node);
   }
 
   /**

--- a/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiPublisher.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiPublisher.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\ecms_api_publisher;
+
+use Drupal\Core\Url;
+use Drupal\ecms_api\EcmsApiBase;
+use Drupal\jsonapi_extras\EntityToJsonApi;
+use Drupal\node\NodeInterface;
+use GuzzleHttp\ClientInterface;
+
+class EcmsApiPublisher extends EcmsApiBase {
+
+  public function __construct(ClientInterface $httpClient, EntityToJsonApi $entityToJsonApi) {
+    parent::__construct($httpClient, $entityToJsonApi);
+  }
+
+  public function syndicateNode(string $method, Url $recipientUrl, NodeInterface $node): bool {
+
+    $clientId = $this->getClientId();
+    $clientSecret = $this->getClientSecret();
+    $clientScope = $this->getClientScope();
+
+    // Get the access token to create this node.
+    $accessToken = $this->getAccessToken($recipientUrl, $clientId, $clientSecret, $clientScope);
+
+    // Guard against a null access token.
+    if (empty($accessToken)) {
+      return FALSE;
+    }
+
+    // Submit the entity to the API.
+    $result = $this->submitEntity($method, $accessToken, $recipientUrl, $node);
+
+    return $result;
+  }
+
+  /**
+   * Get the client id from configuration.
+   *
+   * @return string
+   *   The client id for the recipient site.
+   */
+  private function getClientId(): string {
+    // @todo: Load this from configuration.
+    return 'REDACTED';
+  }
+
+  /**
+   * Get the client secret from configuration.
+   *
+   * @return string
+   *   The client secret for the recipient site.
+   */
+  private function getClientSecret(): string {
+    // @todo: Load this from configuration.
+    return 'REDACTED';
+  }
+
+  /**
+   * @return string
+   *   The client scope for the recipient site.
+   */
+  private function getClientScope(): string {
+    // @todo: Load this from configuration.
+    return 'REDACTED';
+  }
+
+  // @todo: submit the node to the site.
+
+}

--- a/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiPublisher.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiPublisher.php
@@ -4,18 +4,56 @@ declare(strict_types = 1);
 
 namespace Drupal\ecms_api_publisher;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Url;
 use Drupal\ecms_api\EcmsApiBase;
 use Drupal\jsonapi_extras\EntityToJsonApi;
 use Drupal\node\NodeInterface;
 use GuzzleHttp\ClientInterface;
 
+/**
+ * Class EcmsApiPublisher.
+ *
+ * @package Drupal\ecms_api_publisher
+ */
 class EcmsApiPublisher extends EcmsApiBase {
 
-  public function __construct(ClientInterface $httpClient, EntityToJsonApi $entityToJsonApi) {
+  /**
+   * The config.factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  private $configFactory;
+
+  /**
+   * EcmsApiPublisher constructor.
+   *
+   * @param \GuzzleHttp\ClientInterface $httpClient
+   *   The http_client service.
+   * @param \Drupal\jsonapi_extras\EntityToJsonApi $entityToJsonApi
+   *   The jsonapi_extras.entity.to_jsonapi service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config.factory service.
+   */
+  public function __construct(ClientInterface $httpClient, EntityToJsonApi $entityToJsonApi, ConfigFactoryInterface $configFactory) {
     parent::__construct($httpClient, $entityToJsonApi);
+
+    $this->configFactory = $configFactory;
   }
 
+  /**
+   * Queue a node for syndication.
+   *
+   * @param string $method
+   *   The HTTP method to use for the syndication. POST or PATCH.
+   * @param \Drupal\Core\Url $recipientUrl
+   *   The URL of the API receiving the node.
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to submit.
+   *
+   * @return bool
+   *   True if successfully saved.
+   */
   public function syndicateNode(string $method, Url $recipientUrl, NodeInterface $node): bool {
 
     $clientId = $this->getClientId();
@@ -59,6 +97,8 @@ class EcmsApiPublisher extends EcmsApiBase {
   }
 
   /**
+   * Get the client scope from configuration.
+   *
    * @return string
    *   The client scope for the recipient site.
    */
@@ -66,7 +106,5 @@ class EcmsApiPublisher extends EcmsApiBase {
     // @todo: Load this from configuration.
     return 'REDACTED';
   }
-
-  // @todo: submit the node to the site.
 
 }

--- a/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSyndicate.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSyndicate.php
@@ -24,6 +24,11 @@ class EcmsApiSyndicate {
    */
   const SYNDICATE_QUEUE = 'ecms_api_publisher_queue';
 
+  const ALLOWED_METHODS = [
+    'INSERT' => 'POST',
+    'UPDATE' => 'PATCH',
+  ];
+
   /**
    * The entity_type.manager service.
    *
@@ -70,7 +75,10 @@ class EcmsApiSyndicate {
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function syndicateNode(NodeInterface $entity): void {
+  public function syndicateNode(NodeInterface $entity, string $method): void {
+    if (!array_key_exists($method, self::ALLOWED_METHODS)) {
+      return;
+    }
     // @todo: Ensure the node is published.
     // @see: https://www.sitepoint.com/drupal-8-queue-api-powerful-manual-and-cron-queueing/
     $type = $entity->bundle();
@@ -88,6 +96,7 @@ class EcmsApiSyndicate {
       $queueData = [
         'site_entity' => $site,
         'syndicated_content_entity' => $entity,
+        'method' => self::ALLOWED_METHODS[$method],
       ];
 
       // Push a new item onto the queue.

--- a/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSyndicate.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSyndicate.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 
 /**
@@ -116,9 +117,8 @@ class EcmsApiSyndicate {
     ]));
 
     // Add a message on how to manually push the content to all sites.
-    // @todo: Get the correct form link for @href.
-    $this->messenger->addWarning($this->t('If you need this content posted immediately please <a href="@href">follow this link to manually clear the queue</a>.', [
-      '@href' => '/',
+    $this->messenger->addWarning($this->t('If you need this content posted immediately please <a href=":form">follow this link to manually clear the queue</a>.', [
+      ':form' => Url::fromRoute('ecms_api_publisher.batch_send_form')->toString(),
     ]));
     // @todo: Write the form to batch the queued items if any exist.
   }

--- a/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSyndicate.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSyndicate.php
@@ -12,7 +12,7 @@ use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 
 /**
- * Class EcmsApiPublisher.
+ * Class EcmsApiSyndicate.
  *
  * @package Drupal\ecms_api_publisher
  */

--- a/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSyndicate.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSyndicate.php
@@ -24,6 +24,9 @@ class EcmsApiSyndicate {
    */
   const SYNDICATE_QUEUE = 'ecms_api_publisher_queue';
 
+  /**
+   * Translate node method to json method.
+   */
   const ALLOWED_METHODS = [
     'INSERT' => 'POST',
     'UPDATE' => 'PATCH',
@@ -71,6 +74,8 @@ class EcmsApiSyndicate {
    *
    * @param \Drupal\node\NodeInterface $entity
    *   The node that should be syndicated to other sites.
+   * @param string $method
+   *   The method that was provided. Insert or update.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
@@ -115,7 +120,6 @@ class EcmsApiSyndicate {
     $this->messenger->addWarning($this->t('If you need this content posted immediately please <a href="@href">follow this link to manually clear the queue</a>.', [
       '@href' => '/',
     ]));
-    // @todo: Write the cron queue processor.
     // @todo: Write the form to batch the queued items if any exist.
   }
 

--- a/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSyndicate.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSyndicate.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\ecms_api_publisher;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\node\NodeInterface;
+
+/**
+ * Class EcmsApiPublisher.
+ *
+ * @package Drupal\ecms_api_publisher
+ */
+class EcmsApiSyndicate {
+
+  use StringTranslationTrait;
+
+  /**
+   * The publisher queue name.
+   */
+  const SYNDICATE_QUEUE = 'ecms_api_publisher_queue';
+
+  /**
+   * The entity_type.manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private $entityTypeManager;
+
+  /**
+   * The queue interface for the syndicate queue.
+   *
+   * @var \Drupal\Core\Queue\QueueInterface
+   */
+  private $queue;
+
+  /**
+   * The Messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * EcmsApiSyndicate constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity_type.manager service.
+   * @param \Drupal\Core\Queue\QueueFactory $queueFactory
+   *   The queue service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, QueueFactory $queueFactory, MessengerInterface $messenger) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->queue = $queueFactory->get(self::SYNDICATE_QUEUE);
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * Syndicate the entity to all registered sites.
+   *
+   * @param \Drupal\node\NodeInterface $entity
+   *   The node that should be syndicated to other sites.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function syndicateNode(NodeInterface $entity): void {
+    // @todo: Ensure the node is published.
+    // @see: https://www.sitepoint.com/drupal-8-queue-api-powerful-manual-and-cron-queueing/
+    $type = $entity->bundle();
+
+    // Get a list of all ecms_api_site entities that are of the bundle.
+    $sites = $this->getApiSites($type);
+
+    // Ensure we have entities to work with.
+    if (empty($sites)) {
+      return;
+    }
+
+    // Loop through the site entities and add them to a queue.
+    foreach ($sites as $site) {
+      $queueData = [
+        'site_entity' => $site,
+        'syndicated_content_entity' => $entity,
+      ];
+
+      // Push a new item onto the queue.
+      $this->queue->createItem($queueData);
+    }
+
+    // Notify the user that the node will be posted on the next cron run.
+    $this->messenger->addMessage($this->t('Successfully queued the @type "%title" to get posted to @number sites on the next cron run.', [
+      '@type' => $type,
+      '%title' => $entity->getTitle(),
+      '@number' => count($sites),
+    ]));
+
+    // Add a message on how to manually push the content to all sites.
+    // @todo: Get the correct form link for @href.
+    $this->messenger->addWarning($this->t('If you need this content posted immediately please <a href="@href">follow this link to manually clear the queue</a>.', [
+      '@href' => '/',
+    ]));
+    // @todo: Write the cron queue processor.
+    // @todo: Write the form to batch the queued items if any exist.
+  }
+
+  /**
+   * Get the API site entities that want to receive this notification.
+   *
+   * @param string $bundle
+   *   The bundle to filter the ecms_api_site entities with.
+   *
+   * @return array
+   *   The entities that would like to receive the content of $bundle type.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  private function getApiSites(string $bundle): array {
+    $storage = $this->entityTypeManager->getStorage('ecms_api_site');
+
+    $sites = $storage->loadByProperties(['content_type' => $bundle]);
+
+    // Return the ecms_api_sites.
+    return $sites;
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSyndicate.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSyndicate.php
@@ -120,7 +120,6 @@ class EcmsApiSyndicate {
     $this->messenger->addWarning($this->t('If you need this content posted immediately please <a href=":form">follow this link to manually clear the queue</a>.', [
       ':form' => Url::fromRoute('ecms_api_publisher.batch_send_form')->toString(),
     ]));
-    // @todo: Write the form to batch the queued items if any exist.
   }
 
   /**

--- a/ecms_base/modules/custom/ecms_api_publisher/src/Form/EcmsApiBatchSendUpdatesForm.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/Form/EcmsApiBatchSendUpdatesForm.php
@@ -204,10 +204,10 @@ class EcmsApiBatchSendUpdatesForm extends ConfirmFormBase {
       foreach ($operations as $error) {
         if (!empty($error[1])) {
           /** @var \Drupal\ecms_api_publisher\Entity\EcmsApiSiteInterface $site */
-          $ecmsApiSite = $error[1][0];
+          $ecmsApiSite = array_shift($error[1]);
           /** @var \Drupal\node\NodeInterface $node */
-          $node = $error[1][1];
-          $method = $error[1][2];
+          $node = array_shift($error[1]);
+          $method = array_shift($error[1]);
 
           // Rebuild the queue item for requeue.
           $data = [

--- a/ecms_base/modules/custom/ecms_api_publisher/src/Plugin/QueueWorker/EcmsApiSyndicateQueueWorker.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/Plugin/QueueWorker/EcmsApiSyndicateQueueWorker.php
@@ -32,7 +32,7 @@ class EcmsApiSyndicateQueueWorker extends QueueWorkerBase implements ContainerFa
   private $ecmsApiPublisher;
 
   /**
-   * @inheritDoc
+   * {@inheritDoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(
@@ -47,11 +47,11 @@ class EcmsApiSyndicateQueueWorker extends QueueWorkerBase implements ContainerFa
    * EcmsApiSyndicateQueueWorker constructor.
    *
    * @param array $configuration
-   *   The configuration of the plugin.
-   * @param $plugin_id
-   *   The plugin id.
-   * @param $plugin_definition
-   *   The plugin definition.
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
    * @param \Drupal\ecms_api_publisher\EcmsApiPublisher $ecmsApiPublisher
    *   The ecms_api_publisher.publisher service.
    */
@@ -62,7 +62,7 @@ class EcmsApiSyndicateQueueWorker extends QueueWorkerBase implements ContainerFa
   }
 
   /**
-   * @inheritDoc
+   * {@inheritDoc}
    */
   public function processItem($data) {
     /** @var \Drupal\ecms_api_publisher\Entity\EcmsApiSiteInterface $ecmsApiSiteEntity */

--- a/ecms_base/modules/custom/ecms_api_publisher/src/Plugin/QueueWorker/EcmsApiSyndicateQueueWorker.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/Plugin/QueueWorker/EcmsApiSyndicateQueueWorker.php
@@ -55,7 +55,7 @@ class EcmsApiSyndicateQueueWorker extends QueueWorkerBase implements ContainerFa
    * @param \Drupal\ecms_api_publisher\EcmsApiPublisher $ecmsApiPublisher
    *   The ecms_api_publisher.publisher service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EcmsApiPublisher $ecmsApiPublisher) {
+  public function __construct(array $configuration, string $plugin_id, $plugin_definition, EcmsApiPublisher $ecmsApiPublisher) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->ecmsApiPublisher = $ecmsApiPublisher;

--- a/ecms_base/modules/custom/ecms_api_publisher/src/Plugin/QueueWorker/EcmsApiSyndicateQueueWorker.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/Plugin/QueueWorker/EcmsApiSyndicateQueueWorker.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\ecms_api_publisher\Plugin\QueueWorker;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\Core\Queue\RequeueException;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\ecms_api_publisher\EcmsApiPublisher;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Post syndicated content on cron..
+ *
+ * @QueueWorker(
+ *   id = "ecms_api_publisher_queue",
+ *   title = @Translation("Ecms API Cron Publisher"),
+ *   cron = {"time" = 5}
+ * )
+ */
+class EcmsApiSyndicateQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The ecms_api_publisher.publisher service.
+   *
+   * @var \Drupal\ecms_api_publisher\EcmsApiPublisher
+   */
+  private $ecmsApiPublisher;
+
+  /**
+   * @inheritDoc
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('ecms_api_publisher.publisher')
+    );
+  }
+
+  /**
+   * EcmsApiSyndicateQueueWorker constructor.
+   *
+   * @param array $configuration
+   *   The configuration of the plugin.
+   * @param $plugin_id
+   *   The plugin id.
+   * @param $plugin_definition
+   *   The plugin definition.
+   * @param \Drupal\ecms_api_publisher\EcmsApiPublisher $ecmsApiPublisher
+   *   The ecms_api_publisher.publisher service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EcmsApiPublisher $ecmsApiPublisher) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->ecmsApiPublisher = $ecmsApiPublisher;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function processItem($data) {
+    /** @var \Drupal\ecms_api_publisher\Entity\EcmsApiSiteInterface $ecmsApiSiteEntity */
+    $ecmsApiSiteEntity = $data['site_entity'];
+    $apiUrl = $ecmsApiSiteEntity->getApiEndpoint()->getUrl();
+
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $data['syndicated_content_entity'];
+    $method = $data['method'];
+
+    $result = $this->ecmsApiPublisher->syndicateNode($method, $apiUrl, $node);
+
+    // If the submission was not successful, requeue the task.
+    if (!$result) {
+      $message = $this->t('An error occurred accessing the API endpoint here: @endpoint', [
+        '@endpoint' => $apiUrl->toUriString(),
+      ]);
+
+      throw new RequeueException($message->render());
+    }
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_api_publisher/src/Plugin/QueueWorker/EcmsApiSyndicateQueueWorker.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/Plugin/QueueWorker/EcmsApiSyndicateQueueWorker.php
@@ -62,9 +62,15 @@ class EcmsApiSyndicateQueueWorker extends QueueWorkerBase implements ContainerFa
   }
 
   /**
-   * {@inheritDoc}
+   * Process an item in the queue.
+   *
+   * @param mixed $data
+   *   Data should be an array with the following keys:
+   *   - site_entity: \Drupal\ecms_api_publisher\Entity\EcmsApiSiteInterface
+   *   - syndicated_content_entity: \Drupal\node\NodeInterface
+   *   - method: string.
    */
-  public function processItem($data) {
+  public function processItem($data): void {
     /** @var \Drupal\ecms_api_publisher\Entity\EcmsApiSiteInterface $ecmsApiSiteEntity */
     $ecmsApiSiteEntity = $data['site_entity'];
     $apiUrl = $ecmsApiSiteEntity->getApiEndpoint()->getUrl();

--- a/ecms_base/modules/custom/ecms_api_publisher/src/Plugin/QueueWorker/EcmsApiSyndicateQueueWorker.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/Plugin/QueueWorker/EcmsApiSyndicateQueueWorker.php
@@ -12,7 +12,7 @@ use Drupal\ecms_api_publisher\EcmsApiPublisher;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Post syndicated content on cron..
+ * Post syndicated content on cron.
  *
  * @QueueWorker(
  *   id = "ecms_api_publisher_queue",

--- a/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/EcmsApiPublisherTest.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/EcmsApiPublisherTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\ecms_api_publisher\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Url;
+use Drupal\ecms_api_publisher\EcmsApiPublisher;
+use Drupal\jsonapi_extras\EntityToJsonApi;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\ClientInterface;
+
+/**
+ * Class EcmsApiPublisherTest.
+ *
+ * @covers \Drupal\ecms_api_publisher\EcmsApiPublisher
+ * @group ecms
+ * @group ecms_api
+ * @group ecms_api_publisher
+ * @package Drupal\Tests\ecms_api_publisher\Unit
+ */
+class EcmsApiPublisherTest extends UnitTestCase {
+
+  /**
+   * The test client id.
+   */
+  const CLIENT_ID = 'TEST-CLIENT-ID';
+
+  /**
+   * The test client secret.
+   */
+  const CLIENT_SECRET = 'TEST-CLIENT-SECRET';
+
+  /**
+   * The test client scope.
+   */
+  const CLIENT_SCOPE = 'test_client_scope';
+
+  /**
+   * Mock of the config.factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $configFactory;
+
+  /**
+   * Mock of the EcmsApiPublisher class to test.
+   *
+   * @var \Drupal\ecms_api_publisher\EcmsApiPublisher|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $ecmsApiPublisher;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $immutableConfig = $this->createMock(ImmutableConfig::class);
+    $immutableConfig->expects($this->exactly(3))
+      ->method('get')
+      ->withConsecutive(
+        ['recipient_client_id'],
+        ['recipient_client_secret'],
+        ['recipient_client_scope']
+      )
+      ->willReturnOnConsecutiveCalls(self::CLIENT_ID, self::CLIENT_SECRET, self::CLIENT_SCOPE);
+    $this->configFactory = $this->createMock(ConfigFactoryInterface::class);
+
+    $this->configFactory->expects($this->exactly(3))
+      ->method('get')
+      ->with('ecms_api_publisher.settings')
+      ->willReturn($immutableConfig);
+
+    $httpClient = $this->createMock(ClientInterface::class);
+    $entityToJsonApi = $this->createMock(EntityToJsonApi::class);
+
+    $this->ecmsApiPublisher = $this->getMockBuilder(EcmsApiPublisher::class)
+      ->onlyMethods(['getAccessToken', 'submitEntity'])
+      ->setConstructorArgs([$httpClient, $entityToJsonApi, $this->configFactory])
+      ->getMock();
+  }
+
+  /**
+   * Test the syndicateNode method.
+   *
+   * @param string|null $accessToken
+   *   The accessToken to return.
+   * @param bool $expected
+   *   The expected result.
+   *
+   * @dataProvider dataProviderForTestSyndicateNode
+   */
+  public function testSyndicateNode(?string $accessToken, bool $expected): void {
+    $method = 'INSERT';
+    $url = $this->createMock(Url::class);
+    $node = $this->createMock(NodeInterface::class);
+
+    $this->ecmsApiPublisher->expects($this->once())
+      ->method('getAccessToken')
+      ->with($url, self::CLIENT_ID, self::CLIENT_SECRET, self::CLIENT_SCOPE)
+      ->willReturn($accessToken);
+
+    if (!empty($accessToken)) {
+      $this->ecmsApiPublisher->expects($this->once())
+        ->method('submitEntity')
+        ->with($method, $accessToken, $url, $node)
+        ->willReturn($expected);
+    }
+
+    $result = $this->ecmsApiPublisher->syndicateNode($method, $url, $node);
+
+    $this->assertEquals($expected, $result);
+  }
+
+  /**
+   * Data provider for the testSyndicateNode method.
+   *
+   * @return array[]
+   *   Parameters to pass to testSyndicateNode.
+   */
+  public function dataProviderForTestSyndicateNode(): array {
+    return [
+      'test1' => [NULL, FALSE],
+      'test2' => ['123456', FALSE],
+      'test3' => ['987654', TRUE],
+    ];
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/EcmsApiSyndicateTest.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/EcmsApiSyndicateTest.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Queue\QueueInterface;
+use Drupal\Core\Routing\UrlGeneratorInterface;
 use Drupal\ecms_api_publisher\EcmsApiSyndicate;
 use Drupal\ecms_api_publisher\Entity\EcmsApiSiteInterface;
 use Drupal\node\NodeInterface;
@@ -97,6 +98,7 @@ class EcmsApiSyndicateTest extends UnitTestCase {
 
     $container = new ContainerBuilder();
     $container->set('string_translation', $this->getStringTranslationStub());
+    $container->set('url_generator', $this->createMock(UrlGeneratorInterface::class));
 
     \Drupal::setContainer($container);
   }

--- a/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/EcmsApiSyndicateTest.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/EcmsApiSyndicateTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\ecms_api_publisher\Unit;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\QueueInterface;
+use Drupal\ecms_api_publisher\EcmsApiSyndicate;
+use Drupal\ecms_api_publisher\Entity\EcmsApiSiteInterface;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Class EcmsApiSyndicateTest.
+ *
+ * @package Drupal\Tests\ecms_api_publisher\Unit
+ * @covers \Drupal\ecms_api_publisher\EcmsApiSyndicate
+ * @group ecms
+ * @group ecms_api
+ * @group ecms_api_publisher
+ */
+class EcmsApiSyndicateTest extends UnitTestCase {
+
+  /**
+   * The queue name to test with.
+   */
+  const SYNDICATE_QUEUE = 'ecms_api_publisher_queue';
+
+  /**
+   * The bundle to test with.
+   */
+  const NODE_TYPE = 'test_node_type';
+
+  /**
+   * Mock of the entity_type.manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $entityTypeManager;
+
+  /**
+   * Mock of the queue interface.
+   *
+   * @var \Drupal\Core\Queue\QueueInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $queue;
+
+  /**
+   * Mock of the messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $messenger;
+
+  /**
+   * Array of EcmsApiInterface items.
+   *
+   * @var array
+   */
+  private $ecmsApiSites;
+
+  /**
+   * Mock of the queue service.
+   *
+   * @var \Drupal\Core\Queue\QueueFactory|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $queueFactory;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $this->queue = $this->createMock(QueueInterface::class);
+    $this->queueFactory = $this->createMock(QueueFactory::class);
+    $this->queueFactory->expects($this->once())
+      ->method('get')
+      ->with(self::SYNDICATE_QUEUE)
+      ->willReturn($this->queue);
+
+    $this->ecmsApiSites = [
+      $this->createMock(EcmsApiSiteInterface::class),
+      $this->createMock(EcmsApiSiteInterface::class),
+    ];
+    $this->messenger = $this->createMock(MessengerInterface::class);
+
+    $container = new ContainerBuilder();
+    $container->set('string_translation', $this->getStringTranslationStub());
+
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Test the syndicateNode method.
+   */
+  public function testSyndicateNodeSuccess(): void {
+    $entity = $this->createMock(NodeInterface::class);
+
+    $entity->expects($this->once())
+      ->method('bundle')
+      ->willReturn(self::NODE_TYPE);
+
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $storage->expects($this->once())
+      ->method('loadByProperties')
+      ->with(['content_type' => self::NODE_TYPE])
+      ->willReturn($this->ecmsApiSites);
+
+    $this->queue->expects($this->exactly(count($this->ecmsApiSites)))
+      ->method('createItem');
+
+    $this->entityTypeManager->expects($this->once())
+      ->method('getStorage')
+      ->with('ecms_api_site')
+      ->willReturn($storage);
+
+    $this->messenger->expects($this->once())
+      ->method('addMessage');
+
+    $this->messenger->expects($this->once())
+      ->method('addWarning');
+
+    $ecmsApiSyndicate = new EcmsApiSyndicate($this->entityTypeManager, $this->queueFactory, $this->messenger);
+    $ecmsApiSyndicate->syndicateNode($entity);
+
+  }
+
+  /**
+   * Test the syndicateNode method with no api sites available.
+   */
+  public function testSyndicateNodeNone(): void {
+    $entity = $this->createMock(NodeInterface::class);
+
+    $entity->expects($this->once())
+      ->method('bundle')
+      ->willReturn(self::NODE_TYPE);
+
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $storage->expects($this->once())
+      ->method('loadByProperties')
+      ->with(['content_type' => self::NODE_TYPE])
+      ->willReturn([]);
+
+    $this->queue->expects($this->never())
+      ->method('createItem');
+
+    $this->entityTypeManager->expects($this->once())
+      ->method('getStorage')
+      ->with('ecms_api_site')
+      ->willReturn($storage);
+
+    $this->messenger->expects($this->never())
+      ->method('addMessage');
+
+    $this->messenger->expects($this->never())
+      ->method('addWarning');
+
+    $ecmsApiSyndicate = new EcmsApiSyndicate($this->entityTypeManager, $this->queueFactory, $this->messenger);
+    $ecmsApiSyndicate->syndicateNode($entity);
+
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/Form/EcmsApiBatchSendUpdateFormTest.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/Form/EcmsApiBatchSendUpdateFormTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\ecms_api_publisher\Unit\Form;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\QueueInterface;
+use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
+use Drupal\Core\Url;
+use Drupal\ecms_api_publisher\Form\EcmsApiBatchSendUpdatesForm;
+use Drupal\Tests\UnitTestCase;
+
+class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
+
+  const SYNDICATE_QUEUE = 'ecms_api_publisher_queue';
+
+  private $queue;
+  private $batchForm;
+
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->queue = $this->createMock(QueueInterface::class);
+
+    $queueFactory = $this->createMock(QueueFactory::class);
+    $queueFactory->expects($this->once())
+      ->method('get')
+      ->with(self::SYNDICATE_QUEUE)
+      ->willReturn($this->queue);
+
+    $container = new ContainerBuilder();
+
+    $container->set('queue', $queueFactory);
+    $container->set('string_translation', $this->getStringTranslationStub());
+
+    \Drupal::setContainer($container);
+
+    $this->batchForm = EcmsApiBatchSendUpdatesForm::create($container);
+  }
+
+  /**
+   * Test the getDescription method.
+   *
+   * @param int $count
+   *   The count of items in the queue.
+   *
+   * @dataProvider dataProviderForTestGetDescription
+   */
+  public function testGetDescription(int $count): void {
+    $this->queue->expects($this->once())
+      ->method('numberOfItems')
+      ->willReturn($count);
+
+    $expected = "Are you sure you would like to manually push syndicated content to 1 site?  This action cannot be undone!";
+
+    if ($count > 1) {
+      $expected = "Are you sure you would like to manually push syndicated content to {$count} sites?  This action cannot be undone!";
+    }
+
+    // Get the actual description.
+    $result = $this->batchForm->getDescription();
+
+    $this->assertEquals($expected, $result->render());
+  }
+
+  /**
+   * Data provider for the testGetDescription method.
+   *
+   * @return array
+   *   Array of parameters to pass to the testGetDescription method.
+   */
+  public function dataProviderForTestGetDescription(): array {
+    return [
+      'test1' => [1],
+      'test2' => [5],
+      'test3' => [10],
+    ];
+  }
+
+  public function testGetQuestion(): void {
+    $expected = "Do you want to manually push all syndicated content?";
+
+    $actual = $this->batchForm->getQuestion();
+
+    $this->assertEquals($expected, $actual->render());
+  }
+
+  public function testGetFormId(): void {
+    $expected = "ecms_api_publisher_batch_send_updates";
+
+    $actual = $this->batchForm->getFormId();
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  public function testGetCancelUrl(): void {
+    $expected = Url::fromRoute('<front>');
+
+    $actual = $this->batchForm->getCancelUrl();
+
+    $this->assertEquals($expected, $actual);
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/Form/EcmsApiBatchSendUpdateFormTest.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/Form/EcmsApiBatchSendUpdateFormTest.php
@@ -19,16 +19,63 @@ use Drupal\node\NodeInterface;
 use Drupal\Tests\UnitTestCase;
 use phpmock\MockBuilder;
 
+/**
+ * Class EcmsApiBatchSendUpdateFormTest.
+ *
+ * @package Drupal\Tests\ecms_api_publisher\Unit\Form
+ *
+ * @covers \Drupal\ecms_api_publisher\Form\EcmsApiBatchSendUpdatesForm
+ * @group ecms
+ * @group ecms_api
+ * @group ecms_api_publisher
+ */
 class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
 
+  /**
+   * Name of the queue.
+   */
   const SYNDICATE_QUEUE = 'ecms_api_publisher_queue';
 
+  /**
+   * Mock the ecms_api_publisher_queue queue.
+   *
+   * @var \Drupal\Core\Queue\QueueInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
   private $queue;
+
+  /**
+   * The form to test.
+   *
+   * @var \Drupal\ecms_api_publisher\Form\EcmsApiBatchSendUpdatesForm
+   */
   private $batchForm;
+
+  /**
+   * Mock of the messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
   private $messenger;
+
+  /**
+   * Mock of the ecms_api_publisher.publisher service.
+   *
+   * @var \Drupal\ecms_api_publisher\EcmsApiPublisher|\PHPUnit\Framework\MockObject\MockObject
+   */
   private $ecmsApiPublisher;
 
+  /**
+   * Mock the global batch_set() function.
+   *
+   * @var \phpmock\Mock
+   */
   private $globalBatch;
+
+  /**
+   * Mock the global t() function.
+   *
+   * @var \phpmock\Mock
+   */
   private $mockGlobalTFunction;
 
   /**
@@ -291,7 +338,9 @@ class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
    * @param bool $success
    *   Status of the batch to test.
    * @param array $results
+   *   The expected results array.
    * @param array $operations
+   *   The expected operations array.
    *
    * @dataProvider dataProviderForFinishedMethod
    */
@@ -381,7 +430,7 @@ class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
               'apiSite',
               'node',
               $this->randomMachineName(),
-            ]
+            ],
           ],
           2 => [
             '\class\name\space',
@@ -389,8 +438,8 @@ class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
               'apiSite',
               'node',
               $this->randomMachineName(),
-            ]
-          ]
+            ],
+          ],
         ],
       ],
     ];
@@ -452,8 +501,6 @@ class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
       ->method('syndicateNode')
       ->willReturn($result);
 
-
-
     $context = [];
 
     EcmsApiBatchSendUpdatesForm::postSyndicateContent($ecmsApiSite, $node, $method, $context);
@@ -471,4 +518,5 @@ class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
       'test2' => [FALSE],
     ];
   }
+
 }

--- a/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/Form/EcmsApiBatchSendUpdateFormTest.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/Form/EcmsApiBatchSendUpdateFormTest.php
@@ -5,12 +5,18 @@ declare(strict_types = 1);
 namespace Drupal\Tests\ecms_api_publisher\Unit\Form;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Queue\QueueInterface;
-use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
+use Drupal\ecms_api_publisher\Entity\EcmsApiSiteInterface;
 use Drupal\ecms_api_publisher\Form\EcmsApiBatchSendUpdatesForm;
+use Drupal\link\Plugin\Field\FieldType\LinkItem;
+use Drupal\node\NodeInterface;
 use Drupal\Tests\UnitTestCase;
+use phpmock\MockBuilder;
 
 class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
 
@@ -18,12 +24,60 @@ class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
 
   private $queue;
   private $batchForm;
+  private $messenger;
 
+  private $globalBatch;
+  private $mockGlobalTFunction;
+
+  /**
+   * {@inheritDoc}
+   */
   protected function setUp(): void {
     parent::setUp();
 
-    $this->queue = $this->createMock(QueueInterface::class);
+    $mockGlobalBatchFunction = new MockBuilder();
+    $mockGlobalBatchFunction->setNamespace('Drupal\ecms_api_publisher\Form')
+      ->setName('batch_set')
+      ->setFunction(
+        function (array $batch) {
+          return;
+        }
+      );
 
+    $mockGlobalTFunction = new MockBuilder();
+    $mockGlobalTFunction->setNamespace('Drupal\ecms_api_publisher\Form')
+      ->setName('t')
+      ->setFunction(
+        function ($string, array $args = [], array $options = []) {
+          // @codingStandardsIgnoreLine
+          return new TranslatableMarkup($string, $args, $options);
+        }
+      );
+
+    $this->mockGlobalTFunction = $mockGlobalTFunction->build();
+    $this->mockGlobalTFunction->enable();
+
+    $this->globalBatch = $mockGlobalBatchFunction->build();
+    $this->globalBatch->enable();
+
+    $this->queue = $this->createMock(QueueInterface::class);
+    $this->messenger = $this->createMock(MessengerInterface::class);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function tearDown() {
+    parent::tearDown();
+
+    $this->globalBatch->disable();
+    $this->mockGlobalTFunction->disable();
+  }
+
+  /**
+   * Set the Drupal container for the form class.
+   */
+  protected function setFormContainer(): void {
     $queueFactory = $this->createMock(QueueFactory::class);
     $queueFactory->expects($this->once())
       ->method('get')
@@ -34,6 +88,7 @@ class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
 
     $container->set('queue', $queueFactory);
     $container->set('string_translation', $this->getStringTranslationStub());
+    $container->set('messenger', $this->messenger);
 
     \Drupal::setContainer($container);
 
@@ -49,6 +104,7 @@ class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
    * @dataProvider dataProviderForTestGetDescription
    */
   public function testGetDescription(int $count): void {
+    $this->setFormContainer();
     $this->queue->expects($this->once())
       ->method('numberOfItems')
       ->willReturn($count);
@@ -79,7 +135,11 @@ class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
     ];
   }
 
+  /**
+   * Test the getQuestion method.
+   */
   public function testGetQuestion(): void {
+    $this->setFormContainer();
     $expected = "Do you want to manually push all syndicated content?";
 
     $actual = $this->batchForm->getQuestion();
@@ -87,7 +147,11 @@ class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
     $this->assertEquals($expected, $actual->render());
   }
 
+  /**
+   * Test the getFormId method.
+   */
   public function testGetFormId(): void {
+    $this->setFormContainer();
     $expected = "ecms_api_publisher_batch_send_updates";
 
     $actual = $this->batchForm->getFormId();
@@ -95,12 +159,230 @@ class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
     $this->assertEquals($expected, $actual);
   }
 
+  /**
+   * Test the getCancelUrl method.
+   */
   public function testGetCancelUrl(): void {
+    $this->setFormContainer();
     $expected = Url::fromRoute('<front>');
 
     $actual = $this->batchForm->getCancelUrl();
 
     $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * Test the submitForm method.
+   *
+   * @dataProvider dataProviderForTestSubmitForm
+   */
+  public function testSubmitForm(int $queueCount = 3, bool $batchExpected = TRUE): void {
+    $this->setFormContainer();
+    $form = [];
+    $form_state = $this->createMock(FormStateInterface::class);
+    $apiSite = $this->createMock(EcmsApiSiteInterface::class);
+    $node = $this->createMock(NodeInterface::class);
+    // Claims to pass to the queue.
+    $claims = [];
+
+    // Build up the claims array.
+    if ($queueCount > 0) {
+      for ($i = 0; $i < $queueCount; $i++) {
+        $item = new \stdClass();
+        $item->data = [
+          'site_entity' => $apiSite,
+          'syndicated_content_entity' => $node,
+          'method' => $this->randomMachineName(),
+        ];
+
+        $claims[] = $item;
+      }
+
+      $claims[] = FALSE;
+
+      $this->queue->expects($this->exactly($queueCount + 1))
+        ->method('claimItem')
+        ->willReturnOnConsecutiveCalls(...$claims);
+
+      $this->queue->expects($this->exactly($queueCount))
+        ->method('deleteItem');
+    }
+    else {
+      $this->queue->expects($this->exactly(1))
+        ->method('claimItem')
+        ->willReturn(FALSE);
+
+      $this->queue->expects($this->never())
+        ->method('deleteItem');
+    }
+
+    if (!$batchExpected) {
+      $this->messenger->expects($this->once())
+        ->method('addStatus')
+        ->with('No queue items were found or they have been claimed by another process. Please wait a few minutes and try again.');
+
+      $form_state->expects($this->once())
+        ->method('setRedirect')
+        ->with('<front>');
+    }
+
+    $this->batchForm->submitForm($form, $form_state);
+  }
+
+  /**
+   * Parameters to pass to the testSubmitForm method.
+   *
+   * @return array[]
+   *   Parameters to pass to the testSubmitForm method.
+   */
+  public function dataProviderForTestSubmitForm(): array {
+    return [
+      'test1' => [3, TRUE],
+      'test2' => [1, TRUE],
+      'test3' => [0, FALSE],
+    ];
+  }
+
+  protected function setStaticMethodContainer(): void {
+    $queueFactory = $this->createMock(QueueFactory::class);
+    $queueFactory->expects($this->any())
+      ->method('get')
+      ->with(self::SYNDICATE_QUEUE)
+      ->willReturn($this->queue);
+
+    $container = new ContainerBuilder();
+
+    $container->set('queue', $queueFactory);
+    $container->set('string_translation', $this->getStringTranslationStub());
+    $container->set('messenger', $this->messenger);
+
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Test the requeueItem static method.
+   */
+  public function testRequeueItems(): void {
+    $this->setStaticMethodContainer();
+
+    $data = ['test' => 'array'];
+
+    $this->queue->expects($this->once())
+      ->method('createItem')
+      ->with($data);
+
+    EcmsApiBatchSendUpdatesForm::requeueItems($data);
+  }
+
+  /**
+   * Test the postSyndicatedContentFinished method.
+   *
+   * @param bool $success
+   *   Status of the batch to test.
+   * @param array $results
+   * @param array $operations
+   *
+   * @dataProvider dataProviderForFinishedMethod
+   */
+  public function testPostSyndicateContentFinished(bool $success, array $results, array $operations): void {
+    $this->setStaticMethodContainer();
+
+    if ($success) {
+      if (!empty($results['error'])) {
+        $this->messenger->expects($this->exactly(count($results['error'])))
+          ->method('addError');
+      }
+      else {
+        $this->messenger->expects($this->never())
+          ->method('addError');
+      }
+    }
+
+    if (!$success) {
+      foreach ($operations as &$error) {
+        $urlMock = $this->createMock(Url::class);
+        $urlMock->expects($this->once())
+          ->method('toString');
+
+        $linkMock = $this->createMock(LinkItem::class);
+        $linkMock->expects($this->once())
+          ->method('getUrl')
+          ->willReturn($urlMock);
+        $apiSite = $this->createMock(EcmsApiSiteInterface::class);
+        $apiSite->expects($this->once())
+          ->method('getApiEndpoint')
+          ->willReturn($linkMock);
+
+        // Mock the API Site entity.
+        $error[1][0] = $apiSite;
+
+        $node = $this->createMock(NodeInterface::class);
+        $node->expects($this->once())
+          ->method('bundle');
+        $node->expects($this->once())
+          ->method('getTitle');
+
+        $error[1][1] = $node;
+      }
+
+      $this->messenger->expects($this->exactly(count($operations)))
+        ->method('addError');
+
+      $this->queue->expects($this->exactly(count($operations)))
+        ->method('createItem');
+    }
+
+    EcmsApiBatchSendUpdatesForm::postSyndicateContentFinished($success, $results, $operations);
+
+  }
+
+  /**
+   * Parameters for the testPostSyndicateContentFinished method.
+   *
+   * @return array[]
+   *   Parameters for the testPostSyndicateContentFinished method.
+   */
+  public function dataProviderForFinishedMethod(): array {
+    return [
+      'test1' => [
+        TRUE,
+        ['error' => []],
+        [],
+      ],
+      'test2' => [
+        TRUE,
+        [
+          'error' => [
+            1 => 'Message 1',
+            2 => 'Message 2',
+            3 => 'Message 3',
+          ],
+        ],
+        [],
+      ],
+      'test3' => [
+        FALSE,
+        ['error' => []],
+        [
+          0 => [
+            '\class\name\space',
+            [
+              'apiSite',
+              'node',
+              $this->randomMachineName(),
+            ]
+          ],
+          2 => [
+            '\class\name\space',
+            [
+              'apiSite',
+              'node',
+              $this->randomMachineName(),
+            ]
+          ]
+        ],
+      ],
+    ];
   }
 
 }

--- a/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/Plugin/QueueWorker/EcmsApiSyndicateQueueWorkerTest.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/Plugin/QueueWorker/EcmsApiSyndicateQueueWorkerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\ecms_api_publisher\Unit\Plugin\QueueWorker;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Queue\RequeueException;
+use Drupal\Core\Url;
+use Drupal\ecms_api_publisher\EcmsApiPublisher;
+use Drupal\ecms_api_publisher\Entity\EcmsApiSiteInterface;
+use Drupal\ecms_api_publisher\Plugin\QueueWorker\EcmsApiSyndicateQueueWorker;
+use Drupal\link\Plugin\Field\FieldType\LinkItem;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Class EcmsApiSyndicateQueueWorkerTest.
+ *
+ * @covers \Drupal\ecms_api_publisher\Plugin\QueueWorker\EcmsApiSyndicateQueueWorker
+ * @group ecms
+ * @group ecms_api
+ * @group ecms_api_publisher
+ *
+ * @package Drupal\Tests\ecms_api_publisher\Unit\Plugin\QueueWorker
+ */
+class EcmsApiSyndicateQueueWorkerTest extends UnitTestCase {
+
+  /**
+   * Mock the EcmsApiPublisher service.
+   *
+   * @var \Drupal\ecms_api_publisher\EcmsApiPublisher|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $ecmsApiPublisher;
+
+  /**
+   * The QueueWorker class to test.
+   *
+   * @var \Drupal\Core\Plugin\ContainerFactoryPluginInterface|\Drupal\ecms_api_publisher\Plugin\QueueWorker\EcmsApiSyndicateQueueWorker
+   */
+  private $queueWorker;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->ecmsApiPublisher = $this->getMockBuilder(EcmsApiPublisher::class)
+      ->onlyMethods(['syndicateNode'])
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $container = new ContainerBuilder();
+
+    $container->set('ecms_api_publisher.publisher', $this->ecmsApiPublisher);
+    $container->set('string_translation', $this->getStringTranslationStub());
+
+    \Drupal::setContainer($container);
+
+    $this->queueWorker = EcmsApiSyndicateQueueWorker::create($container, [], '', []);
+  }
+
+  /**
+   * Test the processItem method.
+   *
+   * @param bool $expected
+   *   The expected result of the http call.
+   *
+   * @dataProvider dataProviderForProcessItem
+   */
+  public function testProcessItem(bool $expected): void {
+    $method = 'POST';
+    $url = $this->createMock(Url::class);
+    $node = $this->createMock(NodeInterface::class);
+
+    $linkItem = $this->createMock(LinkItem::class);
+    $linkItem->expects($this->once())
+      ->method('getUrl')
+      ->willReturn($url);
+    $siteEntity = $this->createMock(EcmsApiSiteInterface::class);
+    $siteEntity->expects($this->once())
+      ->method('getApiEndpoint')
+      ->willReturn($linkItem);
+
+    $this->ecmsApiPublisher->expects($this->once())
+      ->method('syndicateNode')
+      ->with($method, $url, $node)
+      ->willReturn($expected);
+
+    if (!$expected) {
+      $this->expectException(RequeueException::class);
+    }
+
+    $data = [
+      'site_entity' => $siteEntity,
+      'syndicated_content_entity' => $node,
+      'method' => $method,
+    ];
+
+    $this->queueWorker->processItem($data);
+  }
+
+  /**
+   * Data provider for the testProcessItem method.
+   *
+   * @return array
+   *   Parameters to pass to testProcessItem().
+   */
+  public function dataProviderForProcessItem(): array {
+    return [
+      'test1' => [FALSE],
+      'test2' => [TRUE],
+    ];
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_api_recipient/ecms_api_recipient.install
+++ b/ecms_base/modules/custom/ecms_api_recipient/ecms_api_recipient.install
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * ecms_api_recipient.install
+ */
+
 declare(strict_types = 1);
 
 /**

--- a/ecms_base/modules/custom/ecms_authentication/ecms_authentication.module
+++ b/ecms_base/modules/custom/ecms_authentication/ecms_authentication.module
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * ecms_authentication.module
+ */
+
 declare(strict_types = 1);
 
 /**

--- a/ecms_base/modules/custom/ecms_workflow/ecms_workflow.module
+++ b/ecms_base/modules/custom/ecms_workflow/ecms_workflow.module
@@ -1,13 +1,17 @@
 <?php
 
+/**
+ * @file
+ * ecms_workflow.module
+ */
+
 declare(strict_types = 1);
 
 /**
  * Implements hook_entity_bundle_create().
  *
  * When optional features (content types) are enabled on the site,
- * this will ensure they are assinged to the proper workflow.
- *
+ * this will ensure they are assigned to the proper workflow.
  */
 function ecms_workflow_entity_bundle_create($entity_type_id, $bundle) : void {
   if ($entity_type_id !== 'node') {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,6 +14,7 @@
 
   <!-- PHPCS argument overrides -->
   <arg name="colors" />
+  <arg name="extensions" value="inc,info,install,module,php,profile,test,theme" />
 
   <!-- PHP configuration overrides -->
   <ini name="memory_limit" value="-1" />

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -52,6 +52,7 @@
         </whitelist>
     </filter>
     <logging>
+        <log type="coverage-html" target="tests/phpunit/results/html"/>
         <log type="coverage-text" target="tests/phpunit/results/coverage.txt"/>
     </logging>
 </phpunit>


### PR DESCRIPTION
## Summary
Apologies, this functionality got a little large. This does the following:

1. Coding standards: the phpcs.xml file was not configured properly and was skipping .module/.install/etc. extensions. That has been added and those standards have been fixed.
2. Add a new `ecms_api_publisher.publisher` service that manages posting the node to the recipient site.
3. Add another new `ecms_api_publisher.syndicate` that manages collecting new nodes and adding them to the queue api for publishing with the publishing site's cron job.
4. Add a new confirm form that will collect the queued content and add those to a batch process for immediate processing.

This does not currently contain the workflow logic of determining if a node should be published before syndication.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Medium
| Relevant links | [RIG-72](https://thinkoomph.jira.com/browse/rig-72)