### PR TITLE
Add translation support to the executive order content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-62: Added webform node module install by default.
 - RIG-78: Added default languages and translations for the default content types.
 - RIG-85: Added translation support for the hotel content type.
+- RIG-84: Added translation support for the executive order content type.
 
 ### Changed
 - RIG-23: Changed from OIDC generic to Windows AAD for authentication.

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.media.executive_order_pdf.changed.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.media.executive_order_pdf.changed.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.executive_order_pdf
+id: media.executive_order_pdf.changed
+field_name: changed
+entity_type: media
+bundle: executive_order_pdf
+label: Changed
+description: 'The time the media item was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.media.executive_order_pdf.created.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.media.executive_order_pdf.created.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.executive_order_pdf
+id: media.executive_order_pdf.created
+field_name: created
+entity_type: media
+bundle: executive_order_pdf
+label: 'Authored on'
+description: 'The time the media item was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getRequestTime'
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.media.executive_order_pdf.path.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.media.executive_order_pdf.path.yml
@@ -1,0 +1,19 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.executive_order_pdf
+  module:
+    - path
+id: media.executive_order_pdf.path
+field_name: path
+entity_type: media
+bundle: executive_order_pdf
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.media.executive_order_pdf.status.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.media.executive_order_pdf.status.yml
@@ -1,0 +1,21 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.executive_order_pdf
+id: media.executive_order_pdf.status
+field_name: status
+entity_type: media
+bundle: executive_order_pdf
+label: Published
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.media.executive_order_pdf.uid.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.media.executive_order_pdf.uid.yml
@@ -1,0 +1,19 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.executive_order_pdf
+id: media.executive_order_pdf.uid
+field_name: uid
+entity_type: media
+bundle: executive_order_pdf
+label: 'Authored by'
+description: 'The user ID of the author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getDefaultEntityOwner'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.node.executive_order.changed.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.node.executive_order.changed.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - node.type.executive_order
+id: node.executive_order.changed
+field_name: changed
+entity_type: node
+bundle: executive_order
+label: Changed
+description: 'The time that the node was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.node.executive_order.created.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.node.executive_order.created.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - node.type.executive_order
+id: node.executive_order.created
+field_name: created
+entity_type: node
+bundle: executive_order
+label: 'Authored on'
+description: 'The time that the node was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.node.executive_order.sticky.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.node.executive_order.sticky.yml
@@ -1,0 +1,21 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - node.type.executive_order
+id: node.executive_order.sticky
+field_name: sticky
+entity_type: node
+bundle: executive_order
+label: 'Sticky at top of lists'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.node.executive_order.uid.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.base_field_override.node.executive_order.uid.yml
@@ -1,0 +1,19 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - node.type.executive_order
+id: node.executive_order.uid
+field_name: uid
+entity_type: node
+bundle: executive_order
+label: 'Authored by'
+description: 'The username of the content author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\node\Entity\Node::getDefaultEntityOwner'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.entity_form_display.media.executive_order_pdf.default.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.entity_form_display.media.executive_order_pdf.default.yml
@@ -25,6 +25,13 @@ content:
     third_party_settings: {  }
     type: file_generic
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: -5
@@ -46,6 +53,11 @@ content:
     weight: 100
     region: content
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.entity_form_display.media.executive_order_pdf.media_library.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.entity_form_display.media.executive_order_pdf.media_library.yml
@@ -10,12 +10,24 @@ targetEntityType: media
 bundle: executive_order_pdf
 mode: media_library
 content:
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   name:
     type: string_textfield
     settings:
       size: 60
       placeholder: ''
     weight: 0
+    third_party_settings: {  }
+    region: content
+  translation:
+    weight: 10
+    settings: {  }
     third_party_settings: {  }
     region: content
 hidden:

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.entity_form_display.node.executive_order.default.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.entity_form_display.node.executive_order.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.executive_order.field_executive_order_pdf
     - field.field.node.executive_order.field_executive_order_text
     - node.type.executive_order
+    - workflows.workflow.editorial
   module:
     - content_moderation
     - datetime
@@ -52,6 +53,13 @@ content:
     third_party_settings: {  }
     type: string_textarea
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
     weight: 100
@@ -93,6 +101,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.entity_view_display.media.executive_order_pdf.default.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.entity_view_display.media.executive_order_pdf.default.yml
@@ -21,6 +21,7 @@ content:
     region: content
 hidden:
   created: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.entity_view_display.media.executive_order_pdf.media_library.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.entity_view_display.media.executive_order_pdf.media_library.yml
