### PR TITLE
Add base paragraph feature, update basic page content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-22: Enable Moderation Dashboard module by default.
 - RIG-37: Updated the development script to allow for pattern lab development.
 - RIG-76: Updated the api recipient installation values.
+- RIG-67: Added paragraph reference field to basic page.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-49: Added the hotel content type as a feature.
 - RIG-45: Added Executive Order content type as optional feature.
 - RIG-72: Added the queue and publish service to syndicate content to other sites.
+- RIG-67: Added paragraphs feature to base install.
 
 ### Changed
 - RIG-23: Changed from OIDC generic to Windows AAD for authentication.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-22: Enable Moderation Dashboard module by default.
 - RIG-37: Updated the development script to allow for pattern lab development.
 - RIG-76: Updated the api recipient installation values.
-- RIG-67: Added paragraph reference field to basic page.
+- RIG-67: Added paragraphs reference field to basic page.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-37: Made ECMS custom theme the default.
 - RIG-22: Enable Moderation Dashboard module by default.
 - RIG-37: Updated the development script to allow for pattern lab development.
-- RIG-76: Updatd the api recipient installation values.
+- RIG-76: Updated the api recipient installation values.
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
     "drupal/acsf": "^2.67",
     "drupal/address": "^1.8",
     "drupal/admin_toolbar": "^2.3",
+    "drupal/allowed_formats": "^1.3",
     "drupal/auto_entitylabel": "^3.0@beta",
     "drupal/components": "^2.0",
     "drupal/content_moderation_notifications": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,7 @@
     "drupal/office_hours": "^1.3",
     "drupal/openid_connect": "1.x-dev",
     "drupal/openid_connect_windows_aad": "^1.3",
+    "drupal/paragraphs": "^1.12",
     "drupal/publishcontent": "^1.2",
     "drupal/rabbit_hole": "^1.0",
     "drupal/scheduler": "^1.3",

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -21,6 +21,7 @@ dependencies:
   - datetime
   - dynamic_page_cache
   - editor
+  - entity_reference_revisions
   - field_ui
   - file
   - features

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -35,6 +35,7 @@ dependencies:
   - node
   - openid_connect_windows_aad
   - options
+  - paragraphs
   - path
   - page_cache
   - publishcontent

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -6,6 +6,7 @@ core_version_requirement: ^9
 # Module dependencies for the distribution.
 # Modules that sub-profiles need must be listed here and_not in install.
 dependencies:
+  - allowed_formats
   - admin_toolbar
   - big_pipe
   - block
@@ -62,6 +63,7 @@ install:
   - ecms_landing_page
   - ecms_location
   - ecms_notification
+  - ecms_paragraphs
   - ecms_person
   - ecms_press_release
   - ecms_promotions

--- a/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_form_display.node.basic_page.default.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_form_display.node.basic_page.default.yml
@@ -3,8 +3,12 @@ status: true
 dependencies:
   config:
     - field.field.node.basic_page.field_basic_page_body
+    - field.field.node.basic_page.field_basic_page_paragraphs
     - node.type.basic_page
+    - workflows.workflow.editorial
   module:
+    - content_moderation
+    - paragraphs
     - path
     - text
 id: node.basic_page.default
@@ -28,6 +32,24 @@ content:
     third_party_settings: {  }
     type: text_textarea_with_summary
     region: content
+  field_basic_page_paragraphs:
+    type: entity_reference_paragraphs
+    weight: 122
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: preview
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: _none
+    third_party_settings: {  }
+    region: content
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    settings: {  }
+    region: content
+    third_party_settings: {  }
   path:
     type: path
     weight: 30

--- a/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_view_display.node.basic_page.default.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_view_display.node.basic_page.default.yml
@@ -3,8 +3,10 @@ status: true
 dependencies:
   config:
     - field.field.node.basic_page.field_basic_page_body
+    - field.field.node.basic_page.field_basic_page_paragraphs
     - node.type.basic_page
   module:
+    - entity_reference_revisions
     - text
     - user
 id: node.basic_page.default
@@ -12,6 +14,11 @@ targetEntityType: node
 bundle: basic_page
 mode: default
 content:
+  content_moderation_control:
+    weight: -20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_basic_page_body:
     weight: 101
     label: above
@@ -19,9 +26,18 @@ content:
     third_party_settings: {  }
     type: text_default
     region: content
-  links:
-    weight: 100
-    settings: {  }
+  field_basic_page_paragraphs:
+    type: entity_reference_revisions_entity_view
+    weight: 102
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
     third_party_settings: {  }
     region: content
+  links:
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden: {  }

--- a/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_view_display.node.basic_page.teaser.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_view_display.node.basic_page.teaser.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.basic_page.field_basic_page_body
+    - field.field.node.basic_page.field_basic_page_paragraphs
     - node.type.basic_page
   module:
     - user
@@ -12,6 +13,11 @@ targetEntityType: node
 bundle: basic_page
 mode: teaser
 content:
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   links:
     weight: 100
     settings: {  }
@@ -19,3 +25,4 @@ content:
     region: content
 hidden:
   field_basic_page_body: true
+  field_basic_page_paragraphs: true

--- a/ecms_base/features/custom/ecms_basic_page/config/install/field.field.node.basic_page.field_basic_page_paragraphs.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/field.field.node.basic_page.field_basic_page_paragraphs.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_basic_page_paragraphs
+    - node.type.basic_page
+    - paragraphs.paragraphs_type.formatted_text
+  module:
+    - entity_reference_revisions
+id: node.basic_page.field_basic_page_paragraphs
+field_name: field_basic_page_paragraphs
+entity_type: node
+bundle: basic_page
+label: 'Basic Page Paragraphs'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      formatted_text: formatted_text
+    target_bundles_drag_drop:
+      formatted_text:
+        enabled: true
+        weight: 2
+field_type: entity_reference_revisions

