### PR TITLE
Add translation support to the publication content feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-85: Added translation support for the hotel content type.
 - RIG-84: Added translation support for the executive order content type.
 - RIG-86: Added translation support for the projects content type.
+- RIG-87: Added translation support for the publication content type.
 
 ### Changed
 - RIG-23: Changed from OIDC generic to Windows AAD for authentication.

--- a/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.media.publication_file.changed.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.media.publication_file.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.publication_file
+id: media.publication_file.changed
+field_name: changed
+entity_type: media
+bundle: publication_file
+label: Changed
+description: 'The time the media item was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.media.publication_file.created.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.media.publication_file.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.publication_file
+id: media.publication_file.created
+field_name: created
+entity_type: media
+bundle: publication_file
+label: 'Authored on'
+description: 'The time the media item was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getRequestTime'
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.media.publication_file.path.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.media.publication_file.path.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.publication_file
+  module:
+    - path
+id: media.publication_file.path
+field_name: path
+entity_type: media
+bundle: publication_file
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.media.publication_file.status.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.media.publication_file.status.yml
@@ -2,18 +2,18 @@ langcode: en
 status: true
 dependencies:
   config:
-    - node.type.publication
-id: node.publication.promote
-field_name: promote
-entity_type: node
-bundle: publication
-label: 'Promoted to front page'
+    - media.type.publication_file
+id: media.publication_file.status
+field_name: status
+entity_type: media
+bundle: publication_file
+label: Published
 description: ''
 required: false
 translatable: false
 default_value:
   -
-    value: 0
+    value: 1
 default_value_callback: ''
 settings:
   on_label: 'On'

--- a/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.media.publication_file.uid.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.media.publication_file.uid.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.publication_file
+id: media.publication_file.uid
+field_name: uid
+entity_type: media
+bundle: publication_file
+label: 'Authored by'
+description: 'The user ID of the author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getDefaultEntityOwner'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.node.publication.changed.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.node.publication.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.publication
+id: node.publication.changed
+field_name: changed
+entity_type: node
+bundle: publication
+label: Changed
+description: 'The time that the node was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.node.publication.created.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.node.publication.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.publication
+id: node.publication.created
+field_name: created
+entity_type: node
+bundle: publication
+label: 'Authored on'
+description: 'The time that the node was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.node.publication.sticky.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.node.publication.sticky.yml
@@ -3,11 +3,11 @@ status: true
 dependencies:
   config:
     - node.type.publication
-id: node.publication.promote
-field_name: promote
+id: node.publication.sticky
+field_name: sticky
 entity_type: node
 bundle: publication
-label: 'Promoted to front page'
+label: 'Sticky at top of lists'
 description: ''
 required: false
 translatable: false

--- a/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.node.publication.uid.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.node.publication.uid.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.publication
+id: node.publication.uid
+field_name: uid
+entity_type: node
+bundle: publication
+label: 'Authored by'
+description: 'The username of the content author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\node\Entity\Node::getDefaultEntityOwner'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.paragraph.publications_list.created.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.paragraph.publications_list.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.publications_list
+id: paragraph.publications_list.created
+field_name: created
+entity_type: paragraph
+bundle: publications_list
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.paragraph.publications_list.status.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.paragraph.publications_list.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.publications_list
+id: paragraph.publications_list.status
+field_name: status
+entity_type: paragraph
+bundle: publications_list
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.taxonomy_term.publication_audience.changed.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.taxonomy_term.publication_audience.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.publication_audience
+id: taxonomy_term.publication_audience.changed
+field_name: changed
+entity_type: taxonomy_term
+bundle: publication_audience
+label: Changed
+description: 'The time that the term was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.taxonomy_term.publication_topic.changed.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.taxonomy_term.publication_topic.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.publication_topic
+id: taxonomy_term.publication_topic.changed
+field_name: changed
+entity_type: taxonomy_term
+bundle: publication_topic
+label: Changed
+description: 'The time that the term was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.taxonomy_term.publication_type.changed.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.base_field_override.taxonomy_term.publication_type.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.publication_type
+id: taxonomy_term.publication_type.changed
+field_name: changed
+entity_type: taxonomy_term
+bundle: publication_type
+label: Changed
+description: 'The time that the term was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.media.publication_file.default.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.media.publication_file.default.yml
@@ -53,6 +53,11 @@ content:
     weight: 100
     region: content
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.media.publication_file.media_library.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.media.publication_file.media_library.yml
@@ -25,6 +25,11 @@ content:
     weight: 0
     third_party_settings: {  }
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_file: true

