### PR TITLE
Fixed the class path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-143: Fixed a class path php error.
 
 ### Security
 

--- a/ecms_base/modules/custom/ecms_api_recipient/ecms_api_recipient.services.yml
+++ b/ecms_base/modules/custom/ecms_api_recipient/ecms_api_recipient.services.yml
@@ -21,7 +21,7 @@ services:
     arguments: ['@http_client', '@jsonapi_extras.entity.to_jsonapi', '@ecms_api_helper', '@entity_type.manager', '@ecms_api_recipient.jsonapi_helper']
 
   ecms_api_recipient.jsonapi_helper:
-    class: Drupal\ecms_api_recipient\JsonapiHelper
+    class: Drupal\ecms_api_recipient\JsonApiHelper
     arguments:
       - '@jsonapi.serializer'
       - '@serializer.normalizer.jsonapi_document_toplevel.jsonapi'


### PR DESCRIPTION
## Summary
The live site was throwing a php error during cron that pointed back to a misnamed class in the services file. The case of the class name was incorrect. This fixes that case issue and should resolve the issue.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-143](https://thinkoomph.jira.com/browserig-143)