### PR TITLE
Fix the Active Directory strict role mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-136: Fixed the AAD login removing manually applied roles.
 
 ### Security
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -39,17 +39,23 @@ URL should be:
 `https://new.website.com/openid-connect/windows_aad`
 
 ## Drupal Roles
-Groups created in AAD will be strictly mapped to roles in Drupal via the group
-name, and the role name.
+Groups created in AAD will be mapped to roles in Drupal via the group
+name, and the role name _only if_ those roles exist in Drupal. Any Drupal role
+that is manually applied to a user will remain the next time a user
+authenticates with AAD. The only role that will _not remain_ is the
+`Drupal_Admin` role. If a user is manually given the `Drupal_Admin` role
+in Drupal and the user does not have that group in AAD. On their next login,
+they will be removed from the `Drupal_Admin` role. All other Drupal roles
+will remain with the account.
 
 ### Role Assumptions
 It is to be assumed that the AAD group `Drupal_Admin` will be mapped to the Drupal role
-titled `Drupal Admin`. If a user authenticates and has this group, the user will
+titled `Drupal_Admin`. If a user authenticates and has this group, the user will
 be allowed to administer _ALL SITES_ in the system.
 
 ### Site access
 Site access will be determined by AAD role identified by the site's URI.
-Any user who authenticates through AAD and is NOT in the AAD group `Drupal Admin`
+Any user who authenticates through AAD and is NOT in the AAD group `Drupal_Admin`
 will be required to have a group name that matches domain name of the site.
 If the user does not have a group with the domain name of the site, they will be denied access.
 

--- a/ecms_base/config/install/openid_connect.settings.windows_aad.yml
+++ b/ecms_base/config/install/openid_connect.settings.windows_aad.yml
@@ -9,7 +9,7 @@ settings:
   group_mapping:
     method: '0'
     mappings: ''
-    strict: 1
+    strict: 0
   userinfo_graph_api_wa: '1'
   userinfo_endpoint_wa: 'https://graph.microsoft.com/v1.0/me/memberOf'
   userinfo_graph_api_use_other_mails: 0

--- a/ecms_base/ecms_base.post_update.php
+++ b/ecms_base/ecms_base.post_update.php
@@ -7,8 +7,6 @@
 
 declare(strict_types = 1);
 
-use Drupal\Core\Entity\EntityStorageException;
-
 /**
  * Change the admin role title to "Drupal_Admin".
  */
@@ -121,4 +119,16 @@ function ecms_base_post_update_013_add_new_permissions_to_site_admin(&$sandbox):
       return;
     }
   }
+}
+
+/**
+ * Change the OIDC group mapping setting.
+ */
+function ecms_base_post_update_014_update_oidc_settings(&$sandbox): void {
+  /** @var \Drupal\Core\Config\ConfigFactoryInterface $configFactory */
+  $configFactory = \Drupal::service('config.factory');
+
+  $oidcConfig = $configFactory->getEditable('openid_connect.settings.windows_aad');
+  $oidcConfig->set('settings.group_mapping.strict', FALSE);
+  $oidcConfig->save();
 }

--- a/ecms_base/ecms_base.post_update.php
+++ b/ecms_base/ecms_base.post_update.php
@@ -7,6 +7,8 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Entity\EntityStorageException;
+
 /**
  * Change the admin role title to "Drupal_Admin".
  */

--- a/ecms_base/modules/custom/ecms_authentication/ecms_authentication.module
+++ b/ecms_base/modules/custom/ecms_authentication/ecms_authentication.module
@@ -7,6 +7,8 @@
 
 declare(strict_types = 1);
 
+use Drupal\user\UserInterface;
+
 /**
  * Implements hook_openid_connect_pre_authorize().
  */
@@ -19,4 +21,20 @@ function ecms_authentication_openid_connect_pre_authorize($account, array $conte
   }
 
   return \Drupal::service('ecms_user_authentication')->checkGroupAccess($userGroups);
+}
+
+/**
+ * Implements hook_openid_connect_userinfo_save().
+ */
+function ecms_authentication_openid_connect_userinfo_save(UserInterface $account, array $context): void {
+  if ($context['plugin_id'] !== 'windows_aad' || (!isset($context['user_data']['groups']) && !isset($context['userinfo']['groups']['value']))) {
+    return;
+  }
+
+  // Get the active directory groups from the claim.
+  $userAadGroups = array_column($context['userinfo']['groups']['value'], 'displayName');
+
+  // Remove the drupal_admin group if the user doesn't belong to that group
+  // in active directory.
+  \Drupal::service('ecms_user_authentication')->removeAdminGroup($userAadGroups, $account);
 }