--- a/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.node.publication.default.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.node.publication.default.yml
@@ -126,6 +126,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.paragraph.publications_list.default.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/core.entity_form_display.paragraph.publications_list.default.yml
@@ -46,6 +46,11 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   status: true

--- a/ecms_base/features/custom/ecms_publications/config/install/field.field.node.publication.field_publication_url.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/field.field.node.publication.field_publication_url.yml
@@ -13,7 +13,7 @@ bundle: publication
 label: 'Publication URL'
 description: 'Used for external file resources for publications'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/ecms_base/features/custom/ecms_publications/config/install/language.content_settings.media.publication_file.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/language.content_settings.media.publication_file.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.publication_file
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
+id: media.publication_file
+target_entity_type_id: media
+target_bundle: publication_file
+default_langcode: site_default
+language_alterable: true

--- a/ecms_base/features/custom/ecms_publications/config/install/language.content_settings.node.publication.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/language.content_settings.node.publication.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.publication
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
+id: node.publication
+target_entity_type_id: node
+target_bundle: publication
+default_langcode: site_default
+language_alterable: true

--- a/ecms_base/features/custom/ecms_publications/config/install/language.content_settings.paragraph.publications_list.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/language.content_settings.paragraph.publications_list.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.publications_list
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: paragraph.publications_list
+target_entity_type_id: paragraph
+target_bundle: publications_list
+default_langcode: site_default
+language_alterable: false

--- a/ecms_base/features/custom/ecms_publications/config/install/language.content_settings.paragraph.publications_list.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/language.content_settings.paragraph.publications_list.yml
@@ -7,11 +7,11 @@ dependencies:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: false
+    enabled: true
     bundle_settings:
       untranslatable_fields_hide: '0'
 id: paragraph.publications_list
 target_entity_type_id: paragraph
 target_bundle: publications_list
 default_langcode: site_default
-language_alterable: false
+language_alterable: true

--- a/ecms_base/features/custom/ecms_publications/config/install/language.content_settings.taxonomy_term.publication_audience.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/language.content_settings.taxonomy_term.publication_audience.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.publication_audience
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
+id: taxonomy_term.publication_audience
+target_entity_type_id: taxonomy_term
+target_bundle: publication_audience
+default_langcode: site_default
+language_alterable: true

--- a/ecms_base/features/custom/ecms_publications/config/install/language.content_settings.taxonomy_term.publication_topic.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/language.content_settings.taxonomy_term.publication_topic.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.publication_topic
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
+id: taxonomy_term.publication_topic
+target_entity_type_id: taxonomy_term
+target_bundle: publication_topic
+default_langcode: site_default
+language_alterable: true

--- a/ecms_base/features/custom/ecms_publications/config/install/language.content_settings.taxonomy_term.publication_type.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/language.content_settings.taxonomy_term.publication_type.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.publication_type
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
+id: taxonomy_term.publication_type
+target_entity_type_id: taxonomy_term
+target_bundle: publication_type
+default_langcode: site_default
+language_alterable: true

--- a/ecms_base/features/custom/ecms_publications/ecms_publications.info.yml
+++ b/ecms_base/features/custom/ecms_publications/ecms_publications.info.yml
@@ -4,6 +4,7 @@ type: module
 core_version_requirement: ^9
 dependencies:
   - content_moderation
