### PR TITLE
Remove jQuery from eCMS and change layout templates locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Changed
 - RIG-67: Changed promotion body field to use plain text.
+- RIG-67: Changed location of layout templates in PL.
 
 ### Deprecated
 
 ### Removed
+- RIG-67: Removed jQuery from eCMS theme.
 
 ### Fixed
 - RIG-67: Fixed issue of promotional images using a duplicate source field.

--- a/ecms_base/themes/custom/ecms/ecms.libraries.yml
+++ b/ecms_base/themes/custom/ecms/ecms.libraries.yml
@@ -7,7 +7,6 @@ global-styling:
     ecms_patternlab/dist/js/pattern-lab-compiled.js: {}
   dependencies:
     - core/drupal
-    - core/jquery
 
 header-scripts:
   version: 1

--- a/ecms_base/themes/custom/ecms/templates/layout/layout--four-column.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/layout/layout--four-column.html.twig
@@ -12,5 +12,5 @@
 #}
 
 {% if content|render %}
-  {% include "@molecules/01-layout/four-column.twig" %}
+  {% include "@templates/00-layout/four-column.twig" %}
 {% endif %}

--- a/ecms_base/themes/custom/ecms/templates/layout/layout--one-column.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/layout/layout--one-column.html.twig
@@ -12,5 +12,5 @@
 #}
 
 {% if content|render %}
-  {% include "@molecules/01-layout/one-column.twig" %}
+  {% include "@templates/00-layout/one-column.twig" %}
 {% endif %}

--- a/ecms_base/themes/custom/ecms/templates/layout/layout--three-column.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/layout/layout--three-column.html.twig
@@ -11,5 +11,5 @@
  */
 #}
 {% if content|render %}
-  {% include "@molecules/01-layout/three-column.twig" %}
+  {% include "@templates/00-layout/three-column.twig" %}
 {% endif %}

--- a/ecms_base/themes/custom/ecms/templates/layout/layout--two-column.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/layout/layout--two-column.html.twig
@@ -11,5 +11,5 @@
  */
 #}
 {% if content|render %}
-	{% include "@molecules/01-layout/two-column.twig" %}
+	{% include "@templates/00-layout/two-column.twig" %}
 {% endif %}


### PR DESCRIPTION
## Summary
This is a small PR that removes jQuery and updates some twig template locations in PL.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes/
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIG-67