### PR TITLE
Updated the AAD admin group name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-121: Fixed the AAD administrator group name.
 
 ### Security
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -11,8 +11,8 @@ tags:
 
 Authentication is assumed to be managed with a web application created within
 an Azure Active Directory instance. This is done utilizing the [OpenID Connect Microsoft Azure Active Directory client module](https://www.drupal.org/project/openid_connect_windows_aad)
-and a web application that is configured in the Active Directory instance. 
-The ecms_base installation profile will install the OIDC AAD module by default and setup the 
+and a web application that is configured in the Active Directory instance.
+The ecms_base installation profile will install the OIDC AAD module by default and setup the
 connection using REDACTED values.
 
 ## Settings
@@ -40,10 +40,10 @@ URL should be:
 
 ## Drupal Roles
 Groups created in AAD will be strictly mapped to roles in Drupal via the group
-name, and the role name. 
+name, and the role name.
 
 ### Role Assumptions
-It is to be assumed that the AAD group `Drupal Admin` will be mapped to the Drupal role
+It is to be assumed that the AAD group `Drupal_Admin` will be mapped to the Drupal role
 titled `Drupal Admin`. If a user authenticates and has this group, the user will
 be allowed to administer _ALL SITES_ in the system.
 
@@ -51,7 +51,7 @@ be allowed to administer _ALL SITES_ in the system.
 Site access will be determined by AAD role identified by the site's URI.
 Any user who authenticates through AAD and is NOT in the AAD group `Drupal Admin`
 will be required to have a group name that matches domain name of the site.
-If the user does not have a group with the domain name of the site, they will be denied access. 
+If the user does not have a group with the domain name of the site, they will be denied access.
 
 ## Azure Active Directory Application Configuration
 In order to create the necessary AAD application one must:
@@ -65,7 +65,7 @@ In order to create the necessary AAD application one must:
    (likely Single tenant).
 8. Add an initial `Web` redirect URI pointing to a production URI:
    https://new.website.com/openid-connect/windows_aad
-9. Copy the `Application (client) ID`   
+9. Copy the `Application (client) ID`
 9. Browse to `Endpoints` and copy the following values:
      - `OAuth 2.0 authorization endpoint (v1)`
      - `OAuth 2.0 token endpoint (v1)`
@@ -80,8 +80,8 @@ In order to create the necessary AAD application one must:
          - Directory.Read.All
      - Save these new API permissions
      - Grant Admin Approval for the new API permissions.
-12. Save the copied values to the `secrets.settings.php` file on the ACSF environments. 
+12. Save the copied values to the `secrets.settings.php` file on the ACSF environments.
 
-     
+
 
 

--- a/ecms_base/config/install/user.role.drupal_admin.yml
+++ b/ecms_base/config/install/user.role.drupal_admin.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: drupal_admin
-label: Drupal Admin
+label: Drupal_Admin
 weight: 2
 is_admin: true
 permissions: {  }

--- a/ecms_base/ecms_base.post_update.php
+++ b/ecms_base/ecms_base.post_update.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * ecms_base.post_update.php
+ */
+
+declare(strict_types = 1);
+
+use Drupal\Core\Entity\EntityStorageException;
+
+/**
+ * Change the admin role title to "Drupal_Admin".
+ */
+function ecms_base_post_update_change_admin_role_title(&$sandbox) {
+
+  /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entityManager */
+  $entityManager = \Drupal::service('entity_type.manager');
+
+  $storage = $entityManager->getStorage('user_role');
+
+  /** @var \Drupal\user\RoleInterface $adminRole */
+  $adminRole = $storage->load('drupal_admin');
+
+  if (empty($adminRole)) {
+    return;
+  }
+
+  $adminRole->set('label', 'Drupal_Admin');
+
+  try {
+    $adminRole->save();
+  }
+  catch (EntityStorageException $e) {
+    // Trap any errors.
+  }
+}

--- a/ecms_base/modules/custom/ecms_authentication/src/EcmsUserAuthentication.php
+++ b/ecms_base/modules/custom/ecms_authentication/src/EcmsUserAuthentication.php
@@ -19,7 +19,7 @@ class EcmsUserAuthentication {
   /**
    * Constant of the administrator group/role.
    */
-  const DRUPAL_ADMINISTRATOR = 'Drupal Admin';
+  const DRUPAL_ADMINISTRATOR = 'Drupal_Admin';
 
   /**
    * The request_stack service.

--- a/ecms_base/modules/custom/ecms_authentication/tests/src/Unit/EcmsUserAuthenticationTest.php
+++ b/ecms_base/modules/custom/ecms_authentication/tests/src/Unit/EcmsUserAuthenticationTest.php
@@ -27,7 +27,7 @@ class EcmsUserAuthenticationTest extends UnitTestCase {
   /**
    * The admin group constant.
    */
-  const ADMIN_GROUP = 'Drupal Admin';
+  const ADMIN_GROUP = 'Drupal_Admin';
 
   /**
    * Mock of the request_stack service.
@@ -56,7 +56,7 @@ class EcmsUserAuthenticationTest extends UnitTestCase {
    */
   public function testCheckGroupAccess(array $groups, bool $expected): void {
 
-    if (in_array(self::ADMIN_GROUP, $groups)) {
+    if (in_array(self::ADMIN_GROUP, $groups, TRUE)) {
       $this->requestStack->expects($this->never())
         ->method('getCurrentRequest');
     }
@@ -90,7 +90,7 @@ class EcmsUserAuthenticationTest extends UnitTestCase {
       'test1' => [
         [
           'test group one',
-          'test.subdomain.com',
+          self::HOST,
           'Drupal Admin',
         ],
         TRUE,
@@ -102,7 +102,7 @@ class EcmsUserAuthenticationTest extends UnitTestCase {
           'test.invaliddomainnumbertwo.com',
           'oomphinc.com',
         ],
-        TRUE,
+        FALSE,
       ],
       'test3' => [
         [
@@ -114,7 +114,7 @@ class EcmsUserAuthenticationTest extends UnitTestCase {
       ],
       'test4' => [
         [
-          'test.subdomain.com',
+          self::HOST,
           'test.invaliddomainnumbertwo.com',
           'oomphinc.com',
         ],
@@ -122,6 +122,48 @@ class EcmsUserAuthenticationTest extends UnitTestCase {
       ],
       'test5' => [
         [],
+        FALSE,
+      ],
+      'test6' => [
+        [
+          'test group one',
+          self::HOST,
+          'Drupal_Admin',
+        ],
+        TRUE,
+      ],
+      'test7' => [
+        [
+          'Drupal_Admin',
+          'test.invaliddomain.com',
+          'test.invaliddomainnumbertwo.com',
+          'oomphinc.com',
+        ],
+        TRUE,
+      ],
+      'test8' => [
+        [
+          'test group one',
+          self::HOST,
+          'drupal_admin',
+        ],
+        TRUE,
+      ],
+      'test9' => [
+        [
+          'DrUpAl_AdMiN',
+          'test.invaliddomain.com',
+          'test.invaliddomainnumbertwo.com',
+          'oomphinc.com',
+        ],
+        FALSE,
+      ],
+      'test10' => [
+        [
+          'test group one',
+          $this->randomMachineName(),
+          'drupal_admin',
+        ],
         FALSE,
       ],
     ];


### PR DESCRIPTION
## Summary
This updates the admin group name to 'Drupal_Admin'.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-121](https://thinkoomph.jira.com/browse/rig-121)