### PR TITLE
Fix the language interface detection to only apply to entity forms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-153: Updated the language session fix to only apply to entity forms.
 
 ### Security
 

--- a/ecms_base/modules/custom/ecms_languages/src/LanguageNegotiationSessionFix.php
+++ b/ecms_base/modules/custom/ecms_languages/src/LanguageNegotiationSessionFix.php
@@ -31,6 +31,15 @@ class LanguageNegotiationSessionFix extends LanguageNegotiationSession {
       return $parent;
     }
 
+    /** @var \Symfony\Component\Routing\Route $proposedRoute */
+    $proposedRoute = $options['route'];
+    $form = $proposedRoute->getDefault('_entity_form');
+
+    // If the proposed route is not a form, do not specify a translation.
+    if (empty($form)) {
+      return $parent;
+    }
+
     /** @var \Drupal\Core\Language\LanguageInterface $language */
     $language = $options['language'];
 


### PR DESCRIPTION
## Summary
This fixes the appended `?language=` to entity view links and forces it to only apply to entity form routes.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Medium
| Relevant links | [RIG-153](https://thinkoomph.jira.com/browse/rig-153)