### PR TITLE
Fix language detection to use cookies/sessions instead of URL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-130: Added eCMS Languages custom module.
 
 ### Changed
+- RIG-148: Changed the language detection method to session/cookie.
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,7 @@
     "drupal/extlink": "^1.5",
     "drupal/features": "^3.11",
     "drupal/jsonapi_extras": "^3.16",
+    "drupal/language_cookie": "1.x-dev",
     "drupal/layout_builder_modal": "^1.1",
     "drupal/layout_builder_restrictions": "^2.7",
     "drupal/media_library_theme_reset": "^1.0",

--- a/ecms_base/config/install/language.negotiation.yml
+++ b/ecms_base/config/install/language.negotiation.yml
@@ -23,5 +23,3 @@ url:
     sw: ''
     lo: ''
 selected_langcode: site_default
-_core:
-  default_config_hash: uEePITI9tV6WqzmsTb7MfPCi5yPWXSxAN1xeLcYFQbM

--- a/ecms_base/config/install/language.negotiation.yml
+++ b/ecms_base/config/install/language.negotiation.yml
@@ -1,0 +1,27 @@
+session:
+  parameter: language
+url:
+  source: path_prefix
+  prefixes:
+    en: ''
+    es: es
+    pt-pt: pt-pt
+    ar: ar
+    zh-hans: zh-hans
+    ht: ht
+    fr: fr
+    sw: sw
+    lo: lo
+  domains:
+    en: ''
+    es: ''
+    pt-pt: ''
+    ar: ''
+    zh-hans: ''
+    ht: ''
+    fr: ''
+    sw: ''
+    lo: ''
+selected_langcode: site_default
+_core:
+  default_config_hash: uEePITI9tV6WqzmsTb7MfPCi5yPWXSxAN1xeLcYFQbM

--- a/ecms_base/config/install/language.types.yml
+++ b/ecms_base/config/install/language.types.yml
@@ -1,0 +1,38 @@
+all:
+  - language_interface
+  - language_content
+  - language_url
+configurable:
+  - language_interface
+negotiation:
+  language_content:
+    enabled:
+      language-interface: -14
+    method_weights:
+      language-content-entity: -20
+      language-session: -19
+      language-cookie: -18
+      language-url: -17
+      language-user: -16
+      language-browser: -15
+      language-interface: -14
+      language-selected: -13
+  language_url:
+    enabled:
+      language-url: 0
+      language-url-fallback: 2
+  language_interface:
+    enabled:
+      language-session: -18
+      language-cookie: -17
+      language-selected: -14
+    method_weights:
+      language-user-admin: -20
+      language-url: -19
+      language-session: -18
+      language-cookie: -17
+      language-user: -16
+      language-browser: -15
+      language-selected: -14
+_core:
+  default_config_hash: dqouFqVseNJNvEjsoYKxbinFOITuCxYhi4y2OTNQP_8

--- a/ecms_base/config/install/language.types.yml
+++ b/ecms_base/config/install/language.types.yml
@@ -34,5 +34,3 @@ negotiation:
       language-user: -16
       language-browser: -15
       language-selected: -14
-_core:
-  default_config_hash: dqouFqVseNJNvEjsoYKxbinFOITuCxYhi4y2OTNQP_8

--- a/ecms_base/config/install/language_cookie.negotiation.yml
+++ b/ecms_base/config/install/language_cookie.negotiation.yml
@@ -6,5 +6,3 @@ secure: true
 set_on_every_pageload: true
 blacklisted_paths: {  }
 language_type: language_interface
-_core:
-  default_config_hash: n_3pCzprO9rcyGMNPR5YNLxIpJQyO1RvKi-e87Rb0JM

--- a/ecms_base/config/install/language_cookie.negotiation.yml
+++ b/ecms_base/config/install/language_cookie.negotiation.yml
@@ -1,0 +1,10 @@
+param: language
+time: 31536000
+path: /
+domain: ''
+secure: true
+set_on_every_pageload: true
+blacklisted_paths: {  }
+language_type: language_interface
+_core:
+  default_config_hash: n_3pCzprO9rcyGMNPR5YNLxIpJQyO1RvKi-e87Rb0JM

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -40,6 +40,7 @@ dependencies:
   - layout_builder
   - layout_builder_modal
   - layout_builder_restrictions
+  - language_cookie
   - layout_discovery
   - media
   - media_library