--- a/ecms_base/modules/custom/ecms_authentication/tests/src/Unit/EcmsUserAuthenticationTest.php
+++ b/ecms_base/modules/custom/ecms_authentication/tests/src/Unit/EcmsUserAuthenticationTest.php
@@ -178,8 +178,10 @@ class EcmsUserAuthenticationTest extends UnitTestCase {
    *   Whether the AAD has the admin group.
    * @param bool $hasDrupalAdminRole
    *   Whether the Drupal user has the admin group.
+   * @param bool $exception
+   *   Whether a storage exception should be expected.
    *
-   * @dataProvider  dataProviderForTestRemoveAdminGroup
+   * @dataProvider dataProviderForTestRemoveAdminGroup
    */
   public function testRemoveAdminGroup(bool $hasAadAdminGroup, bool $hasDrupalAdminRole, bool $exception): void {
     $aadGroups = [

--- a/ecms_base/modules/custom/ecms_authentication/tests/src/Unit/EcmsUserAuthenticationTest.php
+++ b/ecms_base/modules/custom/ecms_authentication/tests/src/Unit/EcmsUserAuthenticationTest.php
@@ -4,8 +4,10 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\ecms_authentication\Unit;
 
+use Drupal\Core\Entity\EntityStorageException;
 use Drupal\ecms_authentication\EcmsUserAuthentication;
 use Drupal\Tests\UnitTestCase;
+use Drupal\user\UserInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -166,6 +168,103 @@ class EcmsUserAuthenticationTest extends UnitTestCase {
         ],
         FALSE,
       ],
+    ];
+  }
+
+  /**
+   * Test the removeAdminGroup method.
+   *
+   * @param bool $hasAadAdminGroup
+   *   Whether the AAD has the admin group.
+   * @param bool $hasDrupalAdminRole
+   *   Whether the Drupal user has the admin group.
+   *
+   * @dataProvider  dataProviderForTestRemoveAdminGroup
+   */
+  public function testRemoveAdminGroup(bool $hasAadAdminGroup, bool $hasDrupalAdminRole, bool $exception): void {
+    $aadGroups = [
+      $this->randomMachineName(),
+      $this->randomMachineName(),
+    ];
+
+    if ($hasAadAdminGroup) {
+      $aadGroups[] = self::ADMIN_GROUP;
+    }
+
+    $userRoles = [
+      $this->randomMachineName(),
+      $this->randomMachineName(),
+    ];
+
+    if ($hasDrupalAdminRole) {
+      $userRoles[] = strtolower(self::ADMIN_GROUP);
+    }
+
+    $account = $this->createMock(UserInterface::class);
+
+    // If the admin group is not available in AAD.
+    if (!$hasAadAdminGroup) {
+      $account->expects($this->once())
+        ->method('getRoles')
+        ->with(TRUE)
+        ->willReturn($userRoles);
+
+      if ($hasDrupalAdminRole) {
+        $account->expects($this->once())
+          ->method('removeRole')
+          ->with(strtolower(self::ADMIN_GROUP))
+          ->willReturnSelf();
+
+        if ($exception) {
+          $exception = $this->createMock(EntityStorageException::class);
+          $account->expects($this->once())
+            ->method('save')
+            ->willThrowException($exception);
+        }
+        else {
+          $account->expects($this->once())
+            ->method('save')
+            ->willReturnSelf();
+        }
+
+      }
+      else {
+        $account->expects($this->never())
+          ->method('removeRole')
+          ->with(strtolower(self::ADMIN_GROUP))
+          ->willReturnSelf();
+
+        $account->expects($this->never())
+          ->method('save')
+          ->willReturnSelf();
+      }
+    }
+    else {
+      $account->expects($this->never())
+        ->method('getRoles')
+        ->with(TRUE)
+        ->willReturn($userRoles);
+    }
+
+    // Setup our new class to test.
+    $ecmsUserAuthentication = new EcmsUserAuthentication($this->requestStack);
+
+    $ecmsUserAuthentication->removeAdminGroup($aadGroups, $account);
+  }
+
+  /**
+   * Data provider for the testRemoveAdminGroup method.
+   *
+   * @return array
+   *   Array or parameters to pass to testRemoveAdminGroup.
+   */
+  public function dataProviderForTestRemoveAdminGroup(): array {
+    return [
+      'test1' => [FALSE, FALSE, FALSE],
+      'test2' => [FALSE, TRUE, FALSE],
+      'test3' => [TRUE, TRUE, FALSE],
+      'test4' => [TRUE, FALSE, FALSE],
+      'test5' => [FALSE, TRUE, TRUE],
     ];
   }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -57,6 +57,7 @@
                 <directory>/app/web/profiles/contrib/ecms_profile/*/modules/custom/*/tests</directory>
                 <directory>/app/web/profiles/contrib/ecms_profile/*/tests</directory>
                 <directory>/app/web/profiles/contrib/ecms_profile/tests</directory>
+                <directory>/app/web/profiles/contrib/ecms_profile/*/features/custom/*/tests</directory>
             </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
## Summary
Active directory settings were setup as strict, which was removing manually applied roles upon login. This fixes the login to leave manually applied roles alone _except_ for the Drupal_Admin, which is the only group that should be maintained within AAD. 

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-136](https://thinkoomph.jira.com/browse/rig-136)