### PR TITLE
Social navigation form alterations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIG-142: Added social navigation automatic class functionality.
 
 ### Changed
 

--- a/ecms_base/config/install/system.menu.social-navigation.yml
+++ b/ecms_base/config/install/system.menu.social-navigation.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: social-navigation
+label: 'Social navigation'
+description: ''
+locked: false

--- a/ecms_base/ecms_base.profile
+++ b/ecms_base/ecms_base.profile
@@ -116,3 +116,19 @@ function ecms_base_update_9017(array &$sandbox): void {
   // Enable eCMS distribution module.
   \Drupal::service('module_installer')->install($modules_to_install);
 }
+
+/**
+ * Updates to run for the 0.1.9 tag.
+ */
+function ecms_base_update_9019(array &$sandbox): void {
+  $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
+
+  /** @var \Drupal\Core\Config\FileStorage $install_source */
+  $install_source = new FileStorage($path . "/config/install/");
+
+  /** @var \Drupal\Core\Config\StorageInterface $active_storage */
+  $active_storage = \Drupal::service('config.storage');
+
+  // Add the social navigation menu.
+  $active_storage->write('system.menu.social-navigation', $install_source->read('system.menu.social-navigation'));
+}

--- a/ecms_base/modules/custom/ecms_distribution/README.md
+++ b/ecms_base/modules/custom/ecms_distribution/README.md
@@ -1,0 +1,25 @@
+# ECMS Distribution
+
+The ecms_distribution module can be used to install required configuration ahead
+of the actual profile configuration installation. This is especially useful when
+a feature module requires configuration. Configuration is installed in the
+following order:
+
+1. profile dependencies: See the dependencies key in ecms_base.info.yml
+2. profile installations: See the install key in ecms_base.info.yml
+3. profile configuration: See configuration in ecms_base/config/install
+
+So, if a module that is installed by the profile has configuration dependencies
+that need to be installed before the actual profile's configuration, that
+configuration can be placed in this module.
+
+## Other functionality
+
+### Social Navigation
+The ecms_distribution.module was used to manage the social navigation required
+alterations. See: RIG-142.
+
+The menu link form is being form altered to show a pre-defined list of social
+navigation that the ecms_patternlab theme defines. This will replace the
+title field of the `social-navigation` menu items and will add attributes
+to the links in that menu which will relate to icons that the theme provides.

