### PR TITLE
Add the scheduler module and config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-37: Add accordion and menu twig templates.
 - RIG-37: Added compiled pattern lab js import.
 - RIG-37: Added main navigation block to primary menu region.
+- RIG-91: Installation & configuration of scheduler module for all content types.
 
 ### Changed
 - RIG-37: Update Landing Page full content display with restricted block types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - RIG-82: Added notification retrieval from the hub on installation.
 - RIG-124: Added the external links module and configuration.
+- RIG-91: Installation & configuration of scheduler module for all content types.
 
 ### Changed
 
@@ -31,7 +32,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-37: Add accordion and menu twig templates.
 - RIG-37: Added compiled pattern lab js import.
 - RIG-37: Added main navigation block to primary menu region.
-- RIG-91: Installation & configuration of scheduler module for all content types.
 
 ### Changed
 - RIG-37: Update Landing Page full content display with restricted block types.

--- a/ecms_base/config/install/scheduler.settings.yml
+++ b/ecms_base/config/install/scheduler.settings.yml
@@ -1,0 +1,23 @@
+allow_date_only: false
+date_format: 'Y-m-d H:i:s'
+date_letters: djmnFMyY
+date_only_format: Y-m-d
+default_expand_fieldset: when_required
+default_fields_display_mode: vertical_tab
+default_publish_enable: false
+default_publish_past_date: error
+default_publish_past_date_created: false
+default_publish_required: false
+default_publish_revision: false
+default_publish_touch: false
+default_show_message_after_update: true
+default_time: '00:00:00'
+default_unpublish_enable: false
+default_unpublish_required: false
+default_unpublish_revision: false
+lightweight_cron_access_key: 5477a3f431f092c66d75
+log: true
+time_letters: hHgGisaA
+time_only_format: 'H:i:s'
+_core:
+  default_config_hash: r4UxhkKGliupcWiUEXcB_1LFQjOC415qJnxjGLVBU1Y

--- a/ecms_base/config/install/scheduler.settings.yml
+++ b/ecms_base/config/install/scheduler.settings.yml
@@ -19,5 +19,3 @@ lightweight_cron_access_key: 5477a3f431f092c66d75
 log: true
 time_letters: hHgGisaA
 time_only_format: 'H:i:s'
-_core:
-  default_config_hash: r4UxhkKGliupcWiUEXcB_1LFQjOC415qJnxjGLVBU1Y

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -57,6 +57,7 @@ dependencies:
   - rh_taxonomy
   - responsive_image
   - rdf
+  - scheduler
   - shortcut
   - taxonomy
   - toolbar

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -22,6 +22,7 @@ dependencies:
   - content_moderation_notifications
   - contextual
   - datetime
+  - dblog
   - dynamic_page_cache
   - editor
   - entity_reference_revisions

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -50,20 +50,4 @@ function ecms_base_install() {
 
   $shortcut->save();
 
-  // Set the workflow and permissions for all content types.
-  $types = \Drupal::entityTypeManager()
-    ->getStorage('node_type')
-    ->loadMultiple();
-
-  foreach ($types as $type) {
-    // Notifications are managed using the ecms_api module.
-    if ($type === 'notification') {
-      continue;
-    }
-
-    // Call the workflow service to update configuration.
-    \Drupal::service('ecms_workflow.bundle_create')
-      ->addContentTypeToWorkflow($type->id());
-  }
-
 }

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -50,4 +50,8 @@ function ecms_base_install() {
 
   $shortcut->save();
 
+  // Call the workflow service to update configuration.
+  \Drupal::service('ecms_workflow.bundle_create')
+    ->assignWorkflowToActiveTypes();
+
 }