--- a/ecms_base/features/custom/ecms_basic_page/config/install/field.storage.node.field_basic_page_paragraphs.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/field.storage.node.field_basic_page_paragraphs.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_basic_page_paragraphs
+field_name: field_basic_page_paragraphs
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_basic_page/ecms_basic_page.info.yml
+++ b/ecms_base/features/custom/ecms_basic_page/ecms_basic_page.info.yml
@@ -3,10 +3,14 @@ description: 'Provides Basic page content type and related configuration. Add a 
 type: module
 core_version_requirement: ^9
 dependencies:
+  - content_moderation
+  - ecms_paragraphs
   - ecms_workflow
+  - entity_reference_revisions
   - field
   - menu_ui
   - node
+  - paragraphs
   - path
   - text
   - user

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.formatted_text.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.formatted_text.default.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.formatted_text.field_text
+    - paragraphs.paragraphs_type.formatted_text
+  module:
+    - text
+id: paragraph.formatted_text.default
+targetEntityType: paragraph
+bundle: formatted_text
+mode: default
+content:
+  field_text:
+    weight: 0
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+hidden:
+  created: true
+  status: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.paragraph.formatted_text.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.paragraph.formatted_text.default.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.formatted_text.field_text
+    - paragraphs.paragraphs_type.formatted_text
+  module:
+    - text
+id: paragraph.formatted_text.default
+targetEntityType: paragraph
+bundle: formatted_text
+mode: default
+content:
+  field_text:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+hidden: {  }

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/editor.editor.paragraph_text.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/editor.editor.paragraph_text.yml
@@ -1,0 +1,63 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.paragraph_text
+  module:
+    - ckeditor
+format: paragraph_text
+editor: ckeditor
+settings:
+  toolbar:
+    rows:
+      -
+        -
+          name: Formatting
+          items:
+            - Bold
+            - Italic
+            - Strike
+            - Superscript
+            - Subscript
+        -
+          name: Alignment
+          items:
+            - JustifyLeft
+            - JustifyCenter
+            - JustifyRight
+            - Outdent
+            - Indent
+        -
+          name: Links
+          items:
+            - DrupalLink
+            - DrupalUnlink
+        -
+          name: Lists
+          items:
+            - BulletedList
+            - NumberedList
+        -
+          name: Headings
+          items:
+            - Format
+        -
+          name: Tools
+          items:
+            - HorizontalRule
+            - Blockquote
+            - SpecialChar
+            - RemoveFormat
+  plugins:
+    stylescombo:
+      styles: ''
+    language:
+      language_list: un
+image_upload:
+  status: false
+  scheme: public
+  directory: inline-images
+  max_size: ''
+  max_dimensions:
+    width: null
+    height: null

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.paragraph.formatted_text.field_text.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.paragraph.formatted_text.field_text.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_text
+    - paragraphs.paragraphs_type.formatted_text
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    paragraph_text: paragraph_text
+    basic_html: '0'
+    embed: '0'
+    restricted_html: '0'
+    full_html: '0'
+    plain_text: '0'
+id: paragraph.formatted_text.field_text
+field_name: field_text
+entity_type: paragraph
+bundle: formatted_text
+label: Text
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.storage.paragraph.field_text.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.storage.paragraph.field_text.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_text
+field_name: field_text
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/filter.format.paragraph_text.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/filter.format.paragraph_text.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+name: 'Paragraph Text'
+format: paragraph_text
+weight: 0
+filters:
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: true
+    weight: 0
+    settings:
+      filter_url_length: 72
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -10
+    settings:
+      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <hr> <s> <sup> <sub> <p>'
+      filter_html_help: true
+      filter_html_nofollow: false
+  media_embed:
+    id: media_embed
+    provider: media
+    status: false
+    weight: 100
+    settings:
+      default_view_mode: default
+      allowed_media_types: {  }
+      allowed_view_modes: {  }

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/paragraphs.paragraphs_type.formatted_text.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/paragraphs.paragraphs_type.formatted_text.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: formatted_text
+label: 'Formatted Text'
+icon_uuid: null
+icon_default: null
+description: 'A WYSIWYG driven text editor used for basic markup creation.'
+behavior_plugins: {  }

--- a/ecms_base/features/custom/ecms_paragraphs/ecms_paragraphs.features.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/ecms_paragraphs.features.yml
@@ -1,0 +1,2 @@
+bundle: ecms
+required: true

--- a/ecms_base/features/custom/ecms_paragraphs/ecms_paragraphs.info.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/ecms_paragraphs.info.yml
@@ -1,0 +1,15 @@
+name: 'eCMS Paragraphs'
+description: 'Provides Paragraph types and related configuration.'
+type: module
+core_version_requirement: ^9
+dependencies:
+  - allowed_formats
+  - ckeditor
+  - editor
+  - field
+  - filter
+  - media
+  - paragraphs
+  - text
+version: 9.x-1.0
+package: eCMS


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
<!-- Include a summary of your changes that expands upon the title. -->
Adds a new feature 'ecms_paragraphs'
Adds a new text format used by new "Formatted Text" paragraph type
Installs paragraphs and new paragraph type by default
Adds the allowed_formats module to restrict format options (installed by default)
Updates basic page to add a paragraph reference field

There are some workflow / content moderation settings that have been introduced into the basic page feature. We had previously been removing these, but I feel that during this development phase we should leave them in, as it's tedious to remove these manually, and I think we're going to be faced with that for a while until development stabilizes. Since this is a default content type, assigned to the default workflow, the risk is very low so for now I think we can keep this as is. 

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | JIRA issue, bug reports, security alerts, etc.
https://thinkoomph.jira.com/browse/RIG-67