### PR TITLE
Add translation support to the speeches content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-84: Added translation support for the executive order content type.
 - RIG-86: Added translation support for the projects content type.
 - RIG-87: Added translation support for the publication content type.
+- RIG-88: Added translation support for the speech content type.
 
 ### Changed
 - RIG-23: Changed from OIDC generic to Windows AAD for authentication.

--- a/ecms_base/features/custom/ecms_speeches/config/install/core.base_field_override.node.speech.changed.yml
+++ b/ecms_base/features/custom/ecms_speeches/config/install/core.base_field_override.node.speech.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.speech
+id: node.speech.changed
+field_name: changed
+entity_type: node
+bundle: speech
+label: Changed
+description: 'The time that the node was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_speeches/config/install/core.base_field_override.node.speech.created.yml
+++ b/ecms_base/features/custom/ecms_speeches/config/install/core.base_field_override.node.speech.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.speech
+id: node.speech.created
+field_name: created
+entity_type: node
+bundle: speech
+label: 'Authored on'
+description: 'The time that the node was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_speeches/config/install/core.base_field_override.node.speech.sticky.yml
+++ b/ecms_base/features/custom/ecms_speeches/config/install/core.base_field_override.node.speech.sticky.yml
@@ -3,11 +3,11 @@ status: true
 dependencies:
   config:
     - node.type.speech
-id: node.speech.promote
-field_name: promote
+id: node.speech.sticky
+field_name: sticky
 entity_type: node
 bundle: speech
-label: 'Promoted to front page'
+label: 'Sticky at top of lists'
 description: ''
 required: false
 translatable: false

--- a/ecms_base/features/custom/ecms_speeches/config/install/core.base_field_override.node.speech.uid.yml
+++ b/ecms_base/features/custom/ecms_speeches/config/install/core.base_field_override.node.speech.uid.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.speech
+id: node.speech.uid
+field_name: uid
+entity_type: node
+bundle: speech
+label: 'Authored by'
+description: 'The username of the content author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\node\Entity\Node::getDefaultEntityOwner'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_speeches/config/install/core.entity_form_display.node.speech.default.yml
+++ b/ecms_base/features/custom/ecms_speeches/config/install/core.entity_form_display.node.speech.default.yml
@@ -92,6 +92,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/ecms_base/features/custom/ecms_speeches/config/install/core.entity_form_display.node.speech.default.yml
+++ b/ecms_base/features/custom/ecms_speeches/config/install/core.entity_form_display.node.speech.default.yml
@@ -6,7 +6,9 @@ dependencies:
     - field.field.node.speech.field_speech_long_title
     - field.field.node.speech.field_speech_text
     - node.type.speech
+    - workflows.workflow.editorial
   module:
+    - content_moderation
     - datetime
     - path
 id: node.speech.default
@@ -42,6 +44,19 @@ content:
     third_party_settings: {  }
     type: string_textarea
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    settings: {  }
+    region: content
+    third_party_settings: {  }
   path:
     type: path
     weight: 30

--- a/ecms_base/features/custom/ecms_speeches/config/install/core.entity_view_display.node.speech.default.yml
+++ b/ecms_base/features/custom/ecms_speeches/config/install/core.entity_view_display.node.speech.default.yml
@@ -14,6 +14,11 @@ targetEntityType: node
 bundle: speech
 mode: default
 content:
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   field_speech_date:
     weight: 103
     label: above
@@ -43,4 +48,5 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  langcode: true

--- a/ecms_base/features/custom/ecms_speeches/config/install/core.entity_view_display.node.speech.teaser.yml
+++ b/ecms_base/features/custom/ecms_speeches/config/install/core.entity_view_display.node.speech.teaser.yml
@@ -14,6 +14,11 @@ targetEntityType: node
 bundle: speech
 mode: teaser
 content:
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   links:
     weight: 100
     region: content
@@ -23,3 +28,4 @@ hidden:
   field_speech_date: true
   field_speech_long_title: true
   field_speech_text: true
+  langcode: true

--- a/ecms_base/features/custom/ecms_speeches/config/install/field.field.node.speech.field_speech_long_title.yml
+++ b/ecms_base/features/custom/ecms_speeches/config/install/field.field.node.speech.field_speech_long_title.yml
@@ -11,7 +11,7 @@ bundle: speech
 label: 'Speech Long Title'
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/ecms_base/features/custom/ecms_speeches/config/install/field.field.node.speech.field_speech_text.yml
+++ b/ecms_base/features/custom/ecms_speeches/config/install/field.field.node.speech.field_speech_text.yml
@@ -11,7 +11,7 @@ bundle: speech
 label: 'Speech Text'
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/ecms_base/features/custom/ecms_speeches/config/install/language.content_settings.node.speech.yml
+++ b/ecms_base/features/custom/ecms_speeches/config/install/language.content_settings.node.speech.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.speech
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
+id: node.speech
+target_entity_type_id: node
+target_bundle: speech
+default_langcode: site_default
+language_alterable: true