+  - content_translation
   - datetime
   - field
   - file

--- a/ecms_base/features/custom/ecms_publications/tests/src/ExistingSite/EcmsPublicationsInstallTest.php
+++ b/ecms_base/features/custom/ecms_publications/tests/src/ExistingSite/EcmsPublicationsInstallTest.php
@@ -7,7 +7,12 @@ namespace Drupal\Tests\ecms_publications\ExistingSite;
 // Require the all profiles abstract class since autoloading doesn't work.
 require_once dirname(__FILE__) . '/../../../../../../../tests/src/ExistingSite/AllProfileInstallationTestsAbstract.php';
 
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\media\Entity\Media;
+use Drupal\node\Entity\Node;
+use Drupal\taxonomy\Entity\Term;
 use Drupal\Tests\ecms_profile\ExistingSite\AllProfileInstallationTestsAbstract;
+use Drupal\user\Entity\Role;
 
 /**
  * Functional testing for the EcmsPublicationsInstall feature.
@@ -19,18 +24,67 @@ use Drupal\Tests\ecms_profile\ExistingSite\AllProfileInstallationTestsAbstract;
 class EcmsPublicationsInstallTest extends AllProfileInstallationTestsAbstract {
 
   /**
-   * The profile to install.
-   *
-   * @var string
+   * Required fields for the publication content type.
    */
-  protected $profile = 'ecms_base';
+  const PUBLICATION_TRANSLATABLE_FIELDS = [
+    'title[0][value]' => 'This is a publication title',
+    'field_publication_url[0][uri]' => 'https://oomphinc.com',
+    'field_publication_url[0][title]' => 'Link Title',
+  ];
 
   /**
-   * The theme to test with.
+   * The user entity to test with.
    *
-   * @var string
+   * @var \Drupal\user\Entity\User|false
    */