--- a/ecms_base/ecms_base.profile
+++ b/ecms_base/ecms_base.profile
@@ -10,7 +10,7 @@ declare(strict_types = 1);
 use Drupal\Core\Config\FileStorage;
 
 /**
- * Update Basic HTML configuration and add scheudler settings.
+ * Update Basic HTML configuration.
  */
 function ecms_base_update_9001(array &$sandbox): void {
   $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');

--- a/ecms_base/ecms_base.profile
+++ b/ecms_base/ecms_base.profile
@@ -46,19 +46,8 @@ function ecms_base_update_9013(array &$sandbox): void {
   // Make sure the scheduler module is installed.
   \Drupal::service('module_installer')->install(['scheduler']);
 
-  // Assign the scheduler settings to existing content types.
-  $types = \Drupal::entityTypeManager()
-    ->getStorage('node_type')
-    ->loadMultiple();
+  // Call the workflow service to update configuration.
+  \Drupal::service('ecms_workflow.bundle_create')
+    ->assignWorkflowToActiveTypes();
 
-  foreach ($types as $type) {
-    // Notifications are managed using the ecms_api module.
-    if ($type->id() === 'notification') {
-      continue;
-    }
-
-    // Call the workflow service to update configuration.
-    \Drupal::service('ecms_workflow.bundle_create')
-      ->addContentTypeToWorkflow($type->id());
-  }
 }

--- a/ecms_base/ecms_base.profile
+++ b/ecms_base/ecms_base.profile
@@ -43,6 +43,9 @@ function ecms_base_update_9013(array &$sandbox): void {
   // Change the extlink settings to use what is in ecms_base profile.
   $active_storage->write('extlink.settings', $install_source->read('extlink.settings'));
 
+  // Make sure the scheduler module is installed.
+  \Drupal::service('module_installer')->install(['scheduler']);
+
   // Assign the scheduler settings to existing content types.
   $types = \Drupal::entityTypeManager()
     ->getStorage('node_type')

--- a/ecms_base/ecms_base.profile
+++ b/ecms_base/ecms_base.profile
@@ -10,7 +10,7 @@ declare(strict_types = 1);
 use Drupal\Core\Config\FileStorage;
 
 /**
- * Update Basic HTML configuration to match the install config.
+ * Update Basic HTML configuration and add scheudler settings.
  */
 function ecms_base_update_9001(array &$sandbox): void {
   $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
@@ -42,4 +42,20 @@ function ecms_base_update_9013(array &$sandbox): void {
 
   // Change the extlink settings to use what is in ecms_base profile.
   $active_storage->write('extlink.settings', $install_source->read('extlink.settings'));
+
+  // Assign the scheduler settings to existing content types.
+  $types = \Drupal::entityTypeManager()
+    ->getStorage('node_type')
+    ->loadMultiple();
+
+  foreach ($types as $type) {
+    // Notifications are managed using the ecms_api module.
+    if ($type->id() === 'notification') {
+      continue;
+    }
+
+    // Call the workflow service to update configuration.
+    \Drupal::service('ecms_workflow.bundle_create')
+      ->addContentTypeToWorkflow($type->id());
+  }
 }

--- a/ecms_base/features/custom/ecms_basic_page/ecms_basic_page.info.yml
+++ b/ecms_base/features/custom/ecms_basic_page/ecms_basic_page.info.yml
@@ -15,6 +15,7 @@ dependencies:
   - paragraphs
   - path
   - rabbit_hole
+  - scheduler
   - text
   - user
 package: eCMS

--- a/ecms_base/features/custom/ecms_event/ecms_event.info.yml
+++ b/ecms_base/features/custom/ecms_event/ecms_event.info.yml
@@ -16,6 +16,7 @@ dependencies:
   - node
   - path
   - rabbit_hole
+  - scheduler
   - smart_date
   - taxonomy
   - text

--- a/ecms_base/features/custom/ecms_executive_orders/ecms_executive_orders.info.yml
+++ b/ecms_base/features/custom/ecms_executive_orders/ecms_executive_orders.info.yml
@@ -17,6 +17,7 @@ dependencies:
   - path
   - rabbit_hole
   - rh_node
+  - scheduler
   - user
 version: 9.x-1.0
 package: eCMS

--- a/ecms_base/features/custom/ecms_hotel/ecms_hotel.info.yml
+++ b/ecms_base/features/custom/ecms_hotel/ecms_hotel.info.yml
@@ -17,6 +17,7 @@ dependencies:
   - node
   - path
   - rabbit_hole
+  - scheduler
   - telephone
   - text
   - user

--- a/ecms_base/features/custom/ecms_landing_page/ecms_landing_page.info.yml
+++ b/ecms_base/features/custom/ecms_landing_page/ecms_landing_page.info.yml
@@ -18,6 +18,7 @@ dependencies:
   - paragraphs
   - path
   - rabbit_hole
+  - scheduler
   - text
   - user
 package: eCMS

--- a/ecms_base/features/custom/ecms_location/ecms_location.info.yml
+++ b/ecms_base/features/custom/ecms_location/ecms_location.info.yml
@@ -14,6 +14,7 @@ dependencies:
   - office_hours
   - path
   - rabbit_hole
+  - scheduler
   - telephone
   - text
   - user

--- a/ecms_base/features/custom/ecms_person/ecms_person.info.yml
+++ b/ecms_base/features/custom/ecms_person/ecms_person.info.yml
@@ -17,6 +17,7 @@ dependencies:
   - node
   - path
   - rabbit_hole
+  - scheduler
   - taxonomy
   - telephone
   - token

--- a/ecms_base/features/custom/ecms_press_release/ecms_press_release.info.yml
+++ b/ecms_base/features/custom/ecms_press_release/ecms_press_release.info.yml
@@ -17,6 +17,7 @@ dependencies:
   - paragraphs
   - path
   - rabbit_hole
+  - scheduler
   - taxonomy
   - text
   - user

--- a/ecms_base/features/custom/ecms_projects/ecms_projects.info.yml
+++ b/ecms_base/features/custom/ecms_projects/ecms_projects.info.yml
@@ -15,6 +15,7 @@ dependencies:
   - node
   - path
   - rabbit_hole
+  - scheduler
   - taxonomy
   - text
   - user

--- a/ecms_base/features/custom/ecms_promotions/ecms_promotions.info.yml
+++ b/ecms_base/features/custom/ecms_promotions/ecms_promotions.info.yml
@@ -16,6 +16,7 @@ dependencies:
   - node
   - path
   - rabbit_hole
+  - scheduler
   - text
   - user
 package: eCMS

--- a/ecms_base/features/custom/ecms_publications/ecms_publications.info.yml
+++ b/ecms_base/features/custom/ecms_publications/ecms_publications.info.yml
@@ -18,6 +18,7 @@ dependencies:
   - paragraphs
   - path
   - rh_node
+  - scheduler
   - taxonomy
   - user
 version: 9.x-1.0

--- a/ecms_base/features/custom/ecms_speeches/ecms_speeches.info.yml
+++ b/ecms_base/features/custom/ecms_speeches/ecms_speeches.info.yml
@@ -12,6 +12,7 @@ dependencies:
   - menu_ui
   - node
   - path
+  - scheduler
   - user
 version: 9.x-1.0
 package: eCMS

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -65,7 +65,7 @@ class EcmsWorkflowBundleCreate {
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   private function addSchedulerSettings(string $contentType): void {
-    $type = \Drupal::entityTypeManager()
+    $type = $this->entityTypeManager
       ->getStorage('node_type')
       ->load($contentType);
 
@@ -183,7 +183,7 @@ class EcmsWorkflowBundleCreate {
    */
   public function assignWorkflowToActiveTypes(): void {
 
-    $types = \Drupal::entityTypeManager()
+    $types = $this->entityTypeManager
       ->getStorage('node_type')
       ->loadMultiple();
     foreach ($types as $type) {

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -35,6 +35,11 @@ class EcmsWorkflowBundleCreate {
   const WORKFLOW_ID = 'editorial';
 
   /**
+   * Array of content types to exclude.
+   */
+  const EXCLUDED_TYPES = ['notification'];
+
+  /**
    * The entity_type.manager service.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
@@ -167,6 +172,28 @@ class EcmsWorkflowBundleCreate {
     }
     catch (EntityStorageException $e) {
       return;
+    }
+
+  }
+
+  /**
+   * Apply workflow, schedule, and permissions to active content types.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function assignWorkflowToActiveTypes(): void {
+
+    $types = \Drupal::entityTypeManager()
+      ->getStorage('node_type')
+      ->loadMultiple();
+    foreach ($types as $type) {
+      // Skip if this is an excluded type.
+      if (in_array($type->id(), self::EXCLUDED_TYPES)) {
+        continue;
+      }
+
+      // Call the workflow service to update configuration.
+      $this->addContentTypeToWorkflow($type->id());
     }
 
   }

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -52,6 +52,40 @@ class EcmsWorkflowBundleCreate {
   }
 
   /**
+   * Add scheduler default settings to new content type.
+   *
+   * @param string $contentType
+   *   The machine name of the new content type.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  private function addSchedulerSettings(string $contentType): void {
+    $type = \Drupal::entityTypeManager()
+      ->getStorage('node_type')
+      ->load($contentType);
+
+    $type->setThirdPartySetting('scheduler', 'expand_fieldset', 'when_required');
+    $type->setThirdPartySetting('scheduler', 'fields_display_mode', 'fieldset');
+    $type->setThirdPartySetting('scheduler', 'publish_enable', 1);
+    $type->setThirdPartySetting('scheduler', 'publish_past_date', 0);
+    $type->setThirdPartySetting('scheduler', 'publish_past_date_created', 'error');
+    $type->setThirdPartySetting('scheduler', 'publish_required', 0);
+    $type->setThirdPartySetting('scheduler', 'publish_revision', 0);
+    $type->setThirdPartySetting('scheduler', 'publish_touch', 0);
+    $type->setThirdPartySetting('scheduler', 'show_message_after_update', 1);
+    $type->setThirdPartySetting('scheduler', 'unpublish_enable', 1);
+    $type->setThirdPartySetting('scheduler', 'unpublish_required', 0);
+    $type->setThirdPartySetting('scheduler', 'unpublish_revision', 0);
+
+    try {
+      $type->save();
+    }
+    catch (EntityStorageException $e) {
+      return;
+    }
+  }
+
+  /**
    * Grant node permissions to the author and publisher roles.
    *
    * @param string $contentType
@@ -111,6 +145,7 @@ class EcmsWorkflowBundleCreate {
   public function addContentTypeToWorkflow(string $contentType): void {
 
     $this->setRolePermissions($contentType);
+    $this->addSchedulerSettings($contentType);
 
     // Assign the new content type to the editorial workflow.
     /** @var \Drupal\workflows\WorkflowInterface $workflow */


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
<!-- Include a summary of your changes that expands upon the title. -->
Add the scheduler module by default with automatic assignment for new content types. Using the existing workflow service to accomplish this since this needs to happen for all new content types (except notifications).

Adds the scheduler module as a dependency for all applicable content types (features).

Enables dblog by default for now.

Removes the workflow assignment loop from the .install hook, since this is happening via the bundle_insert hook so we were running it twice. Also, due to a code error, the notification content type was previously being assigned to the workflow with other content types, which we don't want.

Updates the update_9001 hook to add the workflow assignment so existing sites will receive the scheduler work. This includes installation of the scheduler module in said hook.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Medium
| Relevant links | https://thinkoomph.jira.com/browse/RIG-91