--- a/ecms_base/modules/custom/ecms_distribution/ecms_distribution.module
+++ b/ecms_base/modules/custom/ecms_distribution/ecms_distribution.module
@@ -1,0 +1,241 @@
+<?php
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Get the social configuration from pattern lab if available.
+ *
+ * @return array|null
+ *   The available social navigation options, or null if an error.
+ *
+ */
+function get_patternlab_social_source(): ?array {
+  $return = [];
+  /** @var \Drupal\Core\Extension\ThemeHandler $themeHandler */
+  $themeHandler = \Drupal::service('theme_handler');
+
+  $defaultTheme = $themeHandler->getDefault();
+
+  $path = drupal_get_path('theme', $defaultTheme);
+
+  // If the source file doesn't exist, ignore the form alteration.
+  if (!file_exists("{$path}/ecms_patternlab/source/_data/social-config.json")) {
+    return NULL;
+  }
+
+  $json = json_decode(file_get_contents("{$path}/ecms_patternlab/source/_data/social-config.json"));
+
+  if (!property_exists($json, 'social-platforms')) {
+    return NULL;
+  }
+
+  foreach ($json->{'social-platforms'} as $key => $object) {
+    $return[$key] = $object->{'link-title'};
+  }
+
+  $return['other'] = t('Other');
+
+  return $return;
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() for menu_link_content_menu_link_content_form.
+ */
+function ecms_distribution_form_menu_link_content_menu_link_content_form_alter(&$form, FormStateInterface $form_state) {
+  $options = get_patternlab_social_source();
+
+  if (empty($options)) {
+    return;
+  }
+
+  $menuParentValue = $form_state->getValue('menu_parent');
+
+  if (empty($menuParentValue)) {
+    $menuParentValue = $form['menu_parent']['#default_value'];
+  }
+
+  // Add the other title container and textfield.
+  $form['ecms_social_other_container'] = [
+    '#type' => 'container',
+    '#attributes' => [
+      'id' => 'ecms-social-wrapper-other-title',
+    ],
+    '#weight' => -5,
+  ];
+
+  $form['ecms_social_other_container']['ecms_social_other_title'] = [
+    '#type' => 'textfield',
+    '#title' => t('Other Link title'),
+    '#access' => FALSE,
+    '#states' => [
+      'visible' => [
+        ':input[name="title[0][value]"]' => ['value' => 'other'],
+      ],
+      'required' => [
+        ':input[name="title[0][value]"]' => ['value' => 'other'],
+      ]
+    ],
+    '#weight' => -4,
+    '#element_validate' => [
+      '_ecms_distribution_menu_form_validate',
+    ]
+  ];
+
+  $form['title']['#weight'] = -50;
+  $form['title']['#prefix'] = '<div id="ecms-social-wrapper-title">';
+  $form['title']['#suffix'] = '</div>';
+
+  if (str_starts_with($menuParentValue, 'social-navigation:')) {
+    $form['title']['widget'][0]['value']['#type'] = 'select';
+    $form['title']['widget'][0]['value']['#options'] = $options;
+    $form['title']['widget'][0]['value']['#limit'] = 1;
+    $form['title']['widget'][0]['value']['#size'] = 1;
+
+    // If the default isn't in the list of options, try the keys.
+    $defaultTitle = $form['title']['widget'][0]['value']['#default_value'];
+    if (!array_key_exists($defaultTitle, $options)) {
+      $flipped = array_flip($options);
+
+      if (array_key_exists($defaultTitle, $flipped)) {
+        $form['title']['widget'][0]['value']['#default_value'] = $flipped[$defaultTitle];
+      }
+      else {
+        /** @var \Drupal\menu_link_content\MenuLinkContentInterface $menu_link */
+        $menu_link = $form_state->getFormObject()->getEntity();
+        // Ensure this is an existing entity.
+        if ($menu_link->id()) {
+          $options = $menu_link->link->first()->options;
+          if ($options['attributes']['class'][0] === 'other') {
+            $form['title']['widget'][0]['value']['#default_value'] = 'other';
+            $form['ecms_social_other_container']['ecms_social_other_title']['#default_value'] = $options['attributes']['title'];
+          }
+        }
+      }
+    }
+
+    // Enable access to the other title field.
+    $form['ecms_social_other_container']['ecms_social_other_title']['#access'] = TRUE;
+  }
+
+  $form['menu_parent']['#ajax'] = [
+    'callback' => 'ecms_distribution_menu_link_callback',
+  ];
+
+  $form['actions']['submit']['#submit'][] = '_ecms_distribution_menu_form_submit';
+}
+
+/**
+ * Custom validation function for the ecms_social_other_title form element.
+ *
+ * @param array $element
+ *   The ecms_social_other_title form element.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ * @param array $form
+ *   The form.
+ */
+function _ecms_distribution_menu_form_validate(array $element, FormStateInterface $form_state, array $form) {
+  $menuParentValue = $form_state->getValue('menu_parent');
+
+  if (str_starts_with($menuParentValue, 'social-navigation:')) {
+    // The title will be the class name.
+    $class = $form_state->getValue('title');
+    if ($class[0]['value'] === 'other') {
+      $otherTitle = $form_state->getValue('ecms_social_other_title');
+
+      if (empty($otherTitle)) {
+        $form_state->setError($element, t('The title field is required when choosing "other".'));
+      }
+    }
+  }
+}
+
+/**
+ * Custom form submit for the menu link entity form.
+ *
+ * @param $form
+ *   The form array.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ *
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function _ecms_distribution_menu_form_submit($form, FormStateInterface $form_state) {
+  $menuParentValue = $form_state->getValue('menu_parent');
+
+  if (str_starts_with($menuParentValue, 'social-navigation:')) {
+    $options = get_patternlab_social_source();
+
+    // The title will be the class name.
+    $class = $form_state->getValue('title');
+
+    // Get the title from the json array.
+    $title = $options[$class[0]['value']];
+
+    if ($class[0]['value'] === 'other') {
+      // Get the other title in case we need it.
+      $otherTitle = $form_state->getValue('ecms_social_other_title');
+    }
+
+    /** @var \Drupal\menu_link_content\MenuLinkContentInterface $menu_link */
+    $menu_link = $form_state->getFormObject()->getEntity();
+
+    if (!empty($otherTitle)) {
+      $title = $otherTitle;
+    }
+
+    // Set the title of the menu link to the json object.
+    $menu_link->set('title', $title);
+
+    $linkOptions['attributes']['class'] = [$class[0]['value']];
+    $linkOptions['attributes']['title'] = $title;
+    $linkOptions['item_attributes']['class'] = [$class[0]['value']];
+    $linkOptions['item_attributes']['title'] = $title;
+
+    $menu_link->link->first()->options = $linkOptions;
+    $menu_link->link->first()->title = $title;
+    $menu_link->save();
+  }
+}
+
+/**
+ * Ajax callback for the menu link form.
+ *
+ * @param array $form
+ *   The form array.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state interface.
+ *
+ * @return \Drupal\Core\Ajax\AjaxResponse
+ *   The ajax response replacing the two required fields.
+ */
+function ecms_distribution_menu_link_callback(array $form, FormStateInterface $form_state) {
+  $response = new AjaxResponse();
+  $response
+    ->addCommand(new ReplaceCommand('#ecms-social-wrapper-other-title', render($form['ecms_social_other_container'])));
+
+  $response
+    ->addCommand(new ReplaceCommand('#ecms-social-wrapper-title', render($form['title'])));
+
+  return $response;
+}
+
+/**
+ * Implements hook_preprocess_menu().
+ */
+function ecms_distribution_preprocess_menu(&$variables) {
+  if (isset($variables['menu_name']) && $variables['menu_name'] === 'social-navigation') {
+    foreach ($variables['items'] as $linkKey => $item) {
+      $options = $item['url']->getOptions();
+
+      // Set the link item attributes to the <li> elements.
+      if (array_key_exists('item_attributes', $options)) {
+        foreach ($options['item_attributes'] as $key => $value) {
+          $variables['items'][$linkKey]['attributes']->setAttribute($key, $value);
+        }
+      }
+    }
+  }
+}

