### PR TITLE
Add Layout Builder Restrictions and configure Landing Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIG-37: Add Layout Builder Restrictions module.
 
 ### Changed
+- RIG-37: Update Landing Page full content display with restricted block types.
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
     "drupal/features": "^3.11",
     "drupal/jsonapi_extras": "^3.16",
     "drupal/layout_builder_modal": "^1.1",
+    "drupal/layout_builder_restrictions": "^2.7",
     "drupal/moderated_content_bulk_publish": "^2.0",
     "drupal/moderation_dashboard": "^1.0",
     "drupal/office_hours": "^1.3",

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -35,6 +35,7 @@ dependencies:
   - language
   - layout_builder
   - layout_builder_modal
+  - layout_builder_restrictions
   - layout_discovery
   - media
   - media_library

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_view_display.node.landing_page.full.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_view_display.node.landing_page.full.yml
@@ -8,6 +8,7 @@ dependencies:
     - node.type.landing_page
   module:
     - layout_builder
+    - layout_builder_restrictions
     - layout_discovery
     - text
     - user
@@ -57,6 +58,25 @@ third_party_settings:
             additional: {  }
             weight: 2
         third_party_settings: {  }
+  layout_builder_restrictions:
+    allowed_block_categories: {  }
+    entity_view_mode_restriction:
+      whitelisted_blocks:
+        'Chaos Tools': {  }
+        'Content fields':
+          - 'field_block:user:user:changed'
+        Forms: {  }
+        Help: {  }
+        'Lists (Views)': {  }
+        Menus: {  }
+        'Moderation Dashboard': {  }
+        'OpenID Connect': {  }
+        System: {  }
+        User: {  }
+        Webform: {  }
+        core: {  }
+      blacklisted_blocks: {  }
+      allowed_layouts: {  }
 id: node.landing_page.full
 targetEntityType: node
 bundle: landing_page

--- a/ecms_base/features/custom/ecms_landing_page/ecms_landing_page.info.yml
+++ b/ecms_base/features/custom/ecms_landing_page/ecms_landing_page.info.yml
@@ -11,6 +11,7 @@ dependencies:
   - field
   - language
   - layout_builder
+  - layout_builder_restrictions
   - layout_discovery
   - menu_ui
   - node


### PR DESCRIPTION
## Summary
This PR add the Layout Builder Restrictions module and configures the Landing page content type with what blocks can be placed.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIG-37