### PR TITLE
Add press release topics taxonomy and paragraph fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-87: Added translation support for the publication content type.
 - RIG-88: Added translation support for the speech content type.
 - RIG-22: Added moderated_content_bulk_publish module, installed by default.
+- RIG-94: Added Press Release paragraphs field.
+- RIG-95: Added Press Release Topics taxonomy.
 
 ### Changed
 - RIG-23: Changed from OIDC generic to Windows AAD for authentication.

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -51,6 +51,7 @@ dependencies:
   - quickedit
   - rabbit_hole
   - rh_node
+  - rh_taxonomy
   - responsive_image
   - rdf
   - shortcut

--- a/ecms_base/features/custom/ecms_event/config/install/rabbit_hole.behavior_settings.taxonomy_vocabulary_event_taxonomy.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/rabbit_hole.behavior_settings.taxonomy_vocabulary_event_taxonomy.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.event_taxonomy
+id: taxonomy_vocabulary_event_taxonomy
+action: page_not_found
+allow_override: 0
+redirect: ''
+redirect_code: 301

--- a/ecms_base/features/custom/ecms_person/config/install/rabbit_hole.behavior_settings.taxonomy_vocabulary_person_taxonomy.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/rabbit_hole.behavior_settings.taxonomy_vocabulary_person_taxonomy.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.person_taxonomy
+id: taxonomy_vocabulary_person_taxonomy
+action: page_not_found
+allow_override: 0
+redirect: ''
+redirect_code: 301

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.entity_form_display.node.press_release.default.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.entity_form_display.node.press_release.default.yml
@@ -5,13 +5,16 @@ dependencies:
     - field.field.node.press_release.field_press_release_body
     - field.field.node.press_release.field_press_release_date
     - field.field.node.press_release.field_press_release_links
+    - field.field.node.press_release.field_press_release_paragraphs
     - field.field.node.press_release.field_press_release_source
+    - field.field.node.press_release.field_press_release_topics
     - node.type.press_release
     - workflows.workflow.editorial
   module:
     - content_moderation
     - datetime
     - link
+    - paragraphs
     - path
     - text
 id: node.press_release.default
@@ -49,6 +52,18 @@ content:
     third_party_settings: {  }
     type: link_default
     region: content
+  field_press_release_paragraphs:
+    type: entity_reference_paragraphs
+    weight: 125
+    settings:
+      title: 'Content Component'
+      title_plural: 'Content Components'
+      edit_mode: preview
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: _none
+    third_party_settings: {  }
+    region: content
   field_press_release_source:
     weight: 124
     settings:
@@ -56,6 +71,16 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
+    region: content
+  field_press_release_topics:
+    weight: 126
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
     region: content
   langcode:
     type: language_select

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.entity_view_display.node.press_release.default.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.entity_view_display.node.press_release.default.yml
@@ -5,10 +5,13 @@ dependencies:
     - field.field.node.press_release.field_press_release_body
     - field.field.node.press_release.field_press_release_date
     - field.field.node.press_release.field_press_release_links
+    - field.field.node.press_release.field_press_release_paragraphs
     - field.field.node.press_release.field_press_release_source
+    - field.field.node.press_release.field_press_release_topics
     - node.type.press_release
   module:
     - datetime
+    - entity_reference_revisions
     - link
     - text
     - user
@@ -50,12 +53,29 @@ content:
     third_party_settings: {  }
     type: link
     region: content
+  field_press_release_paragraphs:
+    type: entity_reference_revisions_entity_view
+    weight: 105
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
   field_press_release_source:
     weight: 104
     label: above
     settings: {  }
     third_party_settings: {  }
     type: text_default
+    region: content
+  field_press_release_topics:
+    weight: 106
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   links:
     weight: 100

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.entity_view_display.node.press_release.teaser.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.entity_view_display.node.press_release.teaser.yml
@@ -6,7 +6,9 @@ dependencies:
     - field.field.node.press_release.field_press_release_body
     - field.field.node.press_release.field_press_release_date
     - field.field.node.press_release.field_press_release_links
+    - field.field.node.press_release.field_press_release_paragraphs
     - field.field.node.press_release.field_press_release_source
+    - field.field.node.press_release.field_press_release_topics
     - node.type.press_release
   module:
     - user
