### PR TITLE
Add publication list paragraph bundle

### DIFF
--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -8,6 +8,7 @@ core_version_requirement: ^9
 dependencies:
   - allowed_formats
   - admin_toolbar
+  - admin_toolbar_tools
   - big_pipe
   - block
   - block_content
@@ -24,6 +25,7 @@ dependencies:
   - dynamic_page_cache
   - editor
   - entity_reference_revisions
+  - features_ui
   - field_ui
   - file
   - features

--- a/ecms_base/features/custom/ecms_basic_page/config/install/field.field.node.basic_page.field_basic_page_paragraphs.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/field.field.node.basic_page.field_basic_page_paragraphs.yml
@@ -4,7 +4,6 @@ dependencies:
   config:
     - field.storage.node.field_basic_page_paragraphs
     - node.type.basic_page
-    - paragraphs.paragraphs_type.formatted_text
   module:
     - entity_reference_revisions
 id: node.basic_page.field_basic_page_paragraphs
@@ -21,10 +20,19 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     negate: 0
-    target_bundles:
-      formatted_text: formatted_text
+    negate: 1
+    target_bundles: null
     target_bundles_drag_drop:
+      file_list:
+        weight: 5
+        enabled: false
       formatted_text:
-        enabled: true
         weight: 2
+        enabled: false
+      media_item:
+        weight: 7
+        enabled: false
+      publications_list:
+        weight: 8
+        enabled: false
 field_type: entity_reference_revisions

--- a/ecms_base/features/custom/ecms_basic_page/config/install/field.field.node.basic_page.field_basic_page_paragraphs.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/field.field.node.basic_page.field_basic_page_paragraphs.yml
@@ -19,7 +19,6 @@ default_value_callback: ''
 settings:
   handler: 'default:paragraph'
   handler_settings:
-    negate: 0
     negate: 1
     target_bundles: null
     target_bundles_drag_drop:

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.default.yml
@@ -36,6 +36,13 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.media_library.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.media_library.yml
@@ -13,6 +13,13 @@ targetEntityType: media
 bundle: file
 mode: media_library
 content:
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   name:
     type: string_textfield
     settings:

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_image.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_image.default.yml
@@ -1,4 +1,3 @@
-uuid: 2469731b-fa34-428f-b8cb-78263c2c2e0a
 langcode: en
 status: true
 dependencies:
@@ -28,6 +27,13 @@ content:
     third_party_settings: {  }
     type: image_image
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: -5

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_video.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_video.default.yml
@@ -1,4 +1,3 @@
-uuid: b22b4e6d-5eec-43e8-b178-f83f9d31713c
 langcode: en
 status: true
 dependencies:
@@ -27,6 +26,13 @@ content:
     third_party_settings: {  }
     type: oembed_textfield
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   path:
     type: path
     weight: 30

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.file_list.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.file_list.default.yml
@@ -1,4 +1,3 @@
-uuid: 711d8bff-a6c8-4a68-9376-ab93e69c7776
 langcode: en
 status: true
 dependencies:
@@ -15,13 +14,13 @@ mode: default
 content:
   field_files:
     type: media_library_widget
-    weight: 0
+    weight: 1
     settings:
       media_types: {  }
     third_party_settings: {  }
     region: content
   field_list_title:
-    weight: 1
+    weight: 0
     settings:
       size: 60
       placeholder: ''

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.media_item.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.media_item.default.yml
@@ -1,4 +1,3 @@
-uuid: 75f5428c-594d-4988-a542-dde8e76e026f
 langcode: en
 status: true
 dependencies:
@@ -23,9 +22,11 @@ content:
     region: content
   field_caption:
     weight: 3
-    settings: {  }
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
-    type: options_select
+    type: string_textfield
     region: content
   field_media_item:
     type: media_library_widget

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.file.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.file.default.yml
@@ -48,6 +48,7 @@ content:
     region: content
 hidden:
   created: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.file.media_library.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.file.media_library.yml
@@ -31,5 +31,6 @@ hidden:
   field_file_size: true
   field_file_title: true
   field_file_type: true
