### PR TITLE
Update the ecms_api_recipient installation configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-37: Made ECMS custom theme the default.
 - RIG-22: Enable Moderation Dashboard module by default.
 - RIG-37: Updated the development script to allow for pattern lab development.
+- RIG-76: Updatd the api recipient installation values.
 
 ### Deprecated
 

--- a/ecms_base/modules/custom/ecms_api_recipient/config/install/ecms_api_recipient.settings.yml
+++ b/ecms_base/modules/custom/ecms_api_recipient/config/install/ecms_api_recipient.settings.yml
@@ -1,7 +1,8 @@
 oauth_client_id: 'REDACTED'
 oauth_client_secret: 'REDACTED'
 api_recipient_mail: 'ecms_api_recipient@ecms.com'
-allowed_content_types: []
+allowed_content_types:
+  notification: notification
 api_main_hub: 'https://develop-ecms-profile.lndo.site'
 api_main_hub_client_id: 'REDACTED'
 api_main_hub_client_secret: 'REDACTED'

--- a/ecms_base/modules/custom/ecms_api_recipient/config/install/user.role.ecms_api_recipient.yml
+++ b/ecms_base/modules/custom/ecms_api_recipient/config/install/user.role.ecms_api_recipient.yml
@@ -5,4 +5,7 @@ id: ecms_api_recipient
 label: 'eCMS API Recipient'
 weight: 6
 is_admin: null
-permissions: {  }
+permissions:
+  - 'create notification content'
+  - 'edit own notification content'
+  - 'use editorial transition publish'

--- a/ecms_base/modules/custom/ecms_api_recipient/ecms_api_recipient.info.yml
+++ b/ecms_base/modules/custom/ecms_api_recipient/ecms_api_recipient.info.yml
@@ -6,3 +6,4 @@ package: eCMS API
 
 dependencies:
   - ecms_api
+  - ecms_notification

--- a/ecms_base/modules/custom/ecms_api_recipient/ecms_api_recipient.info.yml
+++ b/ecms_base/modules/custom/ecms_api_recipient/ecms_api_recipient.info.yml
@@ -7,3 +7,4 @@ package: eCMS API
 dependencies:
   - ecms_api
   - ecms_notification
+  - ecms_workflow