-  protected $defaultTheme = 'ecms';
+  private $account;
+
+  /**
+   * The role to create for testing.
+   *
+   * @var false|string
+   */
+  private $role;
+
+  /**
+   * The node to test with.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
+  private $node;
+
+  /**
+   * The media element to attach to the node.
+   *
+   * @var \Drupal\media\MediaInterface
+   */
+  private $media;
+
+  private $topicTerm;
+  private $audienceTerm;
+  private $publicationTerm;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    // Provide the role with known permissions to start.
+    $this->role = $this->coreCreateRole([
+      'administer modules',
+      'administer site configuration',
+      'access administration pages',
+      'use editorial transition create_new_draft',
+      'view any unpublished content',
+      'create content translations',
+      'rabbit hole bypass node',
+    ]);
+
+    $this->account = $this->createUser();
+    $this->account->addRole($this->role);
+    $this->account->save();
+  }
 
   /**
    * Test the ecms_publications installation.
@@ -56,6 +110,160 @@ class EcmsPublicationsInstallTest extends AllProfileInstallationTestsAbstract {
     $this->drupalPostForm(NULL, $edit, t('Install'));
     $this->assertSession()->pageTextContainsOnce('Module eCMS Publications has been enabled.');
 
+    // Create the entities to test with after installation.
+    $this->createTestEntities();
+
+    // Once the ecms_publications feature has been enabled,
+    // add the new permissions to the role.
+    /** @var \Drupal\user\RoleInterface $role */
+    $role = Role::load($this->role);
+    $role->grantPermission('create publication content');
+    $role->grantPermission('edit any publication content');
+    $role->grantPermission('translate publication node');
+    $role->save();
+
+    // Browse to the publication page and ensure we can choose a language.
+    $this->drupalGet('node/add/publication');
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Ensure the language selection exists on the node form.
+    $this->assertSession()->fieldExists('edit-langcode-0-value');
+    // Ensure the default languages exist on the node form.
+    foreach (self::DEFAULT_INSTALLED_LANGUAGES as $langcode) {
+      $this->assertSession()->optionExists('edit-langcode-0-value', $langcode);
+    }
+
+    $nodeId = $this->node->id();
+
+    $this->drupalGet("node/{$nodeId}");
+    $this->assertSession()->statusCodeEquals(200);
+
+    foreach (self::PUBLICATION_TRANSLATABLE_FIELDS as $key => $value) {
+      $this->assertSession()->pageTextContainsOnce($value);
+    }
+
+    foreach (self::DEFAULT_INSTALLED_LANGUAGES as $lang) {
+      if ($lang === 'en') {
+        continue;
+      }
+
+      $this->drupalGet("{$lang}/node/{$nodeId}/translations/add/en/{$lang}");
+      $this->assertSession()->statusCodeEquals(200);
+
+      $translationTitle = "Translation in {$lang}";
+      $postTranslation = self::PUBLICATION_TRANSLATABLE_FIELDS;
+      $postTranslation['title[0][value]'] = $translationTitle;
+      $this->drupalPostForm(NULL, $postTranslation, t('Save (this translation)'));
+      $this->assertSession()->pageTextContainsOnce("Publication {$translationTitle} has been updated.");
+      $translatedUrl = $this->getUrl();
+      $translatedUrl = parse_url($translatedUrl, PHP_URL_PATH);
+      $this->assertEqual($translatedUrl, "/{$lang}/node/{$nodeId}/latest");
+    }
+
+    $this->drupalGet('admin/modules/uninstall');
+    $this->assertSession()->checkboxNotChecked('uninstall[ecms_publications]');
+
+    $edit = [];
+    $edit["uninstall[ecms_publications]"] = TRUE;
+    // Submit the uninstall form.
+    $this->drupalPostForm(NULL, $edit, t('Uninstall'));
+
+    // Submit the confirmation form.
+    $this->drupalPostForm(NULL, [], t('Uninstall'));
+
+    $this->assertSession()->fieldNotExists('uninstall[ecms_publications]');
+
+    $this->drupalLogout();
+
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function tearDown(): void {
+    parent::tearDown();
+
+    if (!empty($this->account)) {
+      $this->account->delete();
+    }
+
+    $role = Role::load($this->role);
+    if (!empty($role)) {
+      $role->delete();
+    }
+
+    $this->node->delete();
+    $this->media->delete();
+    $this->publicationTerm->delete();
+    $this->audienceTerm->delete();
+    $this->topicTerm->delete();
+
+  }
+
+  /**
+   * Helper method to create test entities.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  private function createTestEntities(): void {
+
+    $this->media = Media::create([
+      'bundle' => 'publication_file',
+      'name' => 'Test File',
+    ]);
+
+    try {
+      $this->media->save();
+    }
+    catch (EntityStorageException $e) {
+      // Trap storage errors.
+    }
+
+    $this->publicationTerm = Term::create([
+      'bundle' => 'publication_type',
+      'name' => $this->randomMachineName(),
+    ]);
+
+    $this->audienceTerm = Term::create([
+      'bundle' => 'publication_audience',
+      'name' => $this->randomMachineName(),
+    ]);
+
+    $this->topicTerm = Term::create([
+      'bundle' => 'publication_topic',
+      'name' => $this->randomMachineName(),
+    ]);
+
+    try {
+      $this->publicationTerm->save();
+      $this->audienceTerm->save();
+      $this->topicTerm->save();
+    }
+    catch (EntityStorageException $e) {
+      // Trap storage errors.
+    }
+
+    $this->node = Node::create([
+      'type' => 'publication',
+      'title' => 'This is a publication title',
+      'field_publication_date_modified' => '2020-10-12T00:08:45',
+      'field_publication_audiences' => $this->audienceTerm->id(),
+      'field_publication_topics' => $this->topicTerm->id(),
+      'field_publication_types' => $this->publicationTerm->id(),
+      'field_publication_file_download' => $this->media->id(),
+      'field_publication_url' => [
+        'uri' => 'https://oomphinc.com',
+        'title' => 'Link Title',
+      ],
+      'uid' => $this->account->id(),
+    ]);
+
+    try {
+      $this->node->save();
+    }
+    catch (EntityStorageException $e) {
+      // Trap storage errors.
+    }
   }
 
 }

--- a/ecms_base/features/custom/ecms_publications/tests/src/ExistingSite/EcmsPublicationsInstallTest.php
+++ b/ecms_base/features/custom/ecms_publications/tests/src/ExistingSite/EcmsPublicationsInstallTest.php
@@ -60,8 +60,25 @@ class EcmsPublicationsInstallTest extends AllProfileInstallationTestsAbstract {
    */
   private $media;
 