--- a/ecms_base/features/custom/ecms_speeches/ecms_speeches.info.yml
+++ b/ecms_base/features/custom/ecms_speeches/ecms_speeches.info.yml
@@ -3,9 +3,12 @@ description: 'Provides Speech content type and related configuration.'
 type: module
 core_version_requirement: ^9
 dependencies:
-  - ecms_workflow
+  - content_moderation
+  - content_translation
   - datetime
+  - ecms_workflow
   - field
+  - language
   - menu_ui
   - node
   - path

--- a/ecms_base/features/custom/ecms_speeches/tests/src/ExistingSite/EcmsSpeechesInstallTest.php
+++ b/ecms_base/features/custom/ecms_speeches/tests/src/ExistingSite/EcmsSpeechesInstallTest.php
@@ -8,13 +8,12 @@ namespace Drupal\Tests\ecms_speeches\ExistingSite;
 require_once dirname(__FILE__) . '/../../../../../../../tests/src/ExistingSite/AllProfileInstallationTestsAbstract.php';
 
 use Drupal\Core\Entity\EntityStorageException;
-use Drupal\media\Entity\Media;
 use Drupal\node\Entity\Node;
 use Drupal\Tests\ecms_profile\ExistingSite\AllProfileInstallationTestsAbstract;
 use Drupal\user\Entity\Role;
 
 /**
- * Functional tests for the EcmsSpeechesInstall feature.
+ * ExistingSite tests for the EcmsSpeechesInstall feature.
  *
  * @package Drupal\Tests\ecms_hotels\ExistingSite
  * @group ecms

--- a/ecms_base/features/custom/ecms_speeches/tests/src/ExistingSite/EcmsSpeechesInstallTest.php
+++ b/ecms_base/features/custom/ecms_speeches/tests/src/ExistingSite/EcmsSpeechesInstallTest.php
@@ -7,7 +7,11 @@ namespace Drupal\Tests\ecms_speeches\ExistingSite;
 // Require the all profiles abstract class since autoloading doesn't work.
 require_once dirname(__FILE__) . '/../../../../../../../tests/src/ExistingSite/AllProfileInstallationTestsAbstract.php';
 
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\media\Entity\Media;
+use Drupal\node\Entity\Node;
 use Drupal\Tests\ecms_profile\ExistingSite\AllProfileInstallationTestsAbstract;
+use Drupal\user\Entity\Role;
 
 /**
  * Functional tests for the EcmsSpeechesInstall feature.
@@ -19,31 +23,64 @@ use Drupal\Tests\ecms_profile\ExistingSite\AllProfileInstallationTestsAbstract;
 class EcmsSpeechesInstallTest extends AllProfileInstallationTestsAbstract {
 
   /**
-   * The profile to install.
-   *
-   * @var string
+   * Required fields for the speech content type.
    */
-  protected $profile = 'ecms_base';
+  const SPEECH_TRANSLATABLE_FIELDS = [
+    'title[0][value]' => 'This is a speech title',
+    'field_speech_long_title[0][value]' => 'This is a speech long title.',
+    'field_speech_text[0][value]' => 'This is a speech text field.',
+  ];
 
   /**
-   * The theme to test with.
+   * The user entity to test with.
    *
-   * @var string
+   * @var \Drupal\user\Entity\User|false
    */
-  protected $defaultTheme = 'ecms';
+  private $account;
+
+  /**
+   * The role to create for testing.
+   *
+   * @var false|string
+   */
+  private $role;
+
+  /**
+   * The node to test with.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
+  private $node;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    // Provide the role with known permissions to start.
+    $this->role = $this->coreCreateRole([
+      'administer modules',
+      'administer site configuration',
+      'access administration pages',
+      'use editorial transition create_new_draft',
+      'view any unpublished content',
+      'create content translations',
+      'rabbit hole bypass node',
+    ]);
+
+    $this->account = $this->createUser();
+    $this->account->addRole($this->role);
+    $this->account->save();
+  }
 
   /**
    * Test the ecms_speeches installation.
    *
    * @throws \Behat\Mink\Exception\ExpectationException
    */