--- a/ecms_base/ecms_base.profile
+++ b/ecms_base/ecms_base.profile
@@ -178,17 +178,4 @@ function ecms_base_update_9021(array &$sandbox): void {
 
   // Make sure necessary modules are uninstalled.
   \Drupal::service('module_installer')->uninstall($modules_to_uninstall);
-
-  // Install our new configuration.
-  $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
-
-  /** @var \Drupal\Core\Config\FileStorage $install_source */
-  $install_source = new FileStorage($path . "/config/install/");
-
-  /** @var \Drupal\Core\Config\StorageInterface $active_storage */
-  $active_storage = \Drupal::service('config.storage');
-
-  $active_storage->write('language.negotiation', $install_source->read('language.negotiation'));
-  $active_storage->write('language.types', $install_source->read('language.types'));
-  $active_storage->write('language_cookie.negotiation', $install_source->read('language_cookie.negotiation'));
 }

--- a/ecms_base/ecms_base.profile
+++ b/ecms_base/ecms_base.profile
@@ -164,6 +164,7 @@ function ecms_base_update_9021(array &$sandbox): void {
   // Install new modules.
   $modules_to_install = [
     'ecms_languages',
+    'language_cookie',
   ];
 
   // Make sure necessary modules are installed.
@@ -177,4 +178,17 @@ function ecms_base_update_9021(array &$sandbox): void {
 
   // Make sure necessary modules are uninstalled.
   \Drupal::service('module_installer')->uninstall($modules_to_uninstall);
+
+  // Install our new configuration.
+  $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
+
+  /** @var \Drupal\Core\Config\FileStorage $install_source */
+  $install_source = new FileStorage($path . "/config/install/");
+
+  /** @var \Drupal\Core\Config\StorageInterface $active_storage */
+  $active_storage = \Drupal::service('config.storage');
+
+  $active_storage->write('language.negotiation', $install_source->read('language.negotiation'));
+  $active_storage->write('language.types', $install_source->read('language.types'));
+  $active_storage->write('language_cookie.negotiation', $install_source->read('language_cookie.negotiation'));
 }

--- a/ecms_base/modules/custom/ecms_languages/README.md
+++ b/ecms_base/modules/custom/ecms_languages/README.md
@@ -6,3 +6,11 @@ Provides configuration and logic to customize the language switcher.
 
 A configuration form is provided to select which active languages
 should be removed from the switcher drop down.
+
+
+## Alterations
+
+The session negotiator was not respectint the session, making it impossible
+to edit/delete a translation without first using the language switcher. This
+extends the language session negotiator to add the ?language=XX to the
+edit/delete node operation links.

--- a/ecms_base/modules/custom/ecms_languages/README.md
+++ b/ecms_base/modules/custom/ecms_languages/README.md
@@ -10,7 +10,7 @@ should be removed from the switcher drop down.
 
 ## Alterations
 
-The session negotiator was not respectint the session, making it impossible
+The session negotiator was not respecting the session, making it impossible
 to edit/delete a translation without first using the language switcher. This
 extends the language session negotiator to add the ?language=XX to the
 edit/delete node operation links.

--- a/ecms_base/modules/custom/ecms_languages/ecms_languages.module
+++ b/ecms_base/modules/custom/ecms_languages/ecms_languages.module
@@ -38,6 +38,6 @@ function ecms_languages_language_switch_links_alter(array &$links, string $type,
  * We need to update the session negotiator to fix translation
  * links in the admin.
  */
-function ecms_languages_language_negotiation_info_alter(array &$negotiation_info) {
+function ecms_languages_language_negotiation_info_alter(array &$negotiation_info): void {
   $negotiation_info['language-session']['class'] = 'Drupal\ecms_languages\LanguageNegotiationSessionFix';
 }

--- a/ecms_base/modules/custom/ecms_languages/ecms_languages.module
+++ b/ecms_base/modules/custom/ecms_languages/ecms_languages.module
@@ -31,3 +31,13 @@ function ecms_languages_language_switch_links_alter(array &$links, string $type,
     }
   }
 }
+
+/**
+ * Implements hook_language_negotiation_info_alter().
+ *
+ * We need to update the session negotiator to fix translation
+ * links in the admin.
+ */
+function ecms_languages_language_negotiation_info_alter(array &$negotiation_info) {
+  $negotiation_info['language-session']['class'] = 'Drupal\ecms_languages\LanguageNegotiationSessionFix';
+}

--- a/ecms_base/modules/custom/ecms_languages/src/LanguageNegotiationSessionFix.php
+++ b/ecms_base/modules/custom/ecms_languages/src/LanguageNegotiationSessionFix.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\ecms_languages;
+
+use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\language\Plugin\LanguageNegotiation\LanguageNegotiationSession;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Alter the session language negotiator to add query params on node operations.
+ *
+ * @package Drupal\ecms_languages
+ */
+class LanguageNegotiationSessionFix extends LanguageNegotiationSession {
+
+  /**
+   * Node operations to add the language query parameter.
+   */
+  const NODE_OPERATIONS = [
+    'edit',
+    'delete',
+  ];
+
+  /**
+   * {@inheritDoc}
+   */
+  public function processOutbound($path, &$options = [], Request $request = NULL, BubbleableMetadata $bubbleable_metadata = NULL): string {
+    $parent = parent::processOutbound($path, $options, $request, $bubbleable_metadata);
+
+    $parts = explode('/', ltrim($path, '/'));
+
+    // Make sure we have the correct path length.
+    if (count($parts) !== 3) {
+      return $parent;
+    }
+
+    // Make sure we are dealing with a node.
+    if ($parts[0] !== 'node') {
+      return $parent;
+    }
+
+    // We only care about a few operations.
+    if (!in_array($parts[2], self::NODE_OPERATIONS, TRUE)) {
+      return $parent;
+    }
+
+    // Make sure we have an entity.
+    if (empty($options['entity'])) {
+      return $parent;
+    }
+
+    // Make sure we have a language.
+    if (empty($options['language'])) {
+      return $parent;
+    }
+
+    /** @var \Drupal\Core\Language\LanguageInterface $language */
+    $language = $options['language'];
+
+    // Add the language id to the query string.
+    $options['query']['language'] = $language->getId();
+
+    // Add cache metadata.
+    $bubbleable_metadata
+      ->addCacheTags($this->config->get('language.negotiation')->getCacheTags())
+      ->addCacheContexts(['url.query_args:language']);
+
+    return $path;
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_languages/tests/src/Unit/LanguageNegotiationSessionFixTest.php
+++ b/ecms_base/modules/custom/ecms_languages/tests/src/Unit/LanguageNegotiationSessionFixTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\ecms_languages\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\ecms_languages\LanguageNegotiationSessionFix;
+use Drupal\language\ConfigurableLanguageManager;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class LanguageNegotiationSessionFixTest
+ *
+ * @package Drupal\Tests\ecms_languages\Unit
+ * @group ecms_languages
+ */
+class LanguageNegotiationSessionFixTest extends UnitTestCase {
+
+  /**
+   * Mock the request.
+   *
+   * @var \PHPUnit\Framework\MockObject\MockObject|\Symfony\Component\HttpFoundation\Request
+   */
+  private $request;
+
+  /**
+   * Mock the BubbleableMetadata cache.
+   *
+   * @var \Drupal\Core\Render\BubbleableMetadata|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $bubbleCache;
+
+  /**
+   * Mock an entity.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $entity;
+
+  /**
+   * Mock a language object.
+   *
+   * @var \Drupal\Core\Language\LanguageInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $language;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->request = $this->createMock(Request::class);
+    $this->bubbleCache = $this->createMock(BubbleableMetadata::class);
+    $this->entity = $this->createMock(EntityInterface::class);
+    $this->language = $this->createMock(LanguageInterface::class);
+  }
+
+  /**
+   * Test the processOutbound method.
+   *
+   * @param string $path
+   * @param string $langCode
+   *
+   * @dataProvider dataProviderForTestProcessOutbound
+   */
+  public function testProcessOutbound(string $path, bool $entity, bool $langCode, bool $methodsCalled): void {
+
+    $options = [];
+    $options['entity'] = $this->entity;
+    $methodCount = 0;
+
+    if ($langCode) {
+      $options['language'] = $this->language;
+    }
+
+    if (!$entity) {
+      unset($options['entity']);
+    }
+
+    if ($methodsCalled) {
+      $methodCount = 1;
+    }
+
+    $this->language->expects($this->exactly($methodCount))
+      ->method('getId')
+      ->willReturn('de');
+
+    $this->bubbleCache->expects($this->exactly($methodCount))
+      ->method('addCacheTags')
+      ->willReturnSelf();;
+
+    $this->bubbleCache->expects($this->exactly($methodCount))
+      ->method('addCacheContexts')
+      ->with(['url.query_args:language'])
+      ->willReturnSelf();
+
+    $user = $this->createMock(AccountInterface::class);
+    $user->expects($this->once())
+      ->method('isAnonymous')
+      ->willReturn(FALSE);
+
+    $immutableConfig = $this->createMock(ImmutableConfig::class);
+    $immutableConfig->expects($this->exactly($methodCount))
+      ->method('getCacheTags')
+      ->willReturn([]);
+
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->expects($this->exactly($methodCount))
+      ->method('get')
+      ->with('language.negotiation')
+      ->willReturn($immutableConfig);
+
+    $languageManager = $this->createMock(ConfigurableLanguageManager::class);
+
+    $testClass = new LanguageNegotiationSessionFix();
+
+    $testClass->setCurrentUser($user);
+    $testClass->setConfig($configFactory);
+    $testClass->setLanguageManager($languageManager);
+
+    $result = $testClass->processOutbound($path, $options, $this->request, $this->bubbleCache);
+
+    $this->assertEquals($path, $result);
+  }
+
+  /**
+   * Data provider for the testProcessOutbound method.
+   *
+   * @return array[]
+   *   Parameters to pass to testProcessOutbound.
+   */
+  public function dataProviderForTestProcessOutbound(): array {
+    return [
+      'test1' => [
+        'node/123/edit',
+        TRUE,
+        TRUE,
+        TRUE,
+      ],
+      'test2' => [
+        'node/123/delete',
+        TRUE,
+        TRUE,
+        TRUE,
+      ],
+      'test3' => [
+        'node/123/edit',
+        FALSE,
+        TRUE,
+        FALSE,
+      ],
+      'test4' => [
+        'node/123/delete',
+        FALSE,
+        TRUE,
+        FALSE,
+      ],
+      'test5' => [
+        'node/123/edit',
+        TRUE,
+        FALSE,
+        FALSE,
+      ],
+      'test6' => [
+        'node/123/delete',
+        TRUE,
+        FALSE,
+        FALSE,
+      ],
+      'test7' => [
+        'not/a/node/path',
+        FALSE,
+        FALSE,
+        FALSE,
+      ],
+      'test8' => [
+        'node/path/add',
+        TRUE,
+        TRUE,
+        FALSE,
+      ],
+      'test9' => [
+        'path/to/delete',
+        TRUE,
+        TRUE,
+        FALSE,
+      ],
+    ];
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_languages/tests/src/Unit/LanguageNegotiationSessionFixTest.php
+++ b/ecms_base/modules/custom/ecms_languages/tests/src/Unit/LanguageNegotiationSessionFixTest.php
@@ -16,7 +16,7 @@ use Drupal\Tests\UnitTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Class LanguageNegotiationSessionFixTest
+ * Unit tests for the LanguageNegotiationSessionFix class.
  *
  * @package Drupal\Tests\ecms_languages\Unit
  * @group ecms_languages
@@ -67,7 +67,13 @@ class LanguageNegotiationSessionFixTest extends UnitTestCase {
    * Test the processOutbound method.
    *
    * @param string $path
-   * @param string $langCode
+   *   The path to test with.
+   * @param bool $entity
+   *   Whether an entity is expected.
+   * @param bool $langCode
+   *   Whether a language is expected.
+   * @param bool $methodsCalled
+   *   Whether the custom process methods will be called.
    *
    * @dataProvider dataProviderForTestProcessOutbound
    */

--- a/ecms_base/modules/custom/ecms_languages/tests/src/Unit/LanguageNegotiationSessionFixTest.php
+++ b/ecms_base/modules/custom/ecms_languages/tests/src/Unit/LanguageNegotiationSessionFixTest.php
@@ -101,7 +101,7 @@ class LanguageNegotiationSessionFixTest extends UnitTestCase {
 
     $this->bubbleCache->expects($this->exactly($methodCount))
       ->method('addCacheTags')
-      ->willReturnSelf();;
+      ->willReturnSelf();
 
     $this->bubbleCache->expects($this->exactly($methodCount))
       ->method('addCacheContexts')


### PR DESCRIPTION
## Summary
This adds the language_cookie module and adds a custom language negotiator to properly handle session/cookie within the admin pages.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Medium
| Relevant links | [RIG-148](https://thinkoomph.jira.com/browse/rig-148)