+  /**
+   * The topic taxonomy term to test with.
+   *
+   * @var \Drupal\taxonomy\Entity\Term
+   */
   private $topicTerm;
+
+  /**
+   * The audience taxonomy term to test with.
+   *
+   * @var \Drupal\taxonomy\Entity\Term
+   */
   private $audienceTerm;
+
+  /**
+   * The publication taxonomy term to test with.
+   *
+   * @var \Drupal\taxonomy\Entity\Term
+   */
   private $publicationTerm;
 
   /**

--- a/ecms_base/features/custom/ecms_publications/tests/src/ExistingSite/EcmsPublicationsInstallTest.php
+++ b/ecms_base/features/custom/ecms_publications/tests/src/ExistingSite/EcmsPublicationsInstallTest.php
@@ -15,7 +15,7 @@ use Drupal\Tests\ecms_profile\ExistingSite\AllProfileInstallationTestsAbstract;
 use Drupal\user\Entity\Role;
 
 /**
- * Functional testing for the EcmsPublicationsInstall feature.
+ * ExistingSite testing for the EcmsPublicationsInstall feature.
  *
  * @package Drupal\Tests\ecms_publications\ExistingSite
  * @group ecms
@@ -92,12 +92,8 @@ class EcmsPublicationsInstallTest extends AllProfileInstallationTestsAbstract {
    * @throws \Behat\Mink\Exception\ExpectationException
    */
   public function testEcmsPublicationInstallation(): void {
-    $account = $this->createUser([
-      'administer modules',
-      'administer site configuration',
-      'access administration pages',
-    ]);
-    $this->drupalLogin($account);
+
+    $this->drupalLogin($this->account);
 
     $this->drupalGet('admin/modules');
     $this->assertSession()->statusCodeEquals(200);
@@ -137,10 +133,6 @@ class EcmsPublicationsInstallTest extends AllProfileInstallationTestsAbstract {
 
     $this->drupalGet("node/{$nodeId}");
     $this->assertSession()->statusCodeEquals(200);
-
-    foreach (self::PUBLICATION_TRANSLATABLE_FIELDS as $key => $value) {
-      $this->assertSession()->pageTextContainsOnce($value);
-    }
 
     foreach (self::DEFAULT_INSTALLED_LANGUAGES as $lang) {
       if ($lang === 'en') {
@@ -220,17 +212,17 @@ class EcmsPublicationsInstallTest extends AllProfileInstallationTestsAbstract {
     }
 
     $this->publicationTerm = Term::create([
-      'bundle' => 'publication_type',
+      'vid' => 'publication_type',
       'name' => $this->randomMachineName(),
     ]);
 
     $this->audienceTerm = Term::create([
-      'bundle' => 'publication_audience',
+      'vid' => 'publication_audience',
       'name' => $this->randomMachineName(),
     ]);
 
     $this->topicTerm = Term::create([
-      'bundle' => 'publication_topic',
+      'vid' => 'publication_topic',
       'name' => $this->randomMachineName(),
     ]);
 


### PR DESCRIPTION
## Summary
This adds translation support for the publication content type and the supporting media/taxonomy/paragraph included in the feature.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes (mostly)
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-87](https://thinkoomph.jira.com/browse/rig-87)