-  public function testEcmsProjectsInstallation(): void {
-    $account = $this->createUser([
-      'administer modules',
-      'administer site configuration',
-      'access administration pages',
-    ]);
-    $this->drupalLogin($account);
+  public function testEcmsSpeechesInstallation(): void {
+    $this->drupalLogin($this->account);
 
     $this->drupalGet('admin/modules');
     $this->assertSession()->statusCodeEquals(200);
@@ -55,6 +92,112 @@ class EcmsSpeechesInstallTest extends AllProfileInstallationTestsAbstract {
     $this->drupalPostForm(NULL, $edit, t('Install'));
     $this->assertSession()->pageTextContainsOnce('Module eCMS Speeches has been enabled.');
 
+    // Create the entities to test with after installation.
+    $this->createTestEntities();
+
+    // Once the ecms_speeches feature has been enabled,
+    // add the new permissions to the role.
+    /** @var \Drupal\user\RoleInterface $role */
+    $role = Role::load($this->role);
+    $role->grantPermission('create speech content');
+    $role->grantPermission('edit any speech content');
+    $role->grantPermission('translate speech node');
+    $role->save();
+
+    // Browse to the speech page and ensure we can choose a language.
+    $this->drupalGet('node/add/speech');
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Ensure the language selection exists on the node form.
+    $this->assertSession()->fieldExists('edit-langcode-0-value');
+    // Ensure the default languages exist on the node form.
+    foreach (self::DEFAULT_INSTALLED_LANGUAGES as $langcode) {
+      $this->assertSession()->optionExists('edit-langcode-0-value', $langcode);
+    }
+
+    $nodeId = $this->node->id();
+
+    $this->drupalGet("node/{$nodeId}");
+    $this->assertSession()->statusCodeEquals(200);
+
+    foreach (self::SPEECH_TRANSLATABLE_FIELDS as $key => $value) {
+      $this->assertSession()->pageTextContainsOnce($value);
+    }
+
+    foreach (self::DEFAULT_INSTALLED_LANGUAGES as $lang) {
+      if ($lang === 'en') {
+        continue;
+      }
+
+      $this->drupalGet("{$lang}/node/{$nodeId}/translations/add/en/{$lang}");
+      $this->assertSession()->statusCodeEquals(200);
+
+      $translationTitle = "Translation in {$lang}";
+      $postTranslation = self::SPEECH_TRANSLATABLE_FIELDS;
+      $postTranslation['title[0][value]'] = $translationTitle;
+      $this->drupalPostForm(NULL, $postTranslation, t('Save (this translation)'));
+      $this->assertSession()->pageTextContainsOnce("Speech {$translationTitle} has been updated.");
+      $translatedUrl = $this->getUrl();
+      $translatedUrl = parse_url($translatedUrl, PHP_URL_PATH);
+      $this->assertEqual($translatedUrl, "/{$lang}/node/{$nodeId}/latest");
+    }
+
+    $this->drupalGet('admin/modules/uninstall');
+    $this->assertSession()->checkboxNotChecked('uninstall[ecms_speeches]');
+
+    $edit = [];
+    $edit["uninstall[ecms_speeches]"] = TRUE;
+    // Submit the uninstall form.
+    $this->drupalPostForm(NULL, $edit, t('Uninstall'));
+
+    // Submit the confirmation form.
+    $this->drupalPostForm(NULL, [], t('Uninstall'));
+
+    $this->assertSession()->fieldNotExists('uninstall[ecms_speeches]');
+
+    $this->drupalLogout();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function tearDown(): void {
+    parent::tearDown();
+
+    if (!empty($this->account)) {
+      $this->account->delete();
+    }
+
+    $role = Role::load($this->role);
+    if (!empty($role)) {
+      $role->delete();
+    }
+
+    $this->node->delete();
+
+  }
+
+  /**
+   * Helper method to create test entities.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  private function createTestEntities(): void {
+
+    $this->node = Node::create([
+      'type' => 'speech',
+      'title' => 'This is a speech title',
+      'field_speech_long_title' => 'This is a speech long title.',
+      'field_speech_text' => 'This is a speech text field.',
+      'uid' => $this->account->id(),
+    ]);
+
+    try {
+      $this->node->save();
+    }
+    catch (EntityStorageException $e) {
+      // Trap storage errors.
+    }
   }
 
 }


### PR DESCRIPTION
## Summary
This updates the ecms_speeches feature to include translation support for the content type and fields.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-88](https://thinkoomph.jira.com/browse/rig-88)