--- a/ecms_base/modules/custom/ecms_api_recipient/src/Form/EcmsApiRecipientConfigForm.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/src/Form/EcmsApiRecipientConfigForm.php
@@ -26,6 +26,11 @@ class EcmsApiRecipientConfigForm extends ConfigFormBase {
   const RECIPIENT_ROLE = 'ecms_api_recipient';
 
   /**
+   * The publish action for the editorial workflow.
+   */
+  const EDITORIAL_PUBLISH = 'use editorial transition publish';
+
+  /**
    * The entity_type.manager service.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
@@ -158,6 +163,9 @@ class EcmsApiRecipientConfigForm extends ConfigFormBase {
       $role->grantPermission("create {$key} content");
       $role->grantPermission("edit own {$key} content");
     }
+
+    // Grant the publishing permission.
+    $role->grantPermission(self::EDITORIAL_PUBLISH);
 
     try {
       $role->save();

--- a/ecms_base/modules/custom/ecms_api_recipient/tests/src/Functional/InstallationTest.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/tests/src/Functional/InstallationTest.php
@@ -31,7 +31,7 @@ class InstallationTest extends AllProfileInstallationTestsAbstract {
    *
    * @var string[]
    */
-  protected static $modules = ['ecms_workflow', 'ecms_api_recipient'];
+  protected static $modules = ['ecms_api_recipient'];
 
   /**
    * Test the ecms_api_recipient installation.

--- a/ecms_base/modules/custom/ecms_api_recipient/tests/src/Functional/InstallationTest.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/tests/src/Functional/InstallationTest.php
@@ -52,8 +52,13 @@ class InstallationTest extends AllProfileInstallationTestsAbstract {
     // Ensure the ecms_api_recipient role was installed.
     $this->drupalGet('admin/people/roles/manage/ecms_api_recipient');
     $this->assertSession()->statusCodeEquals(200);
-    // Ensure the editorial permission is selected on install.
+
+    // Ensure the correct permissions are selected on install.
+    $this->drupalGet('admin/people/permissions/ecms_api_recipient');
+    $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->checkboxChecked('edit-ecms-api-recipient-use-editorial-transition-publish');
+    $this->assertSession()->checkboxChecked('edit-ecms-api-recipient-create-notification-content');
+    $this->assertSession()->checkboxChecked('edit-ecms-api-recipient-edit-own-notification-content');
 
     // Ensure the user account was created.
     $this->drupalGet('admin/people');

--- a/ecms_base/modules/custom/ecms_api_recipient/tests/src/Functional/InstallationTest.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/tests/src/Functional/InstallationTest.php
@@ -52,7 +52,7 @@ class InstallationTest extends AllProfileInstallationTestsAbstract {
     // Ensure the ecms_api_recipient role was installed.
     $this->drupalGet('admin/people/roles/manage/ecms_api_recipient');
     $this->assertSession()->statusCodeEquals(200);
-    // Ensure the editorial permission is selected on install
+    // Ensure the editorial permission is selected on install.
     $this->assertSession()->checkboxChecked('edit-ecms-api-recipient-use-editorial-transition-publish');
 
     // Ensure the user account was created.

--- a/ecms_base/modules/custom/ecms_api_recipient/tests/src/Functional/InstallationTest.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/tests/src/Functional/InstallationTest.php
@@ -31,7 +31,7 @@ class InstallationTest extends AllProfileInstallationTestsAbstract {
    *
    * @var string[]
    */
-  protected static $modules = ['ecms_api_recipient'];
+  protected static $modules = ['ecms_workflow', 'ecms_api_recipient'];
 
   /**
    * Test the ecms_api_recipient installation.
@@ -52,6 +52,8 @@ class InstallationTest extends AllProfileInstallationTestsAbstract {
     // Ensure the ecms_api_recipient role was installed.
     $this->drupalGet('admin/people/roles/manage/ecms_api_recipient');
     $this->assertSession()->statusCodeEquals(200);
+    // Ensure the editorial permission is selected on install
+    $this->assertSession()->checkboxChecked('edit-ecms-api-recipient-use-editorial-transition-publish');
 
     // Ensure the user account was created.
     $this->drupalGet('admin/people');
@@ -90,18 +92,24 @@ class InstallationTest extends AllProfileInstallationTestsAbstract {
 
     $this->drupalGet('admin/config/ecms_api/ecms_api_recipient/settings');
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->fieldExists('edit-allowed-content-types-notification');
+    $this->assertSession()->checkboxChecked('edit-allowed-content-types-notification');
+
+    $this->assertSession()->fieldExists('edit-allowed-content-types-basic-page');
     $configFormSubmission = [
+      'edit-allowed-content-types-basic-page' => 1,
       'edit-allowed-content-types-notification' => 1,
     ];
     $this->drupalPostForm('admin/config/ecms_api/ecms_api_recipient/settings', $configFormSubmission, 'Save configuration');
     $this->drupalGet('admin/people/permissions/ecms_api_recipient');
     $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->checkboxChecked('edit-ecms-api-recipient-use-editorial-transition-publish');
     $this->assertSession()->checkboxChecked('edit-ecms-api-recipient-create-notification-content');
     $this->assertSession()->checkboxChecked('edit-ecms-api-recipient-edit-own-notification-content');
+    $this->assertSession()->checkboxChecked('edit-ecms-api-recipient-create-basic-page-content');
+    $this->assertSession()->checkboxChecked('edit-ecms-api-recipient-edit-own-basic-page-content');
 
-    $this->assertSession()->checkboxNotChecked('edit-ecms-api-recipient-create-basic-page-content');
-    $this->assertSession()->checkboxNotChecked('edit-ecms-api-recipient-edit-own-basic-page-content');
+    $this->assertSession()->checkboxNotChecked('edit-ecms-api-recipient-create-event-content');
+    $this->assertSession()->checkboxNotChecked('edit-ecms-api-recipient-edit-own-event-content');
 
     // Ensure the menu link is available.
     $this->drupalGet('admin/config/services');

--- a/ecms_base/modules/custom/ecms_api_recipient/tests/src/Unit/Form/EcmsApiRecipientConfigFormTest.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/tests/src/Unit/Form/EcmsApiRecipientConfigFormTest.php
@@ -216,7 +216,8 @@ class EcmsApiRecipientConfigFormTest extends UnitTestCase {
       ->method('revokePermission')
       ->willReturnSelf();
 
-    $roleEntity->expects($this->exactly(count(self::SELECTED_NODE_TYPES) * 2))
+    $grantCount = (count(self::SELECTED_NODE_TYPES) * 2) + 1;
+    $roleEntity->expects($this->exactly($grantCount))
       ->method('grantPermission')
       ->willReturnSelf();
 
@@ -320,7 +321,8 @@ class EcmsApiRecipientConfigFormTest extends UnitTestCase {
       ->method('revokePermission')
       ->willReturnSelf();
 
-    $roleEntity->expects($this->exactly(count(self::SELECTED_NODE_TYPES) * 2))
+    $grantCount = (count(self::SELECTED_NODE_TYPES) * 2) + 1;
+    $roleEntity->expects($this->exactly($grantCount))
       ->method('grantPermission')
       ->willReturnSelf();
 


### PR DESCRIPTION
## Summary
This updates the ecms api recipient module to enable the notification content type by default and updates the configuration form to allow the ecms_api_recipient role to publish nodes using the editorial workflow.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-76](https://thinkoomph.jira.com/browse/rig-76)