@@ -25,5 +25,6 @@ content:
 hidden:
   created: true
   field_executive_order_pdf: true
+  langcode: true
   name: true
   uid: true

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.entity_view_display.node.executive_order.default.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.entity_view_display.node.executive_order.default.yml
@@ -58,4 +58,5 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
-hidden: {  }
+hidden:
+  langcode: true

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/core.entity_view_display.node.executive_order.teaser.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/core.entity_view_display.node.executive_order.teaser.yml
@@ -30,3 +30,4 @@ hidden:
   field_executive_order_long_title: true
   field_executive_order_pdf: true
   field_executive_order_text: true
+  langcode: true

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/field.field.node.executive_order.field_executive_order_long_title.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/field.field.node.executive_order.field_executive_order_long_title.yml
@@ -11,7 +11,7 @@ bundle: executive_order
 label: 'Executive Order Long Title'
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/field.field.node.executive_order.field_executive_order_text.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/field.field.node.executive_order.field_executive_order_text.yml
@@ -11,7 +11,7 @@ bundle: executive_order
 label: 'Executive Order Text'
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/language.content_settings.media.executive_order_pdf.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/language.content_settings.media.executive_order_pdf.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.executive_order_pdf
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: media.executive_order_pdf
+target_entity_type_id: media
+target_bundle: executive_order_pdf
+default_langcode: site_default
+language_alterable: true

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/language.content_settings.node.executive_order.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/language.content_settings.node.executive_order.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - node.type.executive_order
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
+id: node.executive_order
+target_entity_type_id: node
+target_bundle: executive_order
+default_langcode: site_default
+language_alterable: true

--- a/ecms_base/features/custom/ecms_executive_orders/config/install/rabbit_hole.behavior_settings.node_type_executive_order.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/config/install/rabbit_hole.behavior_settings.node_type_executive_order.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
-dependencies:
-  config:
-    - node.type.executive_order
+dependencies: {  }
 id: node_type_executive_order
 action: page_redirect
 allow_override: 1

--- a/ecms_base/features/custom/ecms_executive_orders/ecms_executive_orders.info.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/ecms_executive_orders.info.yml
@@ -4,15 +4,18 @@ type: module
 core_version_requirement: ^9
 dependencies:
   - content_moderation
+  - content_translation
   - datetime
   - field
   - file
   - image
+  - language
   - media
   - media_library
   - menu_ui
   - node
   - path
+  - rabbit_hole
   - rh_node
   - user
 version: 9.x-1.0

--- a/ecms_base/features/custom/ecms_executive_orders/tests/src/ExistingSite/EcmsExecutiveOrdersInstallTest.php
+++ b/ecms_base/features/custom/ecms_executive_orders/tests/src/ExistingSite/EcmsExecutiveOrdersInstallTest.php
@@ -7,7 +7,11 @@ namespace Drupal\Tests\ecms_executive_orders\ExistingSite;
 // Require the all profiles abstract class since autoloading doesn't work.
 require_once dirname(__FILE__) . '/../../../../../../../tests/src/ExistingSite/AllProfileInstallationTestsAbstract.php';
 
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\media\Entity\Media;
+use Drupal\node\Entity\Node;
 use Drupal\Tests\ecms_profile\ExistingSite\AllProfileInstallationTestsAbstract;
