### PR TITLE
Fix the language syndication for the Ecms API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,5 +69,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Fixed
 - RIG-37: Fixed the develop script to properly pull in the pattern lab repo.
+- RIG-89: Fixed the Ecms API to work with syndicating translations.
 
 ### Security

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
       "drupal/core": {
         "1356276 - Allow profiles to define a base/parent profile and load them in the correct order": "https://www.drupal.org/files/issues/2020-03-24/1356276-531-9.0.x-9.patch",
         "2914389 - Allow profiles to exclude dependencies of their parent": "https://www.drupal.org/files/issues/2018-07-09/2914389-8-do-not-test.patch",
-        "3106659 - Error: Call to a member function getItemDefinition() on null in media_requirements()": "https://www.drupal.org/files/issues/2020-04-29/media-install-requirements-3106659.patch"
+        "3106659 - Error: Call to a member function getItemDefinition() on null in media_requirements()": "https://www.drupal.org/files/issues/2020-04-29/media-install-requirements-3106659.patch",
+        "#2794431 #102 [META] Formalize translations support": "https://www.drupal.org/files/issues/2020-09-29/jsonapi_add_and_update_translations_support-2794431-102.patch"
       },
       "drupal/openid_connect_windows_aad": {
         "3169996 - Incorrect configuration schema file": "https://www.drupal.org/files/issues/2020-09-09/openid_connect_windows_aad-schema-update-3169996-3.patch"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "1356276 - Allow profiles to define a base/parent profile and load them in the correct order": "https://www.drupal.org/files/issues/2020-03-24/1356276-531-9.0.x-9.patch",
         "2914389 - Allow profiles to exclude dependencies of their parent": "https://www.drupal.org/files/issues/2018-07-09/2914389-8-do-not-test.patch",
         "3106659 - Error: Call to a member function getItemDefinition() on null in media_requirements()": "https://www.drupal.org/files/issues/2020-04-29/media-install-requirements-3106659.patch",
-        "#2794431 #102 [META] Formalize translations support": "https://www.drupal.org/files/issues/2020-09-29/jsonapi_add_and_update_translations_support-2794431-102.patch"
+        "2794431 - [META] Formalize translations support (#102)": "https://www.drupal.org/files/issues/2020-09-29/jsonapi_add_and_update_translations_support-2794431-102.patch"
       },
       "drupal/openid_connect_windows_aad": {
         "3169996 - Incorrect configuration schema file": "https://www.drupal.org/files/issues/2020-09-09/openid_connect_windows_aad-schema-update-3169996-3.patch"

--- a/ecms_base/modules/custom/ecms_api/src/EcmsApiBase.php
+++ b/ecms_base/modules/custom/ecms_api/src/EcmsApiBase.php
@@ -225,6 +225,9 @@ abstract class EcmsApiBase {
    *   The full url to the endpoint API.
    */
   protected function getEndpointUrl(Url $url, EntityInterface $entity, string $method): string {
+    $language = $entity->language();
+    $languageEndpoint = $language->getId();
+
     // Get the endpoint for the entity.
     $entityPath = "{$entity->getEntityTypeId()}/{$entity->bundle()}";
 
@@ -232,6 +235,11 @@ abstract class EcmsApiBase {
       $entityPath = "{$entityPath}/{$entity->uuid()}";
     }
     $endPoint = self::API_ENDPOINT;
+
+    // Append the language id if it is not the default language.
+    if (!$language->isDefault()) {
+      return "{$url->toString()}/{$languageEndpoint}/{$endPoint}/{$entityPath}";
+    }
 
     return "{$url->toString()}/{$endPoint}/{$entityPath}";
   }

--- a/ecms_base/modules/custom/ecms_api/tests/src/Unit/EcmsApiBaseTest.php
+++ b/ecms_base/modules/custom/ecms_api/tests/src/Unit/EcmsApiBaseTest.php
@@ -328,6 +328,8 @@ class EcmsApiBaseTest extends UnitTestCase {
    *   The HTTP method to submit.
    * @param int $code
    *   The http status code to mock.
+   * @param bool $defaultLanguage
+   *   Whether the entity has the default language.
    * @param bool $expected
    *   The expected response.
    *

--- a/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.module
+++ b/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.module
@@ -24,3 +24,13 @@ function hook_node_update(EntityInterface $entity): void {
   // Call the syndication service on node update.
   \Drupal::service('ecms_api_publisher.syndicate')->syndicateNode($entity, 'UPDATE');
 }
+
+/**
+ * Implements hook_ENTITY_TYPE_translation_insert() for the node entity.
+ */
+function ecms_api_publisher_node_translation_insert(EntityInterface $translation) {
+  // Call the syndication service on translation insert.
+  // Translation support currently requires the patch from here:
+  // @see: https://www.drupal.org/project/drupal/issues/2794431#comment-13841477
+  \Drupal::service('ecms_api_publisher.syndicate')->syndicateNode($translation, 'UPDATE');
+}

--- a/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.module
+++ b/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.module
@@ -28,7 +28,7 @@ function ecms_api_publisher_node_update(EntityInterface $entity): void {
 /**
  * Implements hook_ENTITY_TYPE_translation_insert() for the node entity.
  */
-function ecms_api_publisher_node_translation_insert(EntityInterface $translation) {
+function ecms_api_publisher_node_translation_insert(EntityInterface $translation): void {
   // Call the syndication service on translation insert.
   // Translation support currently requires the patch from here:
   // @see: https://www.drupal.org/project/drupal/issues/2794431#comment-13841477

--- a/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.module
+++ b/ecms_base/modules/custom/ecms_api_publisher/ecms_api_publisher.module
@@ -20,7 +20,7 @@ function ecms_api_publisher_node_insert(EntityInterface $entity) {
 /**
  * Implements hook_ENTITY_TYPE_update() for the node entity.
  */
-function hook_node_update(EntityInterface $entity): void {
+function ecms_api_publisher_node_update(EntityInterface $entity): void {
   // Call the syndication service on node update.
   \Drupal::service('ecms_api_publisher.syndicate')->syndicateNode($entity, 'UPDATE');
 }

--- a/ecms_base/modules/custom/ecms_api_recipient/config/install/user.role.ecms_api_recipient.yml
+++ b/ecms_base/modules/custom/ecms_api_recipient/config/install/user.role.ecms_api_recipient.yml
@@ -9,3 +9,5 @@ permissions:
   - 'create notification content'
   - 'edit own notification content'
   - 'use editorial transition publish'
+  - 'create content translations'
+  - 'translate notification node'

--- a/ecms_base/modules/custom/ecms_api_recipient/src/Form/EcmsApiRecipientConfigForm.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/src/Form/EcmsApiRecipientConfigForm.php
@@ -162,10 +162,14 @@ class EcmsApiRecipientConfigForm extends ConfigFormBase {
     foreach ($contentTypes as $key => $type) {
       $role->grantPermission("create {$key} content");
       $role->grantPermission("edit own {$key} content");
+      $role->grantPermission("translate {$key} node");
     }
 
     // Grant the publishing permission.
     $role->grantPermission(self::EDITORIAL_PUBLISH);
+
+    // Allow the api user translation permissions.
+    $role->grantPermission('create content translations');
 
     try {
       $role->save();

--- a/ecms_base/modules/custom/ecms_api_recipient/tests/src/Unit/Form/EcmsApiRecipientConfigFormTest.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/tests/src/Unit/Form/EcmsApiRecipientConfigFormTest.php
@@ -216,10 +216,12 @@ class EcmsApiRecipientConfigFormTest extends UnitTestCase {
       ->method('revokePermission')
       ->willReturnSelf();
 
-    $grantCount = (count(self::SELECTED_NODE_TYPES) * 2) + 1;
+    $grantCount = (count(self::SELECTED_NODE_TYPES) * 3) + 2;
+    $grantMap = $this->getGrantMap();
+
     $roleEntity->expects($this->exactly($grantCount))
       ->method('grantPermission')
-      ->willReturnSelf();
+      ->willReturnMap($grantMap);
 
     $roleEntity->expects($this->once())
       ->method('save')
@@ -321,10 +323,12 @@ class EcmsApiRecipientConfigFormTest extends UnitTestCase {
       ->method('revokePermission')
       ->willReturnSelf();
 
-    $grantCount = (count(self::SELECTED_NODE_TYPES) * 2) + 1;
+    $grantCount = (count(self::SELECTED_NODE_TYPES) * 3) + 2;
+    $grantMap = $this->getGrantMap();
+
     $roleEntity->expects($this->exactly($grantCount))
       ->method('grantPermission')
-      ->willReturnSelf();
+      ->willReturnMap($grantMap);
 
     $exception = $this->createMock(EntityStorageException::class);
     $roleEntity->expects($this->once())
@@ -344,6 +348,40 @@ class EcmsApiRecipientConfigFormTest extends UnitTestCase {
 
     $form = [];
     $this->configForm->submitForm($form, $this->formState);
+  }
+
+  /**
+   * Get the permissions expected to be granted to a role.
+   *
+   * @return array
+   *   The array of permissions expected to be granted by a role.
+   */
+  private function getGrantMap(): array {
+    $grantMap = [];
+
+    foreach (self::SELECTED_NODE_TYPES as $key => $value) {
+      $grantMap[] = [
+        "create {$key} content"
+      ];
+
+      $grantMap[] = [
+        "edit own {$key} content"
+      ];
+
+      $grantMap[] = [
+        "translate {$key} node"
+      ];
+    }
+
+    $grantMap[] = [
+      'use editorial transition publish'
+    ];
+
+    $grantMap[] = [
+      'create content translations'
+    ];
+
+    return $grantMap;
   }
 
 }

--- a/ecms_base/modules/custom/ecms_api_recipient/tests/src/Unit/Form/EcmsApiRecipientConfigFormTest.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/tests/src/Unit/Form/EcmsApiRecipientConfigFormTest.php
@@ -361,24 +361,24 @@ class EcmsApiRecipientConfigFormTest extends UnitTestCase {
 
     foreach (self::SELECTED_NODE_TYPES as $key => $value) {
       $grantMap[] = [
-        "create {$key} content"
+        "create {$key} content",
       ];
 
       $grantMap[] = [
-        "edit own {$key} content"
+        "edit own {$key} content",
       ];
 
       $grantMap[] = [
-        "translate {$key} node"
+        "translate {$key} node",
       ];
     }
 
     $grantMap[] = [
-      'use editorial transition publish'
+      'use editorial transition publish',
     ];
 
     $grantMap[] = [
-      'create content translations'
+      'create content translations',
     ];
 
     return $grantMap;


### PR DESCRIPTION
## Summary
This updates the permissions for syndicated content to be posted in different translations. A core patch was required to get [translation support working with JsonAPI](https://www.drupal.org/project/drupal/issues/2794431#comment-13841477), as that is not currently supported. This also converted the original Functional test to an ExistingSite test.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Medium
| Relevant links | [RIG-89](https://thinkoomph.jira.com/browse/rig-89)