+  langcode: true
   name: true
   uid: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.media_item_image.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.media_item_image.default.yml
@@ -1,4 +1,3 @@
-uuid: bdf3ea1c-3520-4d22-b6ed-60aeab0846d9
 langcode: en
 status: true
 dependencies:
@@ -23,6 +22,7 @@ content:
     region: content
 hidden:
   created: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.media_item_image.media_library.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.media_item_image.media_library.yml
@@ -1,4 +1,3 @@
-uuid: cb9185a5-bb5f-44e6-8364-5b49536091c4
 langcode: en
 status: true
 dependencies:
@@ -26,5 +25,6 @@ content:
 hidden:
   created: true
   field_media_item_image: true
+  langcode: true
   name: true
   uid: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.media_item_video.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.media_item_video.default.yml
@@ -1,4 +1,3 @@
-uuid: dddbaa82-b0ed-4b78-bf2f-0e89ea9d5470
 langcode: en
 status: true
 dependencies:
@@ -23,6 +22,7 @@ content:
     region: content
 hidden:
   created: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.media_item_video.media_library.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.media_item_video.media_library.yml
@@ -1,4 +1,3 @@
-uuid: ffb74dad-e1bb-4373-9437-91678abdab25
 langcode: en
 status: true
 dependencies:
@@ -26,5 +25,6 @@ content:
 hidden:
   created: true
   field_media_item_video_url: true
+  langcode: true
   name: true
   uid: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.paragraph.file_list.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.paragraph.file_list.default.yml
@@ -1,4 +1,3 @@
-uuid: 045aee3c-ed7d-4456-bef4-d55dd5e35af3
 langcode: en
 status: true
 dependencies:

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.paragraph.media_item.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.paragraph.media_item.default.yml
@@ -1,4 +1,3 @@
-uuid: fd004502-f6f2-44db-81e6-fa7b22249f17
 langcode: en
 status: true
 dependencies:
@@ -25,9 +24,10 @@ content:
   field_caption:
     weight: 3
     label: above
-    settings: {  }
+    settings:
+      link_to_entity: false
     third_party_settings: {  }
-    type: list_default
+    type: string
     region: content
   field_media_item:
     type: entity_reference_entity_view

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.paragraph.media_item.field_caption.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.paragraph.media_item.field_caption.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.paragraph.field_caption
     - paragraphs.paragraphs_type.media_item
-  module:
-    - options
 id: paragraph.media_item.field_caption
 field_name: field_caption
 entity_type: paragraph
@@ -17,4 +15,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: list_string
+field_type: string

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.storage.paragraph.field_caption.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.storage.paragraph.field_caption.yml
@@ -2,16 +2,16 @@ langcode: en
 status: true
 dependencies:
   module:
-    - options
     - paragraphs
 id: paragraph.field_caption
 field_name: field_caption
 entity_type: paragraph
-type: list_string
+type: string
 settings:
-  allowed_values: {  }
-  allowed_values_function: ''
-module: options
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
 locked: false
 cardinality: 1
 translatable: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/paragraphs.paragraphs_type.file_list.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/paragraphs.paragraphs_type.file_list.yml
@@ -1,4 +1,3 @@
-uuid: 6f34be55-cff4-4c34-84fc-ab8f206c1797
 langcode: en
 status: true
 dependencies: {  }

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/paragraphs.paragraphs_type.media_item.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/paragraphs.paragraphs_type.media_item.yml
@@ -1,4 +1,3 @@
-uuid: 77e1996e-6b38-475c-8298-da3227000ffc
 langcode: en
 status: true
 dependencies: {  }

--- a/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.media.publication_file.default.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.media.publication_file.default.yml
@@ -25,6 +25,13 @@ content:
     third_party_settings: {  }
     type: file_generic
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: -5

--- a/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.media.publication_file.media_library.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.media.publication_file.media_library.yml
@@ -10,6 +10,13 @@ targetEntityType: media
 bundle: publication_file
 mode: media_library
 content:
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   name:
     type: string_textfield
     settings:

