### PR TITLE
Add the audio media type

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -137,9 +137,9 @@ jobs:
           echo "\$settings['file_temp_path'] = '/var/www/html/sites/default/files/tmp';" >> /var/www/html/sites/default/settings.php
           echo "\$settings['file_public_path'] = '/var/www/html/sites/default/files';" >> /var/www/html/sites/default/settings.php
 
-       - name: Run functional tests.
-         working-directory: ${{ env.DRUPAL_DIRECTORY }}
-         run: ../vendor/bin/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml --testsuite=functional
+      - name: Run functional tests.
+        working-directory: ${{ env.DRUPAL_DIRECTORY }}
+        run: ../vendor/bin/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml --testsuite=functional
 #      - name: Run functional tests with fastest.
 #        working-directory: ${{ env.ECMS_PROFILE_DIRECTORY }}
 #        run: find . -type f -iname "*Test.php" | grep "Functional" | sudo -u www-data -E /var/www/vendor/liuggio/fastest/fastest  "/var/www/vendor/phpunit/phpunit/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml {};"

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -137,10 +137,12 @@ jobs:
           echo "\$settings['file_temp_path'] = '/var/www/html/sites/default/files/tmp';" >> /var/www/html/sites/default/settings.php
           echo "\$settings['file_public_path'] = '/var/www/html/sites/default/files';" >> /var/www/html/sites/default/settings.php
 
-      - name: Run functional tests with fastest.
-        working-directory: ${{ env.ECMS_PROFILE_DIRECTORY }}
-        run: ../vendor/bin/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml --testsuite=functional
-        #run: find . -type f -iname "*Test.php" | grep "Functional" | sudo -u www-data -E /var/www/vendor/liuggio/fastest/fastest  "/var/www/vendor/phpunit/phpunit/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml {};"
+       - name: Run functional tests.
+         working-directory: ${{ env.DRUPAL_DIRECTORY }}
+         run: ../vendor/bin/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml --testsuite=functional
+#      - name: Run functional tests with fastest.
+#        working-directory: ${{ env.ECMS_PROFILE_DIRECTORY }}
+#        run: find . -type f -iname "*Test.php" | grep "Functional" | sudo -u www-data -E /var/www/vendor/liuggio/fastest/fastest  "/var/www/vendor/phpunit/phpunit/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml {};"
 
 #      - name: Run existing site tests.
 #        working-directory: ${{ env.ECMS_PROFILE_DIRECTORY }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -139,7 +139,8 @@ jobs:
 
       - name: Run functional tests with fastest.
         working-directory: ${{ env.ECMS_PROFILE_DIRECTORY }}
-        run: find . -type f -iname "*Test.php" | grep "Functional" | sudo -u www-data -E /var/www/vendor/liuggio/fastest/fastest  "/var/www/vendor/phpunit/phpunit/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml {};"
+        run: ../vendor/bin/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml --testsuite=functional
+        #run: find . -type f -iname "*Test.php" | grep "Functional" | sudo -u www-data -E /var/www/vendor/liuggio/fastest/fastest  "/var/www/vendor/phpunit/phpunit/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml {};"
 
 #      - name: Run existing site tests.
 #        working-directory: ${{ env.ECMS_PROFILE_DIRECTORY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - RIG-131: Add Search API and database index.
 - RIG-106: Added custom migrations from static websites.
+- RIG-155: Add the Audio media item.
 
 ### Changed
 

--- a/ecms_base/ecms_base.profile
+++ b/ecms_base/ecms_base.profile
@@ -203,3 +203,24 @@ function ecms_base_update_9022(array &$sandbox): void {
   // Add the breadcrumbs block.
   $active_storage->write('block.block.breadcrumbs', $theme_source->read('block.block.breadcrumbs'));
 }