@@ -29,5 +31,7 @@ hidden:
   field_press_release_body: true
   field_press_release_date: true
   field_press_release_links: true
+  field_press_release_paragraphs: true
   field_press_release_source: true
+  field_press_release_topics: true
   langcode: true

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_paragraphs.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_paragraphs.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_press_release_paragraphs
+    - node.type.press_release
+  module:
+    - entity_reference_revisions
+id: node.press_release.field_press_release_paragraphs
+field_name: field_press_release_paragraphs
+entity_type: node
+bundle: press_release
+label: 'Press Release Content Components'
+description: 'Add one or more flexible content components.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 1
+    target_bundles: null
+    target_bundles_drag_drop:
+      file_list:
+        weight: 4
+        enabled: false
+      formatted_text:
+        weight: 5
+        enabled: false
+      media_item:
+        weight: 6
+        enabled: false
+field_type: entity_reference_revisions

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_topics.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_topics.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_press_release_topics
+    - node.type.press_release
+    - taxonomy.vocabulary.press_release_topics
+id: node.press_release.field_press_release_topics
+field_name: field_press_release_topics
+entity_type: node
+bundle: press_release
+label: 'Press Release Topics'
+description: 'Add topics to group press releases.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      press_release_topics: press_release_topics
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_press_release_paragraphs.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_press_release_paragraphs.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_press_release_paragraphs
+field_name: field_press_release_paragraphs
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_press_release_topics.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_press_release_topics.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_press_release_topics
+field_name: field_press_release_topics
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_press_release/config/install/language.content_settings.taxonomy_term.press_release_topics.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/language.content_settings.taxonomy_term.press_release_topics.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.press_release_topics
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: taxonomy_term.press_release_topics
+target_entity_type_id: taxonomy_term
+target_bundle: press_release_topics
+default_langcode: site_default
+language_alterable: true

--- a/ecms_base/features/custom/ecms_press_release/config/install/node.type.press_release.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/node.type.press_release.yml
@@ -9,7 +9,7 @@ third_party_settings:
     parent: ''
 name: 'Press release'
 type: press_release
-description: ''
+description: 'Manage press releases.'
 help: ''
 new_revision: true
 preview_mode: 1

--- a/ecms_base/features/custom/ecms_press_release/config/install/rabbit_hole.behavior_settings.node_type_press_release.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/rabbit_hole.behavior_settings.node_type_press_release.yml
@@ -1,6 +1,8 @@
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - node.type.press_release
 id: node_type_press_release
 action: display_page
 allow_override: 1

--- a/ecms_base/features/custom/ecms_press_release/config/install/rabbit_hole.behavior_settings.taxonomy_vocabulary_press_release_topics.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/rabbit_hole.behavior_settings.taxonomy_vocabulary_press_release_topics.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.press_release_topics
+id: taxonomy_vocabulary_press_release_topics
+action: page_not_found
+allow_override: 0
+redirect: ''
+redirect_code: 301

--- a/ecms_base/features/custom/ecms_press_release/config/install/taxonomy.vocabulary.press_release_topics.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/taxonomy.vocabulary.press_release_topics.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Press Release Topics'
+vid: press_release_topics
+description: 'Group press releases by topics.'
+weight: 0

--- a/ecms_base/features/custom/ecms_press_release/ecms_press_release.info.yml
+++ b/ecms_base/features/custom/ecms_press_release/ecms_press_release.info.yml
@@ -7,13 +7,16 @@ dependencies:
   - content_translation
   - datetime
   - ecms_workflow
+  - entity_reference_revisions
   - field
   - language
   - link
   - menu_ui
   - node
+  - paragraphs
   - path
   - rabbit_hole
+  - taxonomy
   - text
   - user
 package: eCMS


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
<!-- Include a summary of your changes that expands upon the title. -->
This adds a new taxonomy for press release topics.
Adds a paragraph reference field to press releases.
Installs rabbit hole taxonomy (rh_taxonomy) by default and adds the default settings for each of the 3 existing taxonomies.


## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | JIRA issue, bug reports, security alerts, etc.
https://thinkoomph.jira.com/browse/RIG-94
https://thinkoomph.jira.com/browse/RIG-95