--- a/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.node.publication.default.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.node.publication.default.yml
@@ -9,7 +9,9 @@ dependencies:
     - field.field.node.publication.field_publication_types
     - field.field.node.publication.field_publication_url
     - node.type.publication
+    - workflows.workflow.editorial
   module:
+    - content_moderation
     - datetime
     - link
     - media_library
@@ -76,6 +78,19 @@ content:
     third_party_settings: {  }
     type: link_default
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    settings: {  }
+    region: content
+    third_party_settings: {  }
   path:
     type: path
     weight: 30

--- a/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.paragraph.publications_list.default.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.paragraph.publications_list.default.yml
@@ -1,0 +1,51 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.publications_list.field_publication_language
+    - field.field.paragraph.publications_list.field_publication_list_title
+    - field.field.paragraph.publications_list.field_publication_types
+    - field.field.paragraph.publications_list.field_publications_manual
+    - paragraphs.paragraphs_type.publications_list
+id: paragraph.publications_list.default
+targetEntityType: paragraph
+bundle: publications_list
+mode: default
+content:
+  field_publication_language:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_publication_list_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_publication_types:
+    weight: 1
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_publications_manual:
+    weight: 3
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+hidden:
+  created: true
+  status: true

--- a/ecms_base/features/custom/ecms_publications/config/install/core.entity_view_display.media.publication_file.default.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.entity_view_display.media.publication_file.default.yml
@@ -21,6 +21,7 @@ content:
     region: content
 hidden:
   created: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/ecms_base/features/custom/ecms_publications/config/install/core.entity_view_display.media.publication_file.media_library.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.entity_view_display.media.publication_file.media_library.yml
@@ -25,5 +25,6 @@ content:
 hidden:
   created: true
   field_media_file: true
+  langcode: true
   name: true
   uid: true

--- a/ecms_base/features/custom/ecms_publications/config/install/core.entity_view_display.node.publication.default.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.entity_view_display.node.publication.default.yml
@@ -18,6 +18,11 @@ targetEntityType: node
 bundle: publication
 mode: default
 content:
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   field_publication_audiences:
     weight: 105
     label: above
@@ -77,4 +82,5 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
-hidden: {  }
+hidden:
+  langcode: true

--- a/ecms_base/features/custom/ecms_publications/config/install/core.entity_view_display.node.publication.teaser.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.entity_view_display.node.publication.teaser.yml
@@ -17,6 +17,11 @@ targetEntityType: node
 bundle: publication
 mode: teaser
 content:
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   links:
     weight: 100
     settings: {  }
@@ -29,3 +34,4 @@ hidden:
   field_publication_topics: true
   field_publication_types: true
   field_publication_url: true
+  langcode: true

--- a/ecms_base/features/custom/ecms_publications/config/install/core.entity_view_display.paragraph.publications_list.default.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.entity_view_display.paragraph.publications_list.default.yml
@@ -1,0 +1,47 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.publications_list.field_publication_language
+    - field.field.paragraph.publications_list.field_publication_list_title
+    - field.field.paragraph.publications_list.field_publication_types
+    - field.field.paragraph.publications_list.field_publications_manual
+    - paragraphs.paragraphs_type.publications_list
+id: paragraph.publications_list.default
+targetEntityType: paragraph
+bundle: publications_list
+mode: default
+content:
+  field_publication_language:
+    weight: 2
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_publication_list_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_publication_types:
+    weight: 1
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_publications_manual:
+    weight: 3
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+hidden: {  }

--- a/ecms_base/features/custom/ecms_publications/config/install/field.field.paragraph.publications_list.field_publication_language.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/field.field.paragraph.publications_list.field_publication_language.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_publication_language
+    - paragraphs.paragraphs_type.publications_list
+id: paragraph.publications_list.field_publication_language
+field_name: field_publication_language
+entity_type: paragraph
+bundle: publications_list
+label: 'Publication Language'
+description: '(Optional) Select a specific language to display all publications that have a translation for that language.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:configurable_language'
+  handler_settings:
+    target_bundles: null
+    auto_create: false
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_publications/config/install/field.field.paragraph.publications_list.field_publication_list_title.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/field.field.paragraph.publications_list.field_publication_list_title.yml
@@ -11,7 +11,7 @@ bundle: publications_list
 label: 'List Title'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/ecms_base/features/custom/ecms_publications/config/install/field.field.paragraph.publications_list.field_publication_list_title.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/field.field.paragraph.publications_list.field_publication_list_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_publication_list_title