+
+/**
+ * Updates to run for the 0.2.4 tag.
+ */
+function ecms_base_update_9024(array &$sandbox): void {
+  // Reinstall the features that were no longer installed on the Covid site.
+  $modules_to_install = [
+    'ecms_basic_page',
+    'ecms_event',
+    'ecms_landing_page',
+    'ecms_location',
+    'ecms_notification',
+    'ecms_paragraphs',
+    'ecms_person',
+    'ecms_press_release',
+    'ecms_promotions',
+  ];
+
+  // Make sure necessary modules are installed.
+  \Drupal::service('module_installer')->install($modules_to_install);
+}

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_audio.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_audio.default.yml
@@ -1,0 +1,66 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.media_item_audio.field_media_audio_file
+    - media.type.media_item_audio
+  module:
+    - file
+    - path
+id: media.media_item_audio.default
+targetEntityType: media
+bundle: media_item_audio
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_media_audio_file:
+    weight: 0
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: file_generic
+    region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 100
+    region: content
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_audio.media_library.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_audio.media_library.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.media_item_audio.field_media_audio_file
+    - media.type.media_item_audio
+id: media.media_item_audio.media_library
+targetEntityType: media
+bundle: media_item_audio
+mode: media_library
+content:
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_media_audio_file: true
+  langcode: true
+  path: true
+  status: true
+  uid: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.media_item.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.media_item.default.yml
@@ -51,6 +51,11 @@ content:
     third_party_settings: {  }
     type: options_select
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   status: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.media_item_audio.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.media_item_audio.default.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.media_item_audio.field_media_audio_file
+    - media.type.media_item_audio
+  module:
+    - file
+id: media.media_item_audio.default
+targetEntityType: media
+bundle: media_item_audio
+mode: default
+content:
+  field_media_audio_file:
+    type: file_audio
+    label: visually_hidden
+    weight: 0
+    settings:
+      controls: true
+      autoplay: false
+      loop: false
+      multiple_file_display_type: tags
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.media_item_audio.media_library.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.media_item_audio.media_library.yml
@@ -1,0 +1,35 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.media_item_audio.field_media_audio_file
+    - image.style.medium
+    - media.type.media_item_audio
+  module:
+    - svg_image
+id: media.media_item_audio.media_library
+targetEntityType: media
+bundle: media_item_audio
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_style: medium
+      image_link: ''
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_media_audio_file: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  uid: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.media_item_audio.field_media_audio_file.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.media_item_audio.field_media_audio_file.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_audio_file
+    - media.type.media_item_audio
+  module:
+    - file
+id: media.media_item_audio.field_media_audio_file
+field_name: field_media_audio_file
+entity_type: media
+bundle: media_item_audio
+label: 'Audio file'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'mp3 wav aac'
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  description_field: false
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: file

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.media_item_audio.field_media_audio_file.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.media_item_audio.field_media_audio_file.yml
@@ -17,8 +17,8 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_extensions: 'mp3 wav aac'
   file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'mp3 mp4'
   max_filesize: ''
   description_field: false
   handler: 'default:file'

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.paragraph.media_item.field_media_item.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.paragraph.media_item.field_media_item.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_media_item
+    - media.type.media_item_audio
     - media.type.media_item_image
     - media.type.media_item_video
     - paragraphs.paragraphs_type.media_item
@@ -20,6 +21,7 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
+      media_item_audio: media_item_audio
       media_item_image: media_item_image
       media_item_video: media_item_video
     sort:

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.storage.media.field_media_audio_file.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.storage.media.field_media_audio_file.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - media
+id: media.field_media_audio_file
+field_name: field_media_audio_file
+entity_type: media
+type: file
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.media.media_item_audio.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.media.media_item_audio.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.media_item_audio
+id: media.media_item_audio
+target_entity_type_id: media
+target_bundle: media_item_audio
+default_langcode: site_default
+language_alterable: false

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/media.type.media_item_audio.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/media.type.media_item_audio.yml
@@ -1,0 +1,12 @@
+langcode: en
+status: true
+dependencies: {  }
+id: media_item_audio
+label: 'Media Item: Audio'
+description: 'An audio file referenced from a Media Item paragraph.'
+source: audio_file
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  source_field: field_media_audio_file
+field_map: {  }


### PR DESCRIPTION
## Summary
This adds the media type audio to and updates the media item paragraph to allow referencing the new media item. This also adds the 9024 update hook to re-install the feature modules that were no longer installed on the Covid site.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-155](https://thinkoomph.jira.com/browse/rig-155)