+use Drupal\user\Entity\Role;
 
 /**
  * Functional tests for the EcmsExecutiveOrdersInstall feature.
@@ -20,16 +24,70 @@ class EcmsExecutiveOrdersInstallTest extends AllProfileInstallationTestsAbstract
 
   /**
    * Test the ecms_executive_orders installation.
+   * Required fields for the executive_order content type.
+   */
+  const EXECUTIVE_ORDER_TRANSLATABLE_FIELDS = [
+    'title[0][value]' => 'This is an executive order title',
+    'field_executive_order_long_title[0][value]' => 'This is an executive order body',
+    'field_executive_order_text[0][address][address_line1]' => 'This is an executive order long text field',
+  ];
+
+  /**
+   * The user entity to test with.
+   *
+   * @var \Drupal\user\Entity\User|false
+   */
+  private $account;
+
+  /**
+   * The role to create for testing.
+   *
+   * @var false|string
+   */
+  private $role;
+
+  /**
+   * The node to test with.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
+  private $node;
+
+  /**
+   * The media element to attach to the node.
+   *
+   * @var \Drupal\media\MediaInterface
+   */
+  private $media;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    // Provide the role with known permissions to start.
+    $this->role = $this->coreCreateRole([
+      'administer modules',
+      'administer site configuration',
+      'access administration pages',
+      'use editorial transition create_new_draft',
+      'view any unpublished content',
+      'create content translations',
+    ]);
+
+    $this->account = $this->createUser();
+    $this->account->addRole($this->role);
+    $this->account->save();
+  }
+
+  /**
+   * Test the ecms_executive_orders installation.
    *
    * @throws \Behat\Mink\Exception\ExpectationException
    */
   public function testEcmsExecutiveOrdersInstallation(): void {
-    $account = $this->createUser([
-      'administer modules',
-      'administer site configuration',
-      'access administration pages',
-    ]);
-    $this->drupalLogin($account);
+    $this->drupalLogin($this->account);
 
     $this->drupalGet('admin/modules');
     $this->assertSession()->statusCodeEquals(200);
@@ -41,6 +99,127 @@ class EcmsExecutiveOrdersInstallTest extends AllProfileInstallationTestsAbstract
     $this->drupalPostForm(NULL, $edit, t('Install'));
     $this->assertSession()->pageTextContainsOnce('Module eCMS Executive Orders has been enabled.');
 
+    // Create the entities to test with after installation.
+    $this->createTestEntities();
+
+    // Once the executive_order feature has been enabled,
+    // add the new permissions to the role.
+    /** @var \Drupal\user\RoleInterface $role */
+    $role = Role::load($this->role);
+    $role->grantPermission('create executive_order content');
+    $role->grantPermission('edit any executive_order content');
+    $role->grantPermission('translate executive_order node');
+    $role->save();
+
+    // Browse to the executive_order page and ensure we can choose a language.
+    $this->drupalGet('node/add/executive_order');
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Ensure the language selection exists on the node form.
+    $this->assertSession()->fieldExists('edit-langcode-0-value');
+    // Ensure the default languages exist on the node form.
+    foreach (self::DEFAULT_INSTALLED_LANGUAGES as $langcode) {
+      $this->assertSession()->optionExists('edit-langcode-0-value', $langcode);
+    }
+
+    $nodeId = $this->node->id();
+
+    $this->drupalGet("node/{$nodeId}");
+    $this->assertSession()->statusCodeEquals(200);
+
+    foreach (self::EXECUTIVE_ORDER_TRANSLATABLE_FIELDS as $key => $value) {
+      $this->assertSession()->pageTextContainsOnce($value);
+    }
+
+    foreach (self::DEFAULT_INSTALLED_LANGUAGES as $lang) {
+      if ($lang === 'en') {
+        continue;
+      }
+
+      $this->drupalGet("{$lang}/node/{$nodeId}/translations/add/en/{$lang}");
+      $this->assertSession()->statusCodeEquals(200);
+
+      $translationTitle = "Translation in {$lang}";
+      $postTranslation = self::EXECUTIVE_ORDER_TRANSLATABLE_FIELDS;
+      $postTranslation['title[0][value]'] = $translationTitle;
+      $this->drupalPostForm(NULL, $postTranslation, t('Save (this translation)'));
+      $this->assertSession()->pageTextContainsOnce("Executive Order {$translationTitle} has been updated.");
+      $translatedUrl = $this->getUrl();
+      $translatedUrl = parse_url($translatedUrl, PHP_URL_PATH);
+      $this->assertEqual($translatedUrl, "/{$lang}/node/{$nodeId}/latest");
+    }
+
+    $this->drupalGet('admin/modules/uninstall');
+    $this->assertSession()->checkboxNotChecked('uninstall[ecms_executive_order]');
+
+    $edit = [];
+    $edit["uninstall[ecms_executive_order]"] = TRUE;
+    // Submit the uninstall form.
+    $this->drupalPostForm(NULL, $edit, t('Uninstall'));
+
+    // Submit the confirmation form.
+    $this->drupalPostForm(NULL, [], t('Uninstall'));
+
+    $this->assertSession()->fieldNotExists('uninstall[ecms_executive_order]');
+
+    $this->drupalLogout();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function tearDown(): void {
+    parent::tearDown();
+
+    if (!empty($this->account)) {
+      $this->account->delete();
+    }
+
+    $role = Role::load($this->role);
+    if (!empty($role)) {
+      $role->delete();
+    }
+
+    $this->node->delete();
+    $this->media->delete();
+
+  }
+
+  /**
+   * Helper method to create test entities.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  private function createTestEntities(): void {
+
+    $this->media = Media::create([
+      'bundle' => 'executive_order_pdf',
+      'name' => 'Test PDF',
+    ]);
+
+    try {
+      $this->media->save();
+    }
+    catch (EntityStorageException $e) {
+      // Trap storage errors.
+    }
+
+    $this->node = Node::create([
+      'type' => 'executive_order',
+      'title' => 'This is an executive order title',
+      'field_executive_order_date' => '2020-10-09',
+      'field_executive_order_long_title' => 'This is an executive order body',
+      'field_executive_order_text' => 'This is an executive order long text field',
+      'field_executive_order_pdf' => $this->media->id(),
+      'uid' => $this->account->id(),
+    ]);
+
+    try {
+      $this->node->save();
+    }
+    catch (EntityStorageException $e) {
+      // Trap storage errors.
+    }
   }
 
 }

--- a/ecms_base/features/custom/ecms_executive_orders/tests/src/ExistingSite/EcmsExecutiveOrdersInstallTest.php
+++ b/ecms_base/features/custom/ecms_executive_orders/tests/src/ExistingSite/EcmsExecutiveOrdersInstallTest.php
@@ -23,7 +23,6 @@ use Drupal\user\Entity\Role;
 class EcmsExecutiveOrdersInstallTest extends AllProfileInstallationTestsAbstract {
 
   /**
-   * Test the ecms_executive_orders installation.
    * Required fields for the executive_order content type.
    */
   const EXECUTIVE_ORDER_TRANSLATABLE_FIELDS = [

--- a/ecms_base/features/custom/ecms_executive_orders/tests/src/ExistingSite/EcmsExecutiveOrdersInstallTest.php
+++ b/ecms_base/features/custom/ecms_executive_orders/tests/src/ExistingSite/EcmsExecutiveOrdersInstallTest.php
@@ -14,7 +14,7 @@ use Drupal\Tests\ecms_profile\ExistingSite\AllProfileInstallationTestsAbstract;
 use Drupal\user\Entity\Role;
 
 /**
- * Functional tests for the EcmsExecutiveOrdersInstall feature.
+ * ExistingSite tests for the EcmsExecutiveOrdersInstall feature.
  *
  * @package Drupal\Tests\ecms_executive_orders\ExistingSite
  * @group ecms
@@ -29,7 +29,7 @@ class EcmsExecutiveOrdersInstallTest extends AllProfileInstallationTestsAbstract
   const EXECUTIVE_ORDER_TRANSLATABLE_FIELDS = [
     'title[0][value]' => 'This is an executive order title',
     'field_executive_order_long_title[0][value]' => 'This is an executive order body',
-    'field_executive_order_text[0][address][address_line1]' => 'This is an executive order long text field',
+    'field_executive_order_text[0][value]' => 'This is an executive order long text field',
   ];
 
   /**
@@ -74,6 +74,7 @@ class EcmsExecutiveOrdersInstallTest extends AllProfileInstallationTestsAbstract
       'use editorial transition create_new_draft',
       'view any unpublished content',
       'create content translations',
+      'rabbit hole bypass node',
     ]);
 
     $this->account = $this->createUser();
@@ -150,17 +151,17 @@ class EcmsExecutiveOrdersInstallTest extends AllProfileInstallationTestsAbstract
     }
 
     $this->drupalGet('admin/modules/uninstall');
-    $this->assertSession()->checkboxNotChecked('uninstall[ecms_executive_order]');
+    $this->assertSession()->checkboxNotChecked('uninstall[ecms_executive_orders]');
 
     $edit = [];
-    $edit["uninstall[ecms_executive_order]"] = TRUE;
+    $edit["uninstall[ecms_executive_orders]"] = TRUE;
     // Submit the uninstall form.
     $this->drupalPostForm(NULL, $edit, t('Uninstall'));
 
     // Submit the confirmation form.
     $this->drupalPostForm(NULL, [], t('Uninstall'));
 
-    $this->assertSession()->fieldNotExists('uninstall[ecms_executive_order]');
+    $this->assertSession()->fieldNotExists('uninstall[ecms_executive_orders]');
 
     $this->drupalLogout();
   }


### PR DESCRIPTION
## Summary
This adds translation support to the executive order content type.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-84](https://thinkoomph.jira.com/browse/rig-84)