+    - paragraphs.paragraphs_type.publications_list
+id: paragraph.publications_list.field_publication_list_title
+field_name: field_publication_list_title
+entity_type: paragraph
+bundle: publications_list
+label: 'List Title'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_publications/config/install/field.field.paragraph.publications_list.field_publication_types.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/field.field.paragraph.publications_list.field_publication_types.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_publication_types
+    - paragraphs.paragraphs_type.publications_list
+    - taxonomy.vocabulary.publication_type
+id: paragraph.publications_list.field_publication_types
+field_name: field_publication_types
+entity_type: paragraph
+bundle: publications_list
+label: 'Publication Types'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      publication_type: publication_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_publications/config/install/field.field.paragraph.publications_list.field_publications_manual.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/field.field.paragraph.publications_list.field_publications_manual.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_publications_manual
+    - node.type.publication
+    - paragraphs.paragraphs_type.publications_list
+id: paragraph.publications_list.field_publications_manual
+field_name: field_publications_manual
+entity_type: paragraph
+bundle: publications_list
+label: 'Publications (manual tagging)'
+description: 'If you do not wish to display publications by topic or language, you can manually tag specific publications to display. '
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      publication: publication
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_publications/config/install/field.storage.node.field_publication_types.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/field.storage.node.field_publication_types.yml
@@ -13,7 +13,7 @@ settings:
 module: core
 locked: false
 cardinality: -1
-translatable: true
+translatable: false
 indexes: {  }
 persist_with_no_fields: false
 custom_storage: false

--- a/ecms_base/features/custom/ecms_publications/config/install/field.storage.paragraph.field_publication_language.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/field.storage.paragraph.field_publication_language.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+    - paragraphs
+id: paragraph.field_publication_language
+field_name: field_publication_language
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: configurable_language
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_publications/config/install/field.storage.paragraph.field_publication_list_title.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/field.storage.paragraph.field_publication_list_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_publication_list_title
+field_name: field_publication_list_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_publications/config/install/field.storage.paragraph.field_publication_types.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/field.storage.paragraph.field_publication_types.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - taxonomy
+id: paragraph.field_publication_types
+field_name: field_publication_types
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_publications/config/install/field.storage.paragraph.field_publications_manual.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/field.storage.paragraph.field_publications_manual.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_publications_manual
+field_name: field_publications_manual
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_publications/config/install/paragraphs.paragraphs_type.publications_list.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/paragraphs.paragraphs_type.publications_list.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: publications_list
+label: 'Publications list'
+icon_uuid: null
+icon_default: null
+description: 'A list of publications that can be displayed through a variety of controls. '
+behavior_plugins: {  }

--- a/ecms_base/features/custom/ecms_publications/ecms_publications.info.yml
+++ b/ecms_base/features/custom/ecms_publications/ecms_publications.info.yml
@@ -3,15 +3,18 @@ description: 'Provides Publication content type and related configuration.'
 type: module
 core_version_requirement: ^9
 dependencies:
+  - content_moderation
   - datetime
   - field
   - file
   - image
+  - language
   - link
   - media
   - media_library
   - menu_ui
   - node
+  - paragraphs
   - path
   - rh_node
   - taxonomy


### PR DESCRIPTION
## Summary
The main purpose of this PR is too add the `publication list` paragraph bundle to the existing publication feature package. This was handled with all unique fields and therefore should not run into any conflicts.

Also included in this PR is some other minor updates:
* Added features_ui and admin_toolabar_tools to default install
* Changes basic page's paragraphs field to use negate condition rather than exclude
* Fixes a mistake in the last paragraphs PR where field_caption was list (text) rather than plain text
* Adds missing config now that language packs have been added

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIG-67