### PR TITLE
Change path aliases to be language neutral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Fixed
 - RIG-153: Updated the language session fix to only apply to entity forms.
+- RIG-154: Change path aliases to always be language neutral.
 
 ### Security
 

--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,7 @@
     "drupal/features": "^3.11",
     "drupal/jsonapi_extras": "^3.16",
     "drupal/language_cookie": "1.x-dev",
+    "drupal/language_neutral_aliases": "^3.0",
     "drupal/layout_builder_modal": "^1.1",
     "drupal/layout_builder_restrictions": "^2.7",
     "drupal/media_library_theme_reset": "^1.0",

--- a/ecms_base/modules/custom/ecms_languages/ecms_languages.info.yml
+++ b/ecms_base/modules/custom/ecms_languages/ecms_languages.info.yml
@@ -5,3 +5,4 @@ core_version_requirement: ^9
 package: eCMS
 dependencies:
   - drupal:language
+  - drupal:language_neutral_aliases

--- a/ecms_base/modules/custom/ecms_languages/ecms_languages.install
+++ b/ecms_base/modules/custom/ecms_languages/ecms_languages.install
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * ecms_languages.install.
+ * Ecms_languages.install.
  */
 
 declare(strict_types = 1);
@@ -30,7 +30,7 @@ function ecms_languages_update_9000(): void {
       'langcode' => Language::LANGCODE_NOT_SPECIFIED,
     ])
     ->condition('langcode', Language::LANGCODE_NOT_SPECIFIED, '<>')
-  ->execute();
+    ->execute();
 
   // Update the path_alias_revision table and change all alias languages to
   // not specified.

--- a/ecms_base/modules/custom/ecms_languages/ecms_languages.install
+++ b/ecms_base/modules/custom/ecms_languages/ecms_languages.install
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @file
+ * ecms_languages.install.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\Core\Language\Language;
+
+/**
+ * Update all language aliases to be language neutral.
+ */
+function ecms_languages_update_9000(): void {
+  $modules_to_install = [
+    'language_neutral_aliases',
+  ];
+
+  // Make sure necessary modules are installed.
+  \Drupal::service('module_installer')->install($modules_to_install);
+
+  /** @var Drupal\Core\Database\Connection $database */
+  $database = \Drupal::service('database');
+
+  // Update the path_alias table and change all alias languages to
+  // not specified.
+  $database->update('path_alias')
+    ->fields([
+      'langcode' => Language::LANGCODE_NOT_SPECIFIED,
+    ])
+    ->condition('langcode', Language::LANGCODE_NOT_SPECIFIED, '<>')
+  ->execute();
+
+  // Update the path_alias_revision table and change all alias languages to
+  // not specified.
+  $database->update('path_alias_revision')
+    ->fields([
+      'langcode' => Language::LANGCODE_NOT_SPECIFIED,
+    ])
+    ->condition('langcode', Language::LANGCODE_NOT_SPECIFIED, '<>')
+    ->execute();
+}

--- a/ecms_base/modules/custom/ecms_languages/ecms_languages.module
+++ b/ecms_base/modules/custom/ecms_languages/ecms_languages.module
@@ -7,7 +7,19 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Language\Language;
 use Drupal\Core\Url;
+
+/**
+ * Implements hook_module_implements_alter().
+ */
+function ecms_languages_module_implements_alter(&$implementations, $hook) {
+  if (isset($implementations['hook'])) {
+    $group = $implementations['hook'];
+    unset($implementations['hook']);
+    $implementations['hook'] = $group;
+  }
+}
 
 /**
  * Implements hook_language_switch_links_alter().
@@ -40,4 +52,12 @@ function ecms_languages_language_switch_links_alter(array &$links, string $type,
  */
 function ecms_languages_language_negotiation_info_alter(array &$negotiation_info): void {
   $negotiation_info['language-session']['class'] = 'Drupal\ecms_languages\LanguageNegotiationSessionFix';
+}
+
+/**
+ * Implements hook_pathauto_alias_alter().
+ */
+function ecms_languages_pathauto_alias_alter(&$alias, array &$context): void {
+  // Force all aliases to be saved as language neutral.
+  $context['language'] = Language::LANGCODE_NOT_SPECIFIED;
 }


### PR DESCRIPTION
## Summary
This adds the drupal/language_neutral_aliases module to force all url aliases to be language neutral. This also adds pathauto hooks to force all auto-generated paths to be language neutral. Finally, an update hook was added to convert all existing paths to be language neutral [per the recommendation of the language_neutral_aliases module](https://git.drupalcode.org/project/language_neutral_aliases/-/blob/3.x/README.txt)

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | High
| Relevant links | [RIG-154](https://thinkoomph.jira.com/browse/rig-154)