--- a/ecms_base/modules/custom/ecms_distribution/ecms_distribution.module
+++ b/ecms_base/modules/custom/ecms_distribution/ecms_distribution.module
@@ -49,7 +49,7 @@ function get_patternlab_social_source(): ?array {
 /**
  * Implements hook_form_FORM_ID_alter() for menu_link_content_menu_link_content_form.
  */
-function ecms_distribution_form_menu_link_content_menu_link_content_form_alter(&$form, FormStateInterface $form_state) {
+function ecms_distribution_form_menu_link_content_menu_link_content_form_alter(&$form, FormStateInterface $form_state): void {
   $options = get_patternlab_social_source();
 
   if (empty($options)) {

--- a/ecms_base/modules/custom/ecms_distribution/ecms_distribution.module
+++ b/ecms_base/modules/custom/ecms_distribution/ecms_distribution.module
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * @file
+ * ecms_distribution.module
+ */
+
+declare(strict_types=1);
+
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\ReplaceCommand;
 use Drupal\Core\Form\FormStateInterface;
@@ -9,7 +16,6 @@ use Drupal\Core\Form\FormStateInterface;
  *
  * @return array|null
  *   The available social navigation options, or null if an error.
- *
  */
 function get_patternlab_social_source(): ?array {
   $return = [];
@@ -62,6 +68,11 @@ function ecms_distribution_form_menu_link_content_menu_link_content_form_alter(&
     '#attributes' => [
       'id' => 'ecms-social-wrapper-other-title',
     ],
+    '#states' => [
+      'visible' => [
+        ':input[name="title[0][value]"]' => ['value' => 'other'],
+      ],
+    ],
     '#weight' => -5,
   ];
 
@@ -70,17 +81,17 @@ function ecms_distribution_form_menu_link_content_menu_link_content_form_alter(&
     '#title' => t('Other Link title'),
     '#access' => FALSE,
     '#states' => [
+      'required' => [
+        ':input[name="title[0][value]"]' => ['value' => 'other'],
+      ],
       'visible' => [
         ':input[name="title[0][value]"]' => ['value' => 'other'],
       ],
-      'required' => [
-        ':input[name="title[0][value]"]' => ['value' => 'other'],
-      ]
     ],
     '#weight' => -4,
     '#element_validate' => [
       '_ecms_distribution_menu_form_validate',
-    ]
+    ],
   ];
 
   $form['title']['#weight'] = -50;
@@ -136,7 +147,7 @@ function ecms_distribution_form_menu_link_content_menu_link_content_form_alter(&
  * @param array $form
  *   The form.
  */
-function _ecms_distribution_menu_form_validate(array $element, FormStateInterface $form_state, array $form) {
+function _ecms_distribution_menu_form_validate(array $element, FormStateInterface $form_state, array $form): void {
   $menuParentValue = $form_state->getValue('menu_parent');
 
   if (str_starts_with($menuParentValue, 'social-navigation:')) {
@@ -155,14 +166,14 @@ function _ecms_distribution_menu_form_validate(array $element, FormStateInterfac
 /**
  * Custom form submit for the menu link entity form.
  *
- * @param $form
+ * @param array $form
  *   The form array.
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   The form state.
  *
  * @throws \Drupal\Core\Entity\EntityStorageException
  */
-function _ecms_distribution_menu_form_submit($form, FormStateInterface $form_state) {
+function _ecms_distribution_menu_form_submit(array $form, FormStateInterface $form_state): void {
   $menuParentValue = $form_state->getValue('menu_parent');
 
   if (str_starts_with($menuParentValue, 'social-navigation:')) {
@@ -211,13 +222,14 @@ function _ecms_distribution_menu_form_submit($form, FormStateInterface $form_sta
  * @return \Drupal\Core\Ajax\AjaxResponse
  *   The ajax response replacing the two required fields.
  */
-function ecms_distribution_menu_link_callback(array $form, FormStateInterface $form_state) {
+function ecms_distribution_menu_link_callback(array $form, FormStateInterface $form_state): AjaxResponse {
   $response = new AjaxResponse();
-  $response
-    ->addCommand(new ReplaceCommand('#ecms-social-wrapper-other-title', render($form['ecms_social_other_container'])));
 
   $response
     ->addCommand(new ReplaceCommand('#ecms-social-wrapper-title', render($form['title'])));
+
+  $response
+    ->addCommand(new ReplaceCommand('#ecms-social-wrapper-other-title', render($form['ecms_social_other_container'])));
 
   return $response;
 }
@@ -225,12 +237,12 @@ function ecms_distribution_menu_link_callback(array $form, FormStateInterface $f
 /**
  * Implements hook_preprocess_menu().
  */
-function ecms_distribution_preprocess_menu(&$variables) {
+function ecms_distribution_preprocess_menu(&$variables): void {
   if (isset($variables['menu_name']) && $variables['menu_name'] === 'social-navigation') {
     foreach ($variables['items'] as $linkKey => $item) {
       $options = $item['url']->getOptions();
 
-      // Set the link item attributes to the <li> elements.
+      // Set the link item_attributes on the <li> elements.
       if (array_key_exists('item_attributes', $options)) {
         foreach ($options['item_attributes'] as $key => $value) {
           $variables['items'][$linkKey]['attributes']->setAttribute($key, $value);


### PR DESCRIPTION
## Summary
This adds a new `social-navigation` menu to the profile and provides the update hook to install it to the existing sites.

Additional form_alter logic was added to the ecms_distribution module that will alter the menu link form for the social navigation menu and will provide a predefined list of social media icons that the patternlab theme provides. This information is then added to the menu links as class/title attributes that can be passed into pattern lab twig files.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Medium
| Relevant links | [RIG-142](https://thinkoomph.jira.com/browse/rig-142)