### PR TITLE
Fix session language detection for all entities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-149: Fixed the language detection to work with all entities.
 
 ### Security
 

--- a/ecms_base/modules/custom/ecms_api_publisher/tests/src/Functional/PublisherInstallTest.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/tests/src/Functional/PublisherInstallTest.php
@@ -89,8 +89,9 @@ class PublisherInstallTest extends AllProfileInstallationTestsAbstract {
     $this->assertSession()->linkExists('eCMS Publisher');
     $this->clickLink('eCMS Publisher');
     $url = $this->getUrl();
+    $urlParts = explode('?', $url);
     // Edit the consumer.
-    $this->drupalGet("{$url}/edit");
+    $this->drupalGet("{$urlParts[0]}/edit");
     $this->assertSession()->statusCodeEquals(200);
     // Ensure the api user is set.
     $this->assertSession()->fieldValueEquals('edit-user-id-0-target-id', "ecms_api_publisher ({$accountId})");

--- a/ecms_base/modules/custom/ecms_languages/src/LanguageNegotiationSessionFix.php
+++ b/ecms_base/modules/custom/ecms_languages/src/LanguageNegotiationSessionFix.php
@@ -16,35 +16,10 @@ use Symfony\Component\HttpFoundation\Request;
 class LanguageNegotiationSessionFix extends LanguageNegotiationSession {
 
   /**
-   * Node operations to add the language query parameter.
-   */
-  const NODE_OPERATIONS = [
-    'edit',
-    'delete',
-  ];
-
-  /**
    * {@inheritDoc}
    */
   public function processOutbound($path, &$options = [], Request $request = NULL, BubbleableMetadata $bubbleable_metadata = NULL): string {
     $parent = parent::processOutbound($path, $options, $request, $bubbleable_metadata);
-
-    $parts = explode('/', ltrim($path, '/'));
-
-    // Make sure we have the correct path length.
-    if (count($parts) !== 3) {
-      return $parent;
-    }
-
-    // Make sure we are dealing with a node.
-    if ($parts[0] !== 'node') {
-      return $parent;
-    }
-
-    // We only care about a few operations.
-    if (!in_array($parts[2], self::NODE_OPERATIONS, TRUE)) {
-      return $parent;
-    }
 
     // Make sure we have an entity.
     if (empty($options['entity'])) {

--- a/ecms_base/modules/custom/ecms_languages/tests/src/Unit/LanguageNegotiationSessionFixTest.php
+++ b/ecms_base/modules/custom/ecms_languages/tests/src/Unit/LanguageNegotiationSessionFixTest.php
@@ -188,16 +188,52 @@ class LanguageNegotiationSessionFixTest extends UnitTestCase {
         FALSE,
       ],
       'test8' => [
-        'node/path/add',
+        'media/123/delete',
         TRUE,
         TRUE,
-        FALSE,
+        TRUE,
       ],
       'test9' => [
-        'path/to/delete',
+        'media/123/edit',
         TRUE,
+        TRUE,
+        TRUE,
+      ],
+      'test10' => [
+        'taxonomy/term/123/edit',
+        TRUE,
+        TRUE,
+        TRUE,
+      ],
+      'test11' => [
+        'taxonomy/term/123/delete',
+        TRUE,
+        TRUE,
+        TRUE,
+      ],
+      'test12' => [
+        'taxonomy/term/123/edit',
         TRUE,
         FALSE,
+        FALSE,
+      ],
+      'test13' => [
+        'taxonomy/term/123/delete',
+        TRUE,
+        FALSE,
+        FALSE,
+      ],
+      'test14' => [
+        'block/123/?language=de',
+        TRUE,
+        TRUE,
+        TRUE,
+      ],
+      'test15' => [
+        'block/123/delete?language=de',
+        TRUE,
+        TRUE,
+        TRUE,
       ],
     ];
   }


### PR DESCRIPTION
## Summary
This removes the node specific restrictions to allow the session/cookie language detection to work with all entities.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-149](https://thinkoomph.jira.com/browse/rig-149)