### PR TITLE
Add basic page and file migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ## [Unreleased]
 ### Added
 - RIG-131: Add Search API and database index.
+- RIG-106: Added custom migrations from static websites.
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -147,6 +147,7 @@
     "drupal_git/migrate_google_sheets": "1.0.0",
     "drupal_git/migration_tools": "1.0.0",
     "drush/drush": "^10.0",
+    "querypath/querypath": "^3.0",
     "oomphinc/composer-installers-extender": "^2.0",
     "zaporylie/composer-drupal-optimizations": "^1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,32 @@
     {
       "type": "composer",
       "url": "https://asset-packagist.org"
+    },
+    {
+        "type": "package",
+        "package": {
+            "name": "drupal_git/migration_tools",
+            "type": "drupal-module",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/migration_tools.git",
+                "reference": "3e193bc97d127ea2cff6b80f9509bc161bdee19f"
+            }
+        }
+    },
+    {
+        "type": "package",
+        "package": {
+            "name": "drupal_git/migrate_google_sheets",
+            "type": "drupal-module",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/migrate_google_sheets.git",
+                "reference": "22944d55be891cfe48d6a6d7c222ff9e89f67b8d"
+            }
+        }
     }
   ],
   "extra": {
@@ -48,6 +74,12 @@
       },
       "drupal/webform_encrypt": {
         "3142997 - D9 readiness" : "https://www.drupal.org/files/issues/2020-06-05/3142997-20.patch"
+      },
+      "drupal_git/migration_tools": {
+        "3148135 - D9 readiness" : "https://www.drupal.org/files/issues/2020-11-17/automated-d9-compatibility-fixes-3148135-5.patch"
+      },
+      "drupal_git/migrate_google_sheets": {
+        "3138999 - D9 readiness" : "https://www.drupal.org/files/issues/2020-11-17/Drupal-9-readiness-3138999-6.patch"
       }
     },
     "preserve-paths": [],
@@ -110,6 +142,8 @@
     "drupal/twig_vardumper": "^3.0",
     "drupal/webform": "^6.0",
     "drupal/webform_encrypt": "1.x-dev@dev",
+    "drupal_git/migrate_google_sheets": "1.0.0",
+    "drupal_git/migration_tools": "1.0.0",
     "drush/drush": "^10.0",
     "oomphinc/composer-installers-extender": "^2.0",
     "zaporylie/composer-drupal-optimizations": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -121,6 +121,8 @@
     "drupal/layout_builder_restrictions": "^2.7",
     "drupal/media_library_theme_reset": "^1.0",
     "drupal/menu_block": "1.x-dev",
+    "drupal/migrate_plus": "^5.1",
+    "drupal/migrate_tools": "^5.0",
     "drupal/moderated_content_bulk_publish": "^2.0",
     "drupal/moderation_dashboard": "^1.0",
     "drupal/office_hours": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,19 @@
                 "reference": "22944d55be891cfe48d6a6d7c222ff9e89f67b8d"
             }
         }
+    },
+    {
+        "type": "package",
+        "package": {
+            "name": "drupal_git/migrate_process_trim",
+            "type": "drupal-module",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/migrate_process_trim.git",
+                "reference": "79c7ceb9113c1e21818bd124135e5d261ccbebbc"
+            }
+        }
     }
   ],
   "extra": {
@@ -68,6 +81,9 @@
       "drupal/content_moderation_notifications": {
         "3170503 - Core requirement error during Functional test": "https://www.drupal.org/files/issues/2020-09-11/3170503-2.patch"
       },
+      "drupal/redirect": {
+        "3082364 - Fix the migration of the status_code redirect property: status code of NULL or 0 causes exception": "https://www.drupal.org/files/issues/2020-07-28/redirect-fix_status_code_property_migration-3082364-13.patch"
+      },
       "drupal/paragraphs": {
         "2901390 - Integrity constraint violation: 1048 Column 'langcode' cannot be null": "https://www.drupal.org/files/issues/2020-06-25/paragraphs-2901390-51.patch",
         "3090200 - Paragraphs do not render: access check for 'view' fail when using layout builder": "https://www.drupal.org/files/issues/2020-07-08/access-controll-issue-3090200-22.patch"
@@ -80,6 +96,9 @@
       },
       "drupal_git/migrate_google_sheets": {
         "3138999 - D9 readiness" : "https://www.drupal.org/files/issues/2020-11-17/Drupal-9-readiness-3138999-6.patch"
+      },
+      "drupal_git/migrate_process_trim": {
+        "3141131 - D9 Readiness": "https://www.drupal.org/files/issues/2020-05-23/migrate_process_trim.1.x-dev.rector.patch"
       }
     },
     "preserve-paths": [],
@@ -145,10 +164,11 @@
     "drupal/webform": "^6.0",
     "drupal/webform_encrypt": "1.x-dev@dev",
     "drupal_git/migrate_google_sheets": "1.0.0",
+    "drupal_git/migrate_process_trim": "1.0.0",
     "drupal_git/migration_tools": "1.0.0",
     "drush/drush": "^10.0",
-    "querypath/querypath": "^3.0",
     "oomphinc/composer-installers-extender": "^2.0",
+    "querypath/querypath": "^3.0",
     "zaporylie/composer-drupal-optimizations": "^1.0"
   },
   "require-dev": {

--- a/ecms_base/modules/custom/ecms_migration/README.md
+++ b/ecms_base/modules/custom/ecms_migration/README.md
@@ -12,7 +12,7 @@ extension will crawl the site and find all publicly accessible URLs.
 From this list, a master URL Google Sheet can be created. This list can then
 be filtered to pull out the file URLs from the page URLs.
 
-## Migrations included
+## Migrations currently included
 ### eCMS File
 The eCMS File migration will take a sheet with URLs of existing files and create
 the necessary Drupal file/media/redirect entities to ensure a seamless usage of
@@ -20,6 +20,43 @@ pre-existing links within the content.
 
 ### eCMS Basic Page
 The eCMS Basic Page migration will browse to the URL provided in the Google Sheet
-and will use the first <h1> tag on the page as the title of the node. It will
-continue pulling the inner html from three css selectors and will append that
-content to the
+and will use the first _h1_ tag on the page as the title of the node. It will
+continue pulling the inner html from three user defined css selectors
+and will append that content to the `field_basic_page_body` field.
+
+## Google Sheets
+The Google Sheet that is created _MUST_ be publicly accessible and published to
+the web. This is accomplished by going to the `File > Publish to the web` menu.
+
+Once the Google Sheet is published you will need to obtain the sheet id from the
+URL. You can get this by editing the sheet and inspecting the URL. It will look
+similar to the following:
+
+`https://docs.google.com/spreadsheets/d/MY_SHEET_ID/edit#gid=0`
+
+Copy the value of `MY_SHEET_ID` and paste that into the google_sheet_id field
+of the appropriate migration at the following settings form:
+
+`admin/structure/migrate/ecms_migration/settings`
+
+## Migrating
+Once all of your sheets and selectors have been created and saved as configuration
+you can begin migrating. Click `Execute` next to the migration you would like
+to run, select `import` and click execute. This will pull each url from
+the Google Sheet and will create the appropriate Drupal entities.
+
+## Adding New Migrations
+When adding new migrations to this module you'll need to do a few things:
+
+1. Create the migration and export the configuration to the `config/install` directory.
+2. In the `ecms_migration.settings` configuration, add a new key with the values
+   that need replaced in the migration.
+3. In the `ecms_migration.migrations` configuration, add the same key from the
+   settings file in #2 above and the machine names of the migrations that were
+   added to the config/install directory.
+
+Doing the above will ensure the settings form will update the correct migration
+configurations.
+
+Also, note that the migration tools selector keys need to match the
+ecms_migration.settings keys for proper replacement.

--- a/ecms_base/modules/custom/ecms_migration/README.md
+++ b/ecms_base/modules/custom/ecms_migration/README.md
@@ -1,0 +1,25 @@
+# ECMS Migration
+
+The ecms_migration custom module will allow for migrations from static websites.
+It does this by using Google Sheets with a list of URLs from the website that
+is intended to by migrated into the eCMS system.
+
+## URL Gathering
+URL Gathering to generate the Google Sheet is a manual process. Testing has been
+done with the Google Chrome Site Spider Mark II extension with success. This
+extension will crawl the site and find all publicly accessible URLs.
+
+From this list, a master URL Google Sheet can be created. This list can then
+be filtered to pull out the file URLs from the page URLs.
+
+## Migrations included
+### eCMS File
+The eCMS File migration will take a sheet with URLs of existing files and create
+the necessary Drupal file/media/redirect entities to ensure a seamless usage of
+pre-existing links within the content.
+
+### eCMS Basic Page
+The eCMS Basic Page migration will browse to the URL provided in the Google Sheet
+and will use the first <h1> tag on the page as the title of the node. It will
+continue pulling the inner html from three css selectors and will append that
+content to the

--- a/ecms_base/modules/custom/ecms_migration/README.md
+++ b/ecms_base/modules/custom/ecms_migration/README.md
@@ -50,9 +50,9 @@ When adding new migrations to this module you'll need to do a few things:
 
 1. Create the migration and export the configuration to the `config/install` directory.
 2. In the `ecms_migration.settings` configuration, add a new key with the values
-   that need replaced in the migration.
+   to be replaced in the migration.
 3. In the `ecms_migration.migrations` configuration, add the same key from the
-   settings file in #2 above and the machine names of the migrations that were
+   settings file in #2 above, and the machine names of the migrations that were
    added to the config/install directory.
 
 Doing the above will ensure the settings form will update the correct migration

--- a/ecms_base/modules/custom/ecms_migration/config/install/ecms_migration.migrations.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/ecms_migration.migrations.yml
@@ -1,0 +1,7 @@
+ecms_file:
+  - migrate_plus.migration.ecms_file
+  - migrate_plus.migration.ecms_file_media
+  - migrate_plus.migration.ecms_file_redirect
+ecms_basic_page:
+  - migrate_plus.migration.ecms_basic_page
+  - migrate_plus.migration.ecms_basic_page_url

--- a/ecms_base/modules/custom/ecms_migration/config/install/ecms_migration.settings.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/ecms_migration.settings.yml
@@ -1,0 +1,8 @@
+ecms_file:
+  google_sheet_id: REDACTED
+ecms_basic_page:
+  google_sheet_id: REDACTED
+  css_selector_1: REDACTED
+  css_selector_2: REDACTED
+  css_selector_3: REDACTED
+

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page.yml
@@ -1,8 +1,10 @@
 # Migrate a Google spreadsheet of URLs as basic pages into the eCMS system.
-id: ecms_import_basic_page
+id: ecms_basic_page
 label: Migrate basic pages into eCMS.
 migration_group: ecms
 source:
+  constants:
+    domain: http://www.eohhs.ri.gov
   plugin: url
   data_fetcher_plugin: http
   data_parser_plugin: google_sheets
@@ -29,6 +31,7 @@ source:
     - name: url
       label: 'Url'
       selector: 'url'
+
     - name: status
       label: 'Status'
       selector: 'status'
@@ -49,46 +52,81 @@ source:
         title:
           obtainer: ObtainTitle
           jobs:
+            # Find the first h1 and use that as the page title.
             - job: 'addSearch'
               method: 'pluckSelector'
               arguments:
                 - h1
+            # Find the first h2 and use that as the page title
+            # if the h1 is empty.
             - job: 'addSearch'
               method: 'pluckSelector'
               arguments:
                 - h2
-        field_basic_page_body:
+        # Get the body content.
+        body_container_1:
           obtainer: ObtainBody
           jobs:
+            # Get the body using the css selector provided in body_selector.
             - job: 'addSearch'
               method: 'pluckSelector'
               arguments:
                 - '#dnn_contentpane .livehtmlwrapper'
                 - '1'
                 - innerHTML
+        body_container_2:
+          obtainer: ObtainBody
+          jobs:
+            # Get the body using the css selector provided in body_selector.
+            - job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - '#dnn_subleft .livehtmlwrapper'
+                - '1'
+                - innerHTML
+        body_container_3:
+          obtainer: ObtainBody
+          jobs:
+            # Get the body using the css selector provided in body_selector.
+            - job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - '#dnn_subright .livehtmlwrapper'
+                - '1'
+                - innerHTML
       dom_operations:
         - operation: get_field
           field: title
         - operation: get_field
-          field: field_basic_page_body
+          field: body_container_1
+        - operation: get_field
+          field: body_container_2
+        - operation: get_field
+          field: body_container_3
+
 process:
-  id: url
-  title: title
-  status: status
-  field_basic_page_body/value: field_basic_page_body
-  field_basic_page_body/format:
-    plugin: default_value
-    default_value: full_html
   type:
     plugin: default_value
     default_value: basic_page
 
+  id: url
+  title: title
+  status: status
+  'field_basic_page_body/value':
+    plugin: concat
+    source:
+      - body_container_1
+      - body_container_2
+      - body_container_3
+  'field_basic_page_body/format':
+    plugin: default_value
+    default_value: full_html
   moderation_state:
     plugin: static_map
     source: status
     map:
-      publishd: 1
-      archived: 0
+      1: published
+      0: archived
 
   # Disable path auto.
   'path/pathauto':

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page.yml
@@ -105,10 +105,6 @@ source:
           field: body_container_3
 
 process:
-  type:
-    plugin: default_value
-    default_value: basic_page
-
   id: url
   title: title
   status: status
@@ -135,6 +131,7 @@ process:
 
 destination:
   plugin: 'entity:node'
+  default_bundle: 'basic_page'
 
 dependencies:
   enforced:

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page.yml
@@ -3,8 +3,6 @@ id: ecms_basic_page
 label: Migrate basic pages into eCMS.
 migration_group: ecms
 source:
-  constants:
-    domain: http://www.eohhs.ri.gov
   plugin: url
   data_fetcher_plugin: http
   data_parser_plugin: google_sheets
@@ -12,7 +10,7 @@ source:
   # view” in order for the feed to work. Note that the <SHEET> param is the order of the tabs and WILL change if the
   # tabs are re-ordered.
   # Template: 'https://spreadsheets.google.com/feeds/list/<KEY>/<SHEET>/public/values?alt=json'
-  urls: 'https://spreadsheets.google.com/feeds/list/14gljNKk6k78xPpF96lV_oL9URuMqc1V7vlw58hEFFz4/1/public/values?alt=json'
+  urls: 'https://spreadsheets.google.com/feeds/list/REDACTED/1/public/values?alt=json'
   # Under 'fields', we list the data items to be imported. The first level keys
   # are the source field names we want to populate (the names to be used as
   # sources in the process configuration below). For each field we're importing,
@@ -64,45 +62,45 @@ source:
               arguments:
                 - h2
         # Get the body content.
-        body_container_1:
+        css_selector_1:
           obtainer: ObtainBody
           jobs:
             # Get the body using the css selector provided in body_selector.
             - job: 'addSearch'
               method: 'pluckSelector'
               arguments:
-                - '#dnn_contentpane .livehtmlwrapper'
+                - 'REDACTED'
                 - '1'
                 - innerHTML
-        body_container_2:
+        css_selector_2:
           obtainer: ObtainBody
           jobs:
             # Get the body using the css selector provided in body_selector.
             - job: 'addSearch'
               method: 'pluckSelector'
               arguments:
-                - '#dnn_subleft .livehtmlwrapper'
+                - 'REDACTED'
                 - '1'
                 - innerHTML
-        body_container_3:
+        css_selector_3:
           obtainer: ObtainBody
           jobs:
             # Get the body using the css selector provided in body_selector.
             - job: 'addSearch'
               method: 'pluckSelector'
               arguments:
-                - '#dnn_subright .livehtmlwrapper'
+                - 'REDACTED'
                 - '1'
                 - innerHTML
       dom_operations:
         - operation: get_field
           field: title
         - operation: get_field
-          field: body_container_1
+          field: css_selector_1
         - operation: get_field
-          field: body_container_2
+          field: css_selector_2
         - operation: get_field
-          field: body_container_3
+          field: css_selector_3
 
 process:
   id: url
@@ -111,9 +109,9 @@ process:
   'field_basic_page_body/value':
     plugin: concat
     source:
-      - body_container_1
-      - body_container_2
-      - body_container_3
+      - css_selector_1
+      - css_selector_2
+      - css_selector_3
   'field_basic_page_body/format':
     plugin: default_value
     default_value: full_html

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page.yml
@@ -1,0 +1,104 @@
+# Migrate a Google spreadsheet of URLs as basic pages into the eCMS system.
+id: ecms_import_basic_page
+label: Migrate basic pages into eCMS.
+migration_group: ecms
+source:
+  plugin: url
+  data_fetcher_plugin: http
+  data_parser_plugin: google_sheets
+  # The feed file for the spreadsheet. The Google Spreadsheet should be either “Public” or set to “Anyone with link can
+  # view” in order for the feed to work. Note that the <SHEET> param is the order of the tabs and WILL change if the
+  # tabs are re-ordered.
+  # Template: 'https://spreadsheets.google.com/feeds/list/<KEY>/<SHEET>/public/values?alt=json'
+  urls: 'https://spreadsheets.google.com/feeds/list/14gljNKk6k78xPpF96lV_oL9URuMqc1V7vlw58hEFFz4/1/public/values?alt=json'
+  # Under 'fields', we list the data items to be imported. The first level keys
+  # are the source field names we want to populate (the names to be used as
+  # sources in the process configuration below). For each field we're importing,
+  # we provide a label (optional - this is for display in migration tools) and
+  # an selector (xpath) for retrieving that value. It's important to note that this xpath
+  # is relative to the elements retrieved by item_selector.
+  # For Google Spreadsheet XML feeds the actual columns are named with gsx: followed by the cleaned column name (lower,
+  # limited punctuation, etc).
+
+  # Use the URL as the key unique migration identifier.
+  keys:
+    - url
+
+  # What fields are in the google sheet.
+  fields:
+    - name: url
+      label: 'Url'
+      selector: 'url'
+    - name: status
+      label: 'Status'
+      selector: 'status'
+
+  ids:
+    url:
+      type: string
+
+  migration_tools:
+    - source: url
+      source_type: url
+      source_operation:
+        - operation: modifier
+          modifier: basicCleanup
+      fields:
+        # Obtain the title from the h1 on the page.
+        # Use the first h2 if an h1 is not available.
+        title:
+          obtainer: ObtainTitle
+          jobs:
+            - job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - h1
+            - job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - h2
+        field_basic_page_body:
+          obtainer: ObtainBody
+          jobs:
+            - job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - '#dnn_contentpane .livehtmlwrapper'
+                - '1'
+                - innerHTML
+      dom_operations:
+        - operation: get_field
+          field: title
+        - operation: get_field
+          field: field_basic_page_body
+process:
+  id: url
+  title: title
+  status: status
+  field_basic_page_body/value: field_basic_page_body
+  field_basic_page_body/format:
+    plugin: default_value
+    default_value: full_html
+  type:
+    plugin: default_value
+    default_value: basic_page
+
+  moderation_state:
+    plugin: static_map
+    source: status
+    map:
+      publishd: 1
+      archived: 0
+
+  # Disable path auto.
+  'path/pathauto':
+    plugin: default_value
+    default_value: 0
+
+destination:
+  plugin: 'entity:node'
+
+dependencies:
+  enforced:
+    module:
+      - ecms_migration

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page_url.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page_url.yml
@@ -4,7 +4,6 @@ label: Migrate basic page url into eCMS.
 migration_group: ecms
 source:
   constants:
-    domain: 'http://www.eohhs.ri.gov'
     slash: '/'
     entity_path: 'node'
   plugin: url
@@ -14,7 +13,7 @@ source:
   # view” in order for the feed to work. Note that the <SHEET> param is the order of the tabs and WILL change if the
   # tabs are re-ordered.
   # Template: 'https://spreadsheets.google.com/feeds/list/<KEY>/<SHEET>/public/values?alt=json'
-  urls: 'https://spreadsheets.google.com/feeds/list/14gljNKk6k78xPpF96lV_oL9URuMqc1V7vlw58hEFFz4/1/public/values?alt=json'
+  urls: 'https://spreadsheets.google.com/feeds/list/REDACTED/1/public/values?alt=json'
   # Under 'fields', we list the data items to be imported. The first level keys
   # are the source field names we want to populate (the names to be used as
   # sources in the process configuration below). For each field we're importing,

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page_url.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page_url.yml
@@ -1,0 +1,87 @@
+# Migrate url aliases for basic pages.
+id: ecms_basic_page_url
+label: Migrate basic page url into eCMS.
+migration_group: ecms
+source:
+  constants:
+    domain: 'http://www.eohhs.ri.gov'
+    slash: '/'
+    entity_path: 'node'
+  plugin: url
+  data_fetcher_plugin: http
+  data_parser_plugin: google_sheets
+  # The feed file for the spreadsheet. The Google Spreadsheet should be either “Public” or set to “Anyone with link can
+  # view” in order for the feed to work. Note that the <SHEET> param is the order of the tabs and WILL change if the
+  # tabs are re-ordered.
+  # Template: 'https://spreadsheets.google.com/feeds/list/<KEY>/<SHEET>/public/values?alt=json'
+  urls: 'https://spreadsheets.google.com/feeds/list/14gljNKk6k78xPpF96lV_oL9URuMqc1V7vlw58hEFFz4/1/public/values?alt=json'
+  # Under 'fields', we list the data items to be imported. The first level keys
+  # are the source field names we want to populate (the names to be used as
+  # sources in the process configuration below). For each field we're importing,
+  # we provide a label (optional - this is for display in migration tools) and
+  # an selector (xpath) for retrieving that value. It's important to note that this xpath
+  # is relative to the elements retrieved by item_selector.
+  # For Google Spreadsheet XML feeds the actual columns are named with gsx: followed by the cleaned column name (lower,
+  # limited punctuation, etc).
+
+  # Use the URL as the key unique migration identifier.
+  keys:
+    - url
+
+  # What fields are in the google sheet.
+  fields:
+    - name: url
+      label: 'Url'
+      selector: 'url'
+
+    - name: status
+      label: 'Status'
+      selector: 'status'
+
+    - name: body_selector
+      label: "Body css selector"
+      selector: 'bodyselector'
+
+  ids:
+    url:
+      type: string
+
+process:
+  nid:
+    - plugin: migration_lookup
+      migration: ecms_basic_page
+      source: url
+      no_stub: true
+
+  # Parse the URL and extract the path element from the values.
+  computed_path:
+    - plugin: callback
+      callable: parse_url
+      source: url
+    - plugin: extract
+      index:
+        - path
+
+  path:
+    plugin: concat
+    source:
+      - constants/slash
+      - constants/entity_path
+      - constants/slash
+      - '@nid'
+
+  # Set the alias to the original path.
+  alias: '@computed_path'
+
+
+destination:
+  plugin: 'entity:path_alias'
+
+migration_dependencies:
+  required:
+    - ecms_basic_page
+
+dependencies:
+  enforced:
+    module:
+      - ecms_migration

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page_url.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page_url.yml
@@ -38,10 +38,6 @@ source:
       label: 'Status'
       selector: 'status'
 
-    - name: body_selector
-      label: "Body css selector"
-      selector: 'bodyselector'
-
   ids:
     url:
       type: string

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_file.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_file.yml
@@ -1,0 +1,105 @@
+# Migrate a Google spreadsheet of URLs as file entities into the eCMS system.
+id: ecms_file
+label: Migrate files into the eCMS system.
+migration_group: ecms
+
+destination:
+  plugin: 'entity:file'
+
+source:
+  constants:
+    DRUPAL_FILE_DIRECTORY: 'public://'
+  plugin: url
+  data_fetcher_plugin: http
+  data_parser_plugin: google_sheets
+  # The feed file for the spreadsheet. The Google Spreadsheet should be either “Public” or set to “Anyone with link can
+  # view” in order for the feed to work. Note that the <SHEET> param is the order of the tabs and WILL change if the
+  # tabs are re-ordered.
+  # Template: 'https://spreadsheets.google.com/feeds/list/<KEY>/<SHEET>/public/values?alt=json'
+  urls: 'https://spreadsheets.google.com/feeds/list/10bdfSHzTOkmCGuUJKETiAg9OB9UmD_zAz4tn4bnrDiA/1/public/values?alt=json'
+  # Under 'fields', we list the data items to be imported. The first level keys
+  # are the source field names we want to populate (the names to be used as
+  # sources in the process configuration below). For each field we're importing,
+  # we provide a label (optional - this is for display in migration tools) and
+  # an selector (xpath) for retrieving that value. It's important to note that this xpath
+  # is relative to the elements retrieved by item_selector.
+  # For Google Spreadsheet XML feeds the actual columns are named with gsx: followed by the cleaned column name (lower,
+  # limited punctuation, etc).
+
+  # Use the URL as the key unique migration identifier.
+  keys:
+    - url
+
+  # What fields are in the google sheet.
+  fields:
+    - name: url
+      label: 'Url'
+      selector: 'url'
+
+    - name: status
+      label: 'Status'
+      selector: 'status'
+
+  ids:
+    url:
+      type: string
+
+process:
+  # Extract the filepath from the url.
+  pseudo_file_path:
+    - plugin: callback
+      callable: parse_url
+      source: url
+    - plugin: extract
+      index:
+        - path
+
+  pseudo_directory:
+    - plugin: callback
+      callable: pathinfo
+      source: '@pseudo_file_path'
+    - plugin: extract
+      index:
+        - dirname
+
+  pseudo_filename:
+    - plugin: callback
+      callable: pathinfo
+      source: '@pseudo_file_path'
+    - plugin: extract
+      index:
+        - filename
+    - plugin: skip_on_empty
+      method: row
+      message: 'Cannot import empty image filename.'
+
+  pseudo_basename:
+    - plugin: callback
+      callable: pathinfo
+      source: '@pseudo_file_path'
+    - plugin: extract
+      index:
+        - basename
+
+  pseudo_destination_path:
+    - plugin: concat
+      source:
+        - constants/DRUPAL_FILE_DIRECTORY
+        - '@pseudo_directory'
+        - '/'
+        - '@pseudo_basename'
+
+  filename: '@pseudo_filename'
+  uri:
+    - plugin: file_copy
+      source:
+        - url
+        - '@pseudo_destination_path'
+      file_exists: replace
+      move: false
+
+# Add an enforced dependency so the config uninstalls with the module.
+dependencies:
+  enforced:
+    module:
+      - ecms_migration

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_file.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_file.yml
@@ -16,7 +16,7 @@ source:
   # view” in order for the feed to work. Note that the <SHEET> param is the order of the tabs and WILL change if the
   # tabs are re-ordered.
   # Template: 'https://spreadsheets.google.com/feeds/list/<KEY>/<SHEET>/public/values?alt=json'
-  urls: 'https://spreadsheets.google.com/feeds/list/10bdfSHzTOkmCGuUJKETiAg9OB9UmD_zAz4tn4bnrDiA/1/public/values?alt=json'
+  urls: 'https://spreadsheets.google.com/feeds/list/REDACTED/1/public/values?alt=json'
   # Under 'fields', we list the data items to be imported. The first level keys
   # are the source field names we want to populate (the names to be used as
   # sources in the process configuration below). For each field we're importing,

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_file_media.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_file_media.yml
@@ -1,6 +1,6 @@
 # Migrate a Google spreadsheet of URLs as file entities into the eCMS system.
 id: ecms_file_media
-label: Create media entities from the import files..
+label: Create media entities from the import files.
 migration_group: ecms
 
 destination:

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_file_media.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_file_media.yml
@@ -15,7 +15,7 @@ source:
   # view” in order for the feed to work. Note that the <SHEET> param is the order of the tabs and WILL change if the
   # tabs are re-ordered.
   # Template: 'https://spreadsheets.google.com/feeds/list/<KEY>/<SHEET>/public/values?alt=json'
-  urls: 'https://spreadsheets.google.com/feeds/list/10bdfSHzTOkmCGuUJKETiAg9OB9UmD_zAz4tn4bnrDiA/1/public/values?alt=json'
+  urls: 'https://spreadsheets.google.com/feeds/list/REDACTED/1/public/values?alt=json'
   # Under 'fields', we list the data items to be imported. The first level keys
   # are the source field names we want to populate (the names to be used as
   # sources in the process configuration below). For each field we're importing,

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_file_media.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_file_media.yml
@@ -1,0 +1,80 @@
+# Migrate a Google spreadsheet of URLs as file entities into the eCMS system.
+id: ecms_file_media
+label: Create media entities from the import files..
+migration_group: ecms
+
+destination:
+  plugin: 'entity:media'
+  default_bundle: file
+
+source:
+  plugin: url
+  data_fetcher_plugin: http
+  data_parser_plugin: google_sheets
+  # The feed file for the spreadsheet. The Google Spreadsheet should be either “Public” or set to “Anyone with link can
+  # view” in order for the feed to work. Note that the <SHEET> param is the order of the tabs and WILL change if the
+  # tabs are re-ordered.
+  # Template: 'https://spreadsheets.google.com/feeds/list/<KEY>/<SHEET>/public/values?alt=json'
+  urls: 'https://spreadsheets.google.com/feeds/list/10bdfSHzTOkmCGuUJKETiAg9OB9UmD_zAz4tn4bnrDiA/1/public/values?alt=json'
+  # Under 'fields', we list the data items to be imported. The first level keys
+  # are the source field names we want to populate (the names to be used as
+  # sources in the process configuration below). For each field we're importing,
+  # we provide a label (optional - this is for display in migration tools) and
+  # an selector (xpath) for retrieving that value. It's important to note that this xpath
+  # is relative to the elements retrieved by item_selector.
+  # For Google Spreadsheet XML feeds the actual columns are named with gsx: followed by the cleaned column name (lower,
+  # limited punctuation, etc).
+
+  # Use the URL as the key unique migration identifier.
+  keys:
+    - url
+
+  # What fields are in the google sheet.
+  fields:
+    - name: url
+      label: 'Url'
+      selector: 'url'
+
+    - name: status
+      label: 'Status'
+      selector: 'status'
+
+  ids:
+    url:
+      type: string
+
+process:
+  # Extract the filepath from the url.
+  pseudo_file_path:
+    - plugin: callback
+      callable: parse_url
+      source: url
+    - plugin: extract
+      index:
+        - path
+
+  pseudo_filename:
+    - plugin: callback
+      callable: pathinfo
+      source: '@pseudo_file_path'
+    - plugin: extract
+      index:
+        - filename
+    - plugin: callback
+      callable: urldecode
+
+  name: '@pseudo_filename'
+  field_file/target_id:
+    - plugin: migration_lookup
+      migration: ecms_file
+      source: url
+
+migration_dependencies:
+  required:
+    - ecms_file
+
+# Add an enforced dependency so the config uninstalls with the module.
+dependencies:
+  enforced:
+    module:
+      - ecms_migration

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_file_redirect.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_file_redirect.yml
@@ -17,7 +17,7 @@ source:
   # view” in order for the feed to work. Note that the <SHEET> param is the order of the tabs and WILL change if the
   # tabs are re-ordered.
   # Template: 'https://spreadsheets.google.com/feeds/list/<KEY>/<SHEET>/public/values?alt=json'
-  urls: 'https://spreadsheets.google.com/feeds/list/10bdfSHzTOkmCGuUJKETiAg9OB9UmD_zAz4tn4bnrDiA/1/public/values?alt=json'
+  urls: 'https://spreadsheets.google.com/feeds/list/REDACTED/1/public/values?alt=json'
   # Under 'fields', we list the data items to be imported. The first level keys
   # are the source field names we want to populate (the names to be used as
   # sources in the process configuration below). For each field we're importing,

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_file_redirect.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_file_redirect.yml
@@ -1,0 +1,100 @@
+# Migrate a Google spreadsheet of URLs as file entities into the eCMS system.
+id: ecms_file_redirect
+label: Setup file redirects for the ecms_file migration.
+migration_group: ecms
+
+destination:
+  plugin: 'entity:redirect'
+
+source:
+  constants:
+    DRUPAL_FILE_DIRECTORY: 'sites/default/files'
+    REDIRECT_CODE: 301
+  plugin: url
+  data_fetcher_plugin: http
+  data_parser_plugin: google_sheets
+  # The feed file for the spreadsheet. The Google Spreadsheet should be either “Public” or set to “Anyone with link can
+  # view” in order for the feed to work. Note that the <SHEET> param is the order of the tabs and WILL change if the
+  # tabs are re-ordered.
+  # Template: 'https://spreadsheets.google.com/feeds/list/<KEY>/<SHEET>/public/values?alt=json'
+  urls: 'https://spreadsheets.google.com/feeds/list/10bdfSHzTOkmCGuUJKETiAg9OB9UmD_zAz4tn4bnrDiA/1/public/values?alt=json'
+  # Under 'fields', we list the data items to be imported. The first level keys
+  # are the source field names we want to populate (the names to be used as
+  # sources in the process configuration below). For each field we're importing,
+  # we provide a label (optional - this is for display in migration tools) and
+  # an selector (xpath) for retrieving that value. It's important to note that this xpath
+  # is relative to the elements retrieved by item_selector.
+  # For Google Spreadsheet XML feeds the actual columns are named with gsx: followed by the cleaned column name (lower,
+  # limited punctuation, etc).
+
+  # Use the URL as the key unique migration identifier.
+  keys:
+    - url
+
+  # What fields are in the google sheet.
+  fields:
+    - name: url
+      label: 'Url'
+      selector: 'url'
+
+    - name: status
+      label: 'Status'
+      selector: 'status'
+
+  ids:
+    url:
+      type: string
+
+process:
+  # Extract the filepath from the url.
+  pseudo_original_filepath:
+    - plugin: callback
+      callable: parse_url
+      source: url
+    - plugin: extract
+      index:
+        - path
+
+  pseudo_directory:
+    - plugin: callback
+      callable: pathinfo
+      source: '@pseudo_original_filepath'
+    - plugin: extract
+      index:
+        - dirname
+
+  pseudo_basename:
+    - plugin: callback
+      callable: pathinfo
+      source: '@pseudo_original_filepath'
+    - plugin: extract
+      index:
+        - basename
+
+  pseudo_new_file_path:
+    - plugin: concat
+      source:
+        - constants/DRUPAL_FILE_DIRECTORY
+        - '@pseudo_directory'
+        - '/'
+        - '@pseudo_basename'
+
+  redirect_redirect: '@pseudo_new_file_path'
+  redirect_source:
+    - plugin: ltrim
+      mask: '/'
+      source: '@pseudo_original_filepath'
+      # Url Decode the filepath or the redirect won't work.
+    - plugin: callback
+      callable: urldecode
+  status_code: constants/REDIRECT_CODE
+
+migration_dependencies:
+  required:
+    - ecms_file
+
+# Add an enforced dependency so the config uninstalls with the module.
+dependencies:
+  enforced:
+    module:
+      - ecms_migration

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration_group.ecms.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration_group.ecms.yml
@@ -1,24 +1,17 @@
-# A "migration group" is - surprise! - a group of migrations. It is used to
-# group migrations for display by our tools, and to perform operations on a
-# specific set of migrations. It can also be used to hold any configuration
-# common to those migrations, so it doesn't have to be duplicated in each one.
-
 # The machine name of the group, by which it is referenced in individual
 # migrations.
 id: ecms
 
 # A human-friendly label for the group.
-label: eCMS Migrations
+label: eCMS Migration
 
 # More information about the group.
 description: Migrations for the eCMS project.
 
-# Short description of the type of source, e.g. "Drupal 6" or "WordPress".
-source_type: HTML sites
+# Short description of the type of source.
+source_type: HTML site
 
-# As with the migration configuration (see beer_term), we add an enforced
-# dependency so the migration_group configuration will be removed on module
-# uninstall.
+# Add an enforced dependency so the config uninstalls with the module.
 dependencies:
   enforced:
     module:

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration_group.ecms.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration_group.ecms.yml
@@ -1,0 +1,25 @@
+# A "migration group" is - surprise! - a group of migrations. It is used to
+# group migrations for display by our tools, and to perform operations on a
+# specific set of migrations. It can also be used to hold any configuration
+# common to those migrations, so it doesn't have to be duplicated in each one.
+
+# The machine name of the group, by which it is referenced in individual
+# migrations.
+id: ecms
+
+# A human-friendly label for the group.
+label: eCMS Migrations
+
+# More information about the group.
+description: Migrations for the eCMS project.
+
+# Short description of the type of source, e.g. "Drupal 6" or "WordPress".
+source_type: HTML sites
+
+# As with the migration configuration (see beer_term), we add an enforced
+# dependency so the migration_group configuration will be removed on module
+# uninstall.
+dependencies:
+  enforced:
+    module:
+      - ecms_migration

--- a/ecms_base/modules/custom/ecms_migration/config/schema/ecms_migration.schema.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/schema/ecms_migration.schema.yml
@@ -24,3 +24,13 @@ ecms_migration.settings:
         css_selector_3:
           type: string
           label: "Third CSS Selector"
+
+ecms_migration.migrations:
+  type: config_object
+  mapping:
+    ecms_file:
+      type: sequence
+      label: 'Migration configuration objects for the ecms_file migration'
+    ecms_basic_page:
+      type: sequence
+      label: 'Migration configuration objects for the ecms_basic_page migration'

--- a/ecms_base/modules/custom/ecms_migration/config/schema/ecms_migration.schema.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/schema/ecms_migration.schema.yml
@@ -1,0 +1,26 @@
+ecms_migration.settings:
+  type: config_object
+  mapping:
+    ecms_file:
+      type: mapping
+      label: 'Settings for the Basic Page migration'
+      mapping:
+        google_sheet_id:
+          type: string
+          label: "Google Sheet ID for the File Migration"
+    ecms_basic_page:
+      type: mapping
+      label: 'Settings for the Basic Page migration'
+      mapping:
+        google_sheet_id:
+          type: string
+          label: "Google Sheet ID for the Basic Page Migration"
+        css_selector_1:
+          type: string
+          label: "First CSS Selector"
+        css_selector_2:
+          type: string
+          label: "Second CSS Selector"
+        css_selector_3:
+          type: string
+          label: "Third CSS Selector"

--- a/ecms_base/modules/custom/ecms_migration/ecms_migration.info.yml
+++ b/ecms_base/modules/custom/ecms_migration/ecms_migration.info.yml
@@ -7,3 +7,4 @@ dependencies:
   - drupal:migrate_google_sheets
   - drupal:migration_tools
   - drupal:migrate_tools
+  - drupal:migrate_process_trim

--- a/ecms_base/modules/custom/ecms_migration/ecms_migration.info.yml
+++ b/ecms_base/modules/custom/ecms_migration/ecms_migration.info.yml
@@ -1,0 +1,8 @@
+name: 'Migrate eCMS'
+type: module
+description: 'Migrate a site into the eCMS platform.'
+core_version_requirement: ^8 || ^9
+package: 'Migration'
+dependencies:
+  - drupal:migrate_google_sheets
+  - drupal:migration_tools

--- a/ecms_base/modules/custom/ecms_migration/ecms_migration.info.yml
+++ b/ecms_base/modules/custom/ecms_migration/ecms_migration.info.yml
@@ -1,4 +1,4 @@
-name: 'Migrate eCMS'
+name: 'eCMS Migration'
 type: module
 description: 'Migrate a site into the eCMS platform.'
 core_version_requirement: ^8 || ^9
@@ -6,3 +6,4 @@ package: 'Migration'
 dependencies:
   - drupal:migrate_google_sheets
   - drupal:migration_tools
+  - drupal:migrate_tools

--- a/ecms_base/modules/custom/ecms_migration/ecms_migration.links.action.yml
+++ b/ecms_base/modules/custom/ecms_migration/ecms_migration.links.action.yml
@@ -1,0 +1,5 @@
+ecms_migration.ecms_settings_action:
+  route_name: ecms_migration.settings_form
+  title: 'Update eCMS migration settings'
+  appears_on:
+    - entity.migration_group.list

--- a/ecms_base/modules/custom/ecms_migration/ecms_migration.links.menu.yml
+++ b/ecms_base/modules/custom/ecms_migration/ecms_migration.links.menu.yml
@@ -1,0 +1,6 @@
+ecms_migration.ecms_migration_settings:
+  title: 'eCMS Migration Settings'
+  route_name: ecms_migration.settings_form
+  description: 'Setup the source data for the eCMS migration.'
+  parent: migrate_tools.menu
+  weight: 99

--- a/ecms_base/modules/custom/ecms_migration/ecms_migration.module
+++ b/ecms_base/modules/custom/ecms_migration/ecms_migration.module
@@ -1,0 +1,18 @@
+<?php
+
+use Drupal\migrate\Plugin\MigrateSourceInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Row;
+use Drupal\Core\Site\Settings;
+
+/**
+ * Implements hook_migrate_MIGRATION_ID_prepare_row() for the ecms_file_redirect migration.
+ */
+function ecms_migration_migrate_ecms_file_redirect_prepare_row(Row $row, MigrateSourceInterface $source, MigrationInterface $migration) {
+  // Load the $settings['file_public_path'];
+  // This is required as every site within ACSF will have a different path.
+  $public_file_path = Settings::get('file_public_path');
+
+  $row
+    ->setSourceProperty('constants/DRUPAL_FILE_DIRECTORY', "internal:/{$public_file_path}");
+}

--- a/ecms_base/modules/custom/ecms_migration/ecms_migration.module
+++ b/ecms_base/modules/custom/ecms_migration/ecms_migration.module
@@ -15,7 +15,7 @@ use Drupal\Core\Site\Settings;
 /**
  * Implements hook_migrate_MIGRATION_ID_prepare_row() for the ecms_file_redirect migration.
  */
-function ecms_migration_migrate_ecms_file_redirect_prepare_row(Row $row, MigrateSourceInterface $source, MigrationInterface $migration) {
+function ecms_migration_migrate_ecms_file_redirect_prepare_row(Row $row, MigrateSourceInterface $source, MigrationInterface $migration): void {
   // Load the $settings['file_public_path'] for the site.
   // This is required as every site within ACSF will have a different path.
   $public_file_path = Settings::get('file_public_path');

--- a/ecms_base/modules/custom/ecms_migration/ecms_migration.module
+++ b/ecms_base/modules/custom/ecms_migration/ecms_migration.module
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * @file
+ * ecms_migration.module
+ */
+
+declare(strict_types = 1);
+
 use Drupal\migrate\Plugin\MigrateSourceInterface;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate\Row;
@@ -9,10 +16,11 @@ use Drupal\Core\Site\Settings;
  * Implements hook_migrate_MIGRATION_ID_prepare_row() for the ecms_file_redirect migration.
  */
 function ecms_migration_migrate_ecms_file_redirect_prepare_row(Row $row, MigrateSourceInterface $source, MigrationInterface $migration) {
-  // Load the $settings['file_public_path'];
+  // Load the $settings['file_public_path'] for the site.
   // This is required as every site within ACSF will have a different path.
   $public_file_path = Settings::get('file_public_path');
 
+  // Replace the DRUPAL_FILE_DIRECTORY constant with the site specific value.
   $row
     ->setSourceProperty('constants/DRUPAL_FILE_DIRECTORY', "internal:/{$public_file_path}");
 }

--- a/ecms_base/modules/custom/ecms_migration/ecms_migration.routing.yml
+++ b/ecms_base/modules/custom/ecms_migration/ecms_migration.routing.yml
@@ -1,0 +1,7 @@
+ecms_migration.settings_form:
+  path: 'admin/structure/migrate/ecms_migration/settings'
+  defaults:
+    _form: '\Drupal\ecms_migration\Form\EcmsMigrationConfigForm'
+    _title: 'eCMS Migration Settings'
+  requirements:
+    _permission: 'administer site configuration'

--- a/ecms_base/modules/custom/ecms_migration/src/Form/EcmsMigrationConfigForm.php
+++ b/ecms_base/modules/custom/ecms_migration/src/Form/EcmsMigrationConfigForm.php
@@ -25,7 +25,7 @@ class EcmsMigrationConfigForm extends ConfigFormBase {
   const GOOGLE_SHEET_UUID = 'GOOGLE_SHEET_UUID';
 
   /**
-   * @inheritDoc
+   * {@inheritDoc}
    */
   protected function getEditableConfigNames(): array {
     $return = [
@@ -35,11 +35,10 @@ class EcmsMigrationConfigForm extends ConfigFormBase {
     $migrations = $this->getRawMigrationConfiguration();
 
     return array_merge($return, $migrations);
-
   }
 
   /**
-   * @inheritDoc
+   * {@inheritDoc}
    */
   public function getFormId(): string {
     return 'ecms_migration_settings_form';
@@ -207,4 +206,5 @@ class EcmsMigrationConfigForm extends ConfigFormBase {
       $migrationConfig->set('source.urls', [$googleSheetPath])->save();
     }
   }
+
 }

--- a/ecms_base/modules/custom/ecms_migration/src/Form/EcmsMigrationConfigForm.php
+++ b/ecms_base/modules/custom/ecms_migration/src/Form/EcmsMigrationConfigForm.php
@@ -15,12 +15,27 @@ use Drupal\Core\Form\FormStateInterface;
 class EcmsMigrationConfigForm extends ConfigFormBase {
 
   /**
+   * The Google Sheets URL mask for migration imports.
+   */
+  const GOOGLE_SHEET_URL_MASK = 'https://spreadsheets.google.com/feeds/list/GOOGLE_SHEET_UUID/1/public/values?alt=json';
+
+  /**
+   * The default UUID for the migration url.
+   */
+  const GOOGLE_SHEET_UUID = 'GOOGLE_SHEET_UUID';
+
+  /**
    * @inheritDoc
    */
   protected function getEditableConfigNames(): array {
-    return [
+    $return = [
       'ecms_migration.settings',
     ];
+
+    $migrations = $this->getRawMigrationConfiguration();
+
+    return array_merge($return, $migrations);
+
   }
 
   /**
@@ -30,14 +45,164 @@ class EcmsMigrationConfigForm extends ConfigFormBase {
     return 'ecms_migration_settings_form';
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildForm($form, $form_state);
+    $form['#tree'] = TRUE;
+
+    $values = $this->getRawSettingsConfiguration();
+
+    foreach (array_keys($values) as $fieldsetName) {
+      $form["{$fieldsetName}"] = [
+        '#type' => 'fieldset',
+        '#title' => $this->t('Settings for the %name migration', ['%name' => $fieldsetName]),
+      ];
+    }
+
+    foreach ($values as $fieldset => $settings) {
+      foreach ($settings as $setting => $value) {
+        $form["{$fieldset}"]["{$setting}"] = [
+          '#type' => 'textfield',
+          '#title' => $this->t('Set the %name value', ['%name' => $setting]),
+          '#default_value' => $value,
+        ];
+      }
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
     parent::submitForm($form, $form_state);
 
-//    $values = $form_state->getValue('excluded_languages');
-//
-//    $this->config('ecms_migration.settings')
-//      ->set('excluded_languages', $values)
-//      ->save();
+    $values = $this->getRawSettingsConfiguration();
+
+    foreach (array_keys($values) as $fieldset) {
+      $newConfig = $form_state->getValue("{$fieldset}");
+
+      $this->config('ecms_migration.settings')
+        ->set("{$fieldset}", $newConfig)
+        ->save();
+
+      $this->updateMigrationConfiguration($fieldset, $newConfig);
+    }
+
+    // Flush all caches to detect the new migration configuration settings.
+    drupal_flush_all_caches();
   }
 
+  /**
+   * Get the array of data from configuration.
+   *
+   * @return array
+   *   The raw data for the configuration.
+   */
+  private function getRawSettingsConfiguration(): array {
+    $config = $this->config('ecms_migration.settings');
+    $values = $config->getRawData();
+
+    if (isset($values['_core'])) {
+      unset($values['_core']);
+    }
+
+    return $values;
+  }
+
+  /**
+   * Get the migration configuration object names.
+   *
+   * @return array
+   *   A flattened array of migration keys to update.
+   */
+  private function getRawMigrationConfiguration(): array {
+    $config = $this->configFactory->get('ecms_migration.migrations');
+    $values = $config->getRawData();
+
+    if (isset($values['_core'])) {
+      unset($values['_core']);
+    }
+
+    $flattendArray = array_values($values);
+    return array_merge(...$flattendArray);
+  }
+
+  /**
+   * @param string $name
+   *   The name of the migration fieldset.
+   * @param array $settings
+   *   The settings for the migration.
+   */
+  private function updateMigrationConfiguration(string $name, array $settings): void {
+    // Get the migration configuration for this migration name.
+    $migrations = $this->config('ecms_migration.migrations')->get($name);
+
+    foreach ($settings as $key => $value) {
+      if ($key === 'google_sheet_id') {
+        $this->setGoogleSheet($settings['google_sheet_id'], $migrations);
+      }
+      else {
+        $this->setCssSelector($key, $value, $migrations);
+      }
+    }
+  }
+
+  /**
+   * Set the css selectors for the migration tools.
+   *
+   * @param string $key
+   *   The migration tools key to update.
+   * @param string $selector
+   *   The new css selector to replace the key.
+   * @param array $migrations
+   *   The migrations associated with this form setting.
+   */
+  private function setCssSelector(string $key, string $selector, array $migrations): void {
+    // Set a null selector if the selector key is empty.
+    if (empty($selector)) {
+      $selector = "#ECMS-MIGRATION-NULL-SELECTOR";
+    }
+
+    /** @var \Drupal\Core\Config\Config $migration */
+    foreach ($migrations as $migration) {
+      $migrationConfig = $this->config($migration);
+      $migration_tools = $migrationConfig->get('source.migration_tools');
+
+      // Guard against no migration tools.
+      if (empty($migration_tools)) {
+        continue;
+      }
+
+      // Change the selector value to that of the form.
+      if (isset($migration_tools[0]['fields']["{$key}"])) {
+        $migration_tools[0]['fields']["{$key}"]['jobs'][0]['arguments'][0] = $selector;
+      }
+
+      // Save the migration configuration.
+      $migrationConfig->set('source.migration_tools', $migration_tools)->save();
+    }
+  }
+
+  /**
+   * Set the Google Sheet url for the supplied migrations.
+   *
+   * @param string $googleSheetId
+   *   The UUID of the Google Sheet.
+   * @param array $migrations
+   *   The migrations to apply this sheet ID.
+   */
+  private function setGoogleSheet(string $googleSheetId, array $migrations): void {
+    $googleSheetPath = str_replace(self::GOOGLE_SHEET_UUID, $googleSheetId, self::GOOGLE_SHEET_URL_MASK);
+
+    // All migrations have a URL in the source.
+    /** @var \Drupal\Core\Config\Config $migration */
+    foreach ($migrations as $migration) {
+      $migrationConfig = $this->config($migration);
+      $migrationConfig->set('source.urls', [$googleSheetPath])->save();
+    }
+  }
 }

--- a/ecms_base/modules/custom/ecms_migration/src/Form/EcmsMigrationConfigForm.php
+++ b/ecms_base/modules/custom/ecms_migration/src/Form/EcmsMigrationConfigForm.php
@@ -127,11 +127,13 @@ class EcmsMigrationConfigForm extends ConfigFormBase {
       unset($values['_core']);
     }
 
-    $flattendArray = array_values($values);
-    return array_merge(...$flattendArray);
+    $flattenedArray = array_values($values);
+    return array_merge(...$flattenedArray);
   }
 
   /**
+   * Update the migration configuration with the user supplied values.
+   *
    * @param string $name
    *   The name of the migration fieldset.
    * @param array $settings
@@ -161,7 +163,7 @@ class EcmsMigrationConfigForm extends ConfigFormBase {
    * @param array $migrations
    *   The migrations associated with this form setting.
    */
-  private function setCssSelector(string $key, string $selector, array $migrations): void {
+  protected function setCssSelector(string $key, string $selector, array $migrations): void {
     // Set a null selector if the selector key is empty.
     if (empty($selector)) {
       $selector = "#ECMS-MIGRATION-NULL-SELECTOR";
@@ -195,7 +197,7 @@ class EcmsMigrationConfigForm extends ConfigFormBase {
    * @param array $migrations
    *   The migrations to apply this sheet ID.
    */
-  private function setGoogleSheet(string $googleSheetId, array $migrations): void {
+  protected function setGoogleSheet(string $googleSheetId, array $migrations): void {
     $googleSheetPath = str_replace(self::GOOGLE_SHEET_UUID, $googleSheetId, self::GOOGLE_SHEET_URL_MASK);
 
     // All migrations have a URL in the source.

--- a/ecms_base/modules/custom/ecms_migration/src/Form/EcmsMigrationConfigForm.php
+++ b/ecms_base/modules/custom/ecms_migration/src/Form/EcmsMigrationConfigForm.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\ecms_migration\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provide a configuration form for setting up the eCMS Migration URLs.
+ *
+ * @package Drupal\ecms_migration\Form
+ */
+class EcmsMigrationConfigForm extends ConfigFormBase {
+
+  /**
+   * @inheritDoc
+   */
+  protected function getEditableConfigNames(): array {
+    return [
+      'ecms_migration.settings',
+    ];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getFormId(): string {
+    return 'ecms_migration_settings_form';
+  }
+
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    parent::submitForm($form, $form_state);
+
+//    $values = $form_state->getValue('excluded_languages');
+//
+//    $this->config('ecms_migration.settings')
+//      ->set('excluded_languages', $values)
+//      ->save();
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_migration/src/Form/EcmsMigrationConfigForm.php
+++ b/ecms_base/modules/custom/ecms_migration/src/Form/EcmsMigrationConfigForm.php
@@ -47,7 +47,7 @@ class EcmsMigrationConfigForm extends ConfigFormBase {
   /**
    * {@inheritDoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state) {
+  public function buildForm(array $form, FormStateInterface $form_state): array {
     $form = parent::buildForm($form, $form_state);
     $form['#tree'] = TRUE;
 

--- a/ecms_base/modules/custom/ecms_migration/tests/src/Unit/Form/EcmsMigrationConfigFormTest.php
+++ b/ecms_base/modules/custom/ecms_migration/tests/src/Unit/Form/EcmsMigrationConfigFormTest.php
@@ -45,7 +45,7 @@ class EcmsMigrationConfigFormTest extends UnitTestCase {
   ];
 
   /**
-   * Then expected migration configuration.
+   * The expected migration configuration.
    */
   const MIGRATION_MIGRATIONS_CONFIG = [
     'ecms_file' => [

--- a/ecms_base/modules/custom/ecms_migration/tests/src/Unit/Form/EcmsMigrationConfigFormTest.php
+++ b/ecms_base/modules/custom/ecms_migration/tests/src/Unit/Form/EcmsMigrationConfigFormTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\ecms_migration\Unit\Form;
+
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\ecms_migration\Form\EcmsMigrationConfigForm;
+use Drupal\Tests\UnitTestCase;
+use phpmock\MockBuilder;
+
+/**
+ * Unit tests for the EcmsMigrationConfigForm.
+ *
+ * @package Drupal\Tests\ecms_migration\Unit\Form
+ *
+ * @group ecms_migration
+ */
+class EcmsMigrationConfigFormTest extends UnitTestCase {
+
+  const FORM_ID = 'ecms_migration_settings_form';
+
+  const MIGRATION_SETTINGS_CONFIG = [
+    'ecms_file' => [
+      'google_sheet_id' => 'GOOGLE_ID_123',
+    ],
+    'ecms_basic_page' => [
+      'google_sheet_id' => 'GOOGLE_ID_456',
+      'css_selector_1' => '#css-selector-1',
+      'css_selector_2' => '#css-selector-2',
+      'css_selector_3' => '#css-selector-3',
+    ],
+    '_core' => 'TEST',
+  ];
+
+  const MIGRATION_MIGRATIONS_CONFIG = [
+    'ecms_file' => [
+      'migrate_plus.migration.ecms_file',
+      'migrate_plus.migration.ecms_file_media',
+      'migrate_plus.migration.ecms_file_redirect',
+    ],
+    'ecms_basic_page' => [
+      'migrate_plus.migration.ecms_basic_page',
+      'migrate_plus.migration.ecms_basic_page_url',
+    ],
+    '_core' => 'TEST',
+  ];
+
+  const GOOGLE_SHEET_URL_MASK = 'https://spreadsheets.google.com/feeds/list/GOOGLE_ID/1/public/values?alt=json';
+
+  private $configFactory;
+
+  private $formState;
+
+  private $settingsConfig;
+
+  private $migrationConfig;
+
+  private $mockFlushCache;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $this->formState = $this->createMock(FormStateInterface::class);
+    $this->settingsConfig =$this->createMock(Config::class);
+    $this->migrationConfig = $this->createMock(ImmutableConfig::class);
+
+    $container = new ContainerBuilder();
+    $container->set('string_translation', $this->getStringTranslationStub());
+    $container->set('messenger', $this->createMock(MessengerInterface::class));
+
+    \Drupal::setContainer($container);
+
+    $mockFlushCache = new MockBuilder();
+    $mockFlushCache->setNamespace('Drupal\ecms_migration\Form')
+      ->setName('drupal_flush_all_caches')
+      ->setFunction(
+        function () {
+         return;
+        }
+      );
+
+    $this->mockFlushCache = $mockFlushCache->build();
+    $this->mockFlushCache->enable();
+  }
+
+  protected function tearDown() {
+    parent::tearDown();
+
+    $this->mockFlushCache->disable();
+  }
+
+  /**
+   * Test the getFormId() method.
+   */
+  public function testGetFormId(): void {
+    $form = new EcmsMigrationConfigForm($this->configFactory);
+
+    $id = $form->getFormId();
+
+    $this->assertEquals(self::FORM_ID, $id);
+  }
+
+  /**
+   * Test the buildForm() method.
+   */
+  public function testBuildForm(): void {
+    $form = [];
+
+    $this->settingsConfig->expects($this->once())
+      ->method('getRawData')
+      ->willReturn(self::MIGRATION_SETTINGS_CONFIG);
+
+    $this->migrationConfig->expects($this->once())
+      ->method('getRawData')
+      ->willReturn(self::MIGRATION_MIGRATIONS_CONFIG);
+
+    $this->configFactory->expects($this->once())
+      ->method('get')
+      ->with('ecms_migration.migrations')
+      ->willReturn($this->migrationConfig);
+
+    $this->configFactory->expects($this->once())
+      ->method('getEditable')
+      ->with('ecms_migration.settings')
+      ->willReturn($this->settingsConfig);
+
+    $testForm = new EcmsMigrationConfigForm($this->configFactory);
+
+    $actualFormValues = $testForm->buildForm($form, $this->formState);
+
+    foreach (self::MIGRATION_SETTINGS_CONFIG as $key => $value) {
+      if ($key === '_core') {
+        $this->assertArrayNotHasKey($key, $actualFormValues);
+        continue;
+      }
+
+      $this->assertArrayHasKey($key, $actualFormValues);
+
+      foreach ($value as $sub => $subvalue) {
+        $this->assertArrayHasKey($sub, $actualFormValues[$key]);
+      }
+    }
+  }
+
+  /**
+   * Test the submitForm method.
+   */
+  public function testSubmitForm(): void {
+    $form = [];
+
+    $this->settingsConfig->expects($this->once())
+      ->method('getRawData')
+      ->willReturn(self::MIGRATION_SETTINGS_CONFIG);
+
+    $this->settingsConfig->expects($this->exactly(2))
+      ->method('set')
+      ->withConsecutive(
+        ['ecms_file', self::MIGRATION_SETTINGS_CONFIG['ecms_file']],
+        ['ecms_basic_page', self::MIGRATION_SETTINGS_CONFIG['ecms_basic_page']],
+      )
+      ->willReturnSelf();
+
+    $this->migrationConfig->expects($this->any())
+      ->method('getRawData')
+      ->willReturn(self::MIGRATION_MIGRATIONS_CONFIG);
+
+    $this->migrationConfig->expects($this->exactly(2))
+      ->method('get')
+      ->withConsecutive(
+        ['ecms_file'],
+        ['ecms_basic_page']
+      )
+      ->willReturnOnConsecutiveCalls(
+        self::MIGRATION_MIGRATIONS_CONFIG['ecms_file'],
+        self::MIGRATION_MIGRATIONS_CONFIG['ecms_basic_page']
+      );
+
+    $this->configFactory->expects($this->any())
+      ->method('get')
+      ->with('ecms_migration.migrations')
+      ->willReturn($this->migrationConfig);
+
+    $this->configFactory->expects($this->exactly(3))
+      ->method('getEditable')
+      ->with('ecms_migration.settings')
+      ->willReturn($this->settingsConfig);
+
+    $this->formState->expects($this->exactly(2))
+      ->method('getValue')
+      ->withConsecutive(
+        ['ecms_file'],
+        ['ecms_basic_page'],
+      )
+      ->willReturnOnConsecutiveCalls(
+        self::MIGRATION_SETTINGS_CONFIG['ecms_file'],
+        self::MIGRATION_SETTINGS_CONFIG['ecms_basic_page']
+      );
+
+    //$testForm = new EcmsMigrationConfigForm($this->configFactory);
+    $testForm = $this->getMockBuilder(EcmsMigrationConfigForm::class)
+      ->onlyMethods(['setGoogleSheet', 'setCssSelector'])
+      ->setConstructorArgs([$this->configFactory])
+      ->getMock();
+
+    $testForm->expects($this->exactly(2))
+      ->method('setGoogleSheet')
+      ->withConsecutive(
+        [
+          self::MIGRATION_SETTINGS_CONFIG['ecms_file']['google_sheet_id'],
+          self::MIGRATION_MIGRATIONS_CONFIG['ecms_file'],
+        ],
+        [
+          self::MIGRATION_SETTINGS_CONFIG['ecms_basic_page']['google_sheet_id'],
+          self::MIGRATION_MIGRATIONS_CONFIG['ecms_basic_page'],
+        ]
+      );
+
+    $testForm->expects($this->exactly(3))
+      ->method('setCssSelector')
+      ->withConsecutive(
+        [
+          'css_selector_1',
+          self::MIGRATION_SETTINGS_CONFIG['ecms_basic_page']['css_selector_1'],
+          self::MIGRATION_MIGRATIONS_CONFIG['ecms_basic_page'],
+        ],
+        [
+          'css_selector_2',
+          self::MIGRATION_SETTINGS_CONFIG['ecms_basic_page']['css_selector_2'],
+          self::MIGRATION_MIGRATIONS_CONFIG['ecms_basic_page'],
+        ],
+        [
+          'css_selector_3',
+          self::MIGRATION_SETTINGS_CONFIG['ecms_basic_page']['css_selector_3'],
+          self::MIGRATION_MIGRATIONS_CONFIG['ecms_basic_page'],
+        ],
+      );
+
+    $testForm->submitForm($form, $this->formState);
+  }
+
+  public function testSetGoogleSheet(): void {
+    $id = self::MIGRATION_MIGRATIONS_CONFIG['ecms_file']['google_sheet_id'];
+
+    $this->configFactory->expects($this->exactly(count(self::MIGRATION_MIGRATIONS_CONFIG['ecms_file'])))
+      ->method('getEditable')
+      ->withConsecutive(...self::MIGRATION_MIGRATIONS_CONFIG['ecms_file'])
+      ->willReturnOnConsecutiveCalls();
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_migration/tests/src/Unit/Form/EcmsMigrationConfigFormTest.php
+++ b/ecms_base/modules/custom/ecms_migration/tests/src/Unit/Form/EcmsMigrationConfigFormTest.php
@@ -23,8 +23,14 @@ use phpmock\MockBuilder;
  */
 class EcmsMigrationConfigFormTest extends UnitTestCase {
 
+  /**
+   * The expected form id.
+   */
   const FORM_ID = 'ecms_migration_settings_form';
 
+  /**
+   * The expected settings configuration.
+   */
   const MIGRATION_SETTINGS_CONFIG = [
     'ecms_file' => [
       'google_sheet_id' => 'GOOGLE_ID_123',
@@ -38,6 +44,9 @@ class EcmsMigrationConfigFormTest extends UnitTestCase {
     '_core' => 'TEST',
   ];
 
+  /**
+   * Then expected migration configuration.
+   */
   const MIGRATION_MIGRATIONS_CONFIG = [
     'ecms_file' => [
       'migrate_plus.migration.ecms_file',
@@ -51,16 +60,44 @@ class EcmsMigrationConfigFormTest extends UnitTestCase {
     '_core' => 'TEST',
   ];
 
+  /**
+   * The expected google sheet url.
+   */
   const GOOGLE_SHEET_URL_MASK = 'https://spreadsheets.google.com/feeds/list/GOOGLE_ID/1/public/values?alt=json';
 
+  /**
+   * Mock of the config.factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
   private $configFactory;
 
+  /**
+   * Mock of the FormStateInterface.
+   *
+   * @var \Drupal\Core\Form\FormStateInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
   private $formState;
 
+  /**
+   * Mock of the editable settings configuration.
+   *
+   * @var \Drupal\Core\Config\Config|\PHPUnit\Framework\MockObject\MockObject
+   */
   private $settingsConfig;
 
+  /**
+   * Mock of the immutable migration configuration.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig|\PHPUnit\Framework\MockObject\MockObject
+   */
   private $migrationConfig;
 
+  /**
+   * Mock of the drupal_flush_all_caches() method.
+   *
+   * @var \phpmock\Mock
+   */
   private $mockFlushCache;
 
   /**
@@ -71,7 +108,7 @@ class EcmsMigrationConfigFormTest extends UnitTestCase {
 
     $this->configFactory = $this->createMock(ConfigFactoryInterface::class);
     $this->formState = $this->createMock(FormStateInterface::class);
-    $this->settingsConfig =$this->createMock(Config::class);
+    $this->settingsConfig = $this->createMock(Config::class);
     $this->migrationConfig = $this->createMock(ImmutableConfig::class);
 
     $container = new ContainerBuilder();
@@ -85,7 +122,7 @@ class EcmsMigrationConfigFormTest extends UnitTestCase {
       ->setName('drupal_flush_all_caches')
       ->setFunction(
         function () {
-         return;
+          return;
         }
       );
 
@@ -93,6 +130,9 @@ class EcmsMigrationConfigFormTest extends UnitTestCase {
     $this->mockFlushCache->enable();
   }
 
+  /**
+   * {@inheritDoc}
+   */
   protected function tearDown() {
     parent::tearDown();
 
@@ -206,7 +246,6 @@ class EcmsMigrationConfigFormTest extends UnitTestCase {
         self::MIGRATION_SETTINGS_CONFIG['ecms_basic_page']
       );
 
-    //$testForm = new EcmsMigrationConfigForm($this->configFactory);
     $testForm = $this->getMockBuilder(EcmsMigrationConfigForm::class)
       ->onlyMethods(['setGoogleSheet', 'setCssSelector'])
       ->setConstructorArgs([$this->configFactory])
@@ -246,15 +285,6 @@ class EcmsMigrationConfigFormTest extends UnitTestCase {
       );
 
     $testForm->submitForm($form, $this->formState);
-  }
-
-  public function testSetGoogleSheet(): void {
-    $id = self::MIGRATION_MIGRATIONS_CONFIG['ecms_file']['google_sheet_id'];
-
-    $this->configFactory->expects($this->exactly(count(self::MIGRATION_MIGRATIONS_CONFIG['ecms_file'])))
-      ->method('getEditable')
-      ->withConsecutive(...self::MIGRATION_MIGRATIONS_CONFIG['ecms_file'])
-      ->willReturnOnConsecutiveCalls();
   }
 
 }

--- a/scripts/ci-develop.sh
+++ b/scripts/ci-develop.sh
@@ -40,6 +40,15 @@ $COMPOSER require "symfony/phpunit-bridge:^5.1" --dev --no-update
 $COMPOSER require "drupal/coder:^8.3" --dev --no-update
 $COMPOSER require "drush/drush:^10.0" --dev --no-update
 
+# Add the migrate_google_sheets repository.
+$COMPOSER config repositories.migrate_google_sheets '{"type": "package", "package": {"name": "drupal_git/migrate_google_sheets", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migrate_google_sheets.git", "reference": "22944d55be891cfe48d6a6d7c222ff9e89f67b8d"}}}'
+
+# Add the migration_tools repository.
+$COMPOSER config repositories.migratation_tools '{"type": "package", "package": {"name": "drupal_git/migration_tools", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migration_tools.git", "reference": "3e193bc97d127ea2cff6b80f9509bc161bdee19f"}}}'
+
+# Add the migrate_process_trim repository.
+$COMPOSER config repositories.migratation_process_trim '{"type": "package", "package": {"name": "drupal_git/migrate_process_trim", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migrate_process_trim.git", "reference": "79c7ceb9113c1e21818bd124135e5d261ccbebbc"}}}'
+
 $COMPOSER config repositories.${INSTALL_PROFILE_DIRECTORY} '{"type": "path", "url": "../'${INSTALL_PROFILE_DIRECTORY}'"}'
 
 # Add the pattern lab installer type.
@@ -61,14 +70,5 @@ $COMPOSER require "${REPOSITORY_NAME}:*" --no-progress
 # Require pattern lab master branch from Github.
 $COMPOSER config repositories.${PATTERN_LAB_DIRECTORY} '{"type": "git", "url": "https://github.com/State-of-Rhode-Island-eCMS/ecms_patternlab.git"}'
 $COMPOSER require "${PATTERN_LAB_REPOSITORY_NAME}:dev-master" --no-progress
-
-# Add the migrate_google_sheets repository.
-$COMPOSER config repositories.migrate_google_sheets '{"type": "package", "package": {"name": "drupal_git/migrate_google_sheets", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migrate_google_sheets.git", "reference": "22944d55be891cfe48d6a6d7c222ff9e89f67b8d"}}}'
-
-# Add the migration_tools repository.
-$COMPOSER config repositories.migratation_tools '{"type": "package", "package": {"name": "drupal_git/migration_tools", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migration_tools.git", "reference": "3e193bc97d127ea2cff6b80f9509bc161bdee19f"}}}'
-
-# Add the migrate_process_trim repository.
-$COMPOSER config repositories.migratation_process_trim '{"type": "package", "package": {"name": "drupal_git/migrate_process_trim", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migrate_process_trim.git", "reference": "79c7ceb9113c1e21818bd124135e5d261ccbebbc"}}}'
 
 $COMPOSER install

--- a/scripts/ci-develop.sh
+++ b/scripts/ci-develop.sh
@@ -62,4 +62,13 @@ $COMPOSER require "${REPOSITORY_NAME}:*" --no-progress
 $COMPOSER config repositories.${PATTERN_LAB_DIRECTORY} '{"type": "git", "url": "https://github.com/State-of-Rhode-Island-eCMS/ecms_patternlab.git"}'
 $COMPOSER require "${PATTERN_LAB_REPOSITORY_NAME}:dev-master" --no-progress
 
+# Add the migrate_google_sheets repository.
+$COMPOSER config repositories.migrate_google_sheets '{"type": "package", "package": {"name": "drupal_git/migrate_google_sheets", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migrate_google_sheets.git", "reference": "22944d55be891cfe48d6a6d7c222ff9e89f67b8d"}}}'
+
+# Add the migration_tools repository.
+$COMPOSER config repositories.migratation_tools '{"type": "package", "package": {"name": "drupal_git/migration_tools", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migration_tools.git", "reference": "3e193bc97d127ea2cff6b80f9509bc161bdee19f"}}}'
+
+# Add the migrate_process_trim repository.
+$COMPOSER config repositories.migratation_process_trim '{"type": "package", "package": {"name": "drupal_git/migrate_process_trim", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migrate_process_trim.git", "reference": "79c7ceb9113c1e21818bd124135e5d261ccbebbc"}}}'
+
 $COMPOSER install

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -245,7 +245,7 @@ fi
 $LANDO composer config repositories.migrate_google_sheets '{"type": "package", "package": {"name": "drupal_git/migrate_google_sheets", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migrate_google_sheets.git", "reference": "22944d55be891cfe48d6a6d7c222ff9e89f67b8d"}}}'
 
 # Add the migration_tools repository.
-$LANDO composer config repositories.migrate_google_sheets '{"type": "package", "package": {"name": "drupal_git/migration_tools", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migration_tools.git", "reference": "3e193bc97d127ea2cff6b80f9509bc161bdee19f"}}}'
+$LANDO composer config repositories.migratation_tools '{"type": "package", "package": {"name": "drupal_git/migration_tools", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migration_tools.git", "reference": "3e193bc97d127ea2cff6b80f9509bc161bdee19f"}}}'
 
 $LANDO composer config extra.enable-patching true
 $LANDO composer require "${REPOSITORY_NAME}:*" --no-progress

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -241,6 +241,12 @@ else
   sed -i 's/"PATTERN_LAB_REPLACE"/\["type:pattern-lab"]/g' composer.json
 fi
 
+# Add the migrate_google_sheets repository.
+$LANDO composer config repositories.migrate_google_sheets '{"type": "package", "package": {"name": "drupal_git/migrate_google_sheets", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migrate_google_sheets.git", "reference": "22944d55be891cfe48d6a6d7c222ff9e89f67b8d"}}}'
+
+# Add the migration_tools repository.
+$LANDO composer config repositories.migrate_google_sheets '{"type": "package", "package": {"name": "drupal_git/migration_tools", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migration_tools.git", "reference": "3e193bc97d127ea2cff6b80f9509bc161bdee19f"}}}'
+
 $LANDO composer config extra.enable-patching true
 $LANDO composer require "${REPOSITORY_NAME}:*" --no-progress
 

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -247,6 +247,9 @@ $LANDO composer config repositories.migrate_google_sheets '{"type": "package", "
 # Add the migration_tools repository.
 $LANDO composer config repositories.migratation_tools '{"type": "package", "package": {"name": "drupal_git/migration_tools", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migration_tools.git", "reference": "3e193bc97d127ea2cff6b80f9509bc161bdee19f"}}}'
 
+# Add the migrate_process_trim repository.
+$LANDO composer config repositories.migratation_process_trim '{"type": "package", "package": {"name": "drupal_git/migrate_process_trim", "type": "drupal-module", "version": "1.0.0", "source": {"type": "git", "url": "https://git.drupalcode.org/project/migrate_process_trim.git", "reference": "79c7ceb9113c1e21818bd124135e5d261ccbebbc"}}}'
+
 $LANDO composer config extra.enable-patching true
 $LANDO composer require "${REPOSITORY_NAME}:*" --no-progress
 


### PR DESCRIPTION
## Summary
This adds a new ecms_migration module that will take a google sheet of urls and create basic pages and file/media entities from those URLS.


## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes (mostly)
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-106](https://thinkoomph.jira.com/browse/rig-106)