### PR TITLE
Add Text Card Collection and Page Title with Photo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-155: Add the Audio media item.
 - RIG-131: Add custom eCMS search form.
 - RIG-131: Theme search page.
+- RIG-130: Add text card paragraph.
+- RIG-130: Add text card collection block type.
+- RIG-130: Add photo title with image block type.
 
 ### Changed
 

--- a/ecms_base/config/install/user.role.anonymous.yml
+++ b/ecms_base/config/install/user.role.anonymous.yml
@@ -15,3 +15,4 @@ permissions:
   - 'view paragraph content formatted_text'
   - 'view paragraph content icon_card'
   - 'view paragraph content media_item'
+  - 'view paragraph content text_card'

--- a/ecms_base/features/custom/ecms_landing_page/config/install/block_content.type.content_components.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/block_content.type.content_components.yml
@@ -2,6 +2,6 @@ langcode: en
 status: true
 dependencies: {  }
 id: content_components
-label: 'Content Components'
+label: 'Content components'
 revision: 0
 description: 'A block type which allows for multiple paragraphs to be embedded.'

--- a/ecms_base/features/custom/ecms_landing_page/config/install/block_content.type.page_title_with_photo.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/block_content.type.page_title_with_photo.yml
@@ -1,0 +1,7 @@
+langcode: es
+status: true
+dependencies: {  }
+id: page_title_with_photo
+label: 'Page title with photo'
+revision: 0
+description: 'A block type that can be used to add a stylized page title with photo.'

--- a/ecms_base/features/custom/ecms_landing_page/config/install/block_content.type.text_card_collection.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/block_content.type.text_card_collection.yml
@@ -1,0 +1,7 @@
+langcode: es
+status: true
+dependencies: {  }
+id: text_card_collection
+label: 'Text Card Collection'
+revision: 0
+description: 'A block type that displays multiple text cards.'

--- a/ecms_base/features/custom/ecms_landing_page/config/install/block_content.type.text_card_collection.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/block_content.type.text_card_collection.yml
@@ -2,6 +2,6 @@ langcode: es
 status: true
 dependencies: {  }
 id: text_card_collection
-label: 'Text Card Collection'
+label: 'Text card collection'
 revision: 0
 description: 'A block type that displays multiple text cards.'

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_view_display.block_content.page_title_with_photo.default.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_view_display.block_content.page_title_with_photo.default.yml
@@ -1,0 +1,23 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - block_content.type.page_title_with_photo
+    - field.field.block_content.page_title_with_photo.field_image
+id: block_content.page_title_with_photo.default
+targetEntityType: block_content
+bundle: page_title_with_photo
+mode: default
+content:
+  field_image:
+    type: entity_reference_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_view_display.block_content.text_card_collection.default.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_view_display.block_content.text_card_collection.default.yml
@@ -1,0 +1,43 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - block_content.type.text_card_collection
+    - field.field.block_content.text_card_collection.field_cards
+    - field.field.block_content.text_card_collection.field_collection_card_style
+    - field.field.block_content.text_card_collection.field_collection_description
+  module:
+    - entity_reference_revisions
+    - options
+    - text
+id: block_content.text_card_collection.default
+targetEntityType: block_content
+bundle: text_card_collection
+mode: default
+content:
+  field_cards:
+    type: entity_reference_revisions_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_collection_card_style:
+    weight: 3
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: list_key
+    region: content
+  field_collection_description:
+    weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/ecms_base/features/custom/ecms_landing_page/config/install/field.field.block_content.page_title_with_photo.field_image.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/field.field.block_content.page_title_with_photo.field_image.yml
@@ -1,0 +1,28 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - block_content.type.page_title_with_photo
+    - field.storage.block_content.field_image
+    - media.type.media_item_image
+id: block_content.page_title_with_photo.field_image
+field_name: field_image
+entity_type: block_content
+bundle: page_title_with_photo
+label: Image
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      media_item_image: media_item_image
+    sort:
+      field: changed
+      direction: DESC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_landing_page/config/install/field.field.block_content.text_card_collection.field_cards.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/field.field.block_content.text_card_collection.field_cards.yml
@@ -1,0 +1,54 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - block_content.type.text_card_collection
+    - field.storage.block_content.field_cards
+    - paragraphs.paragraphs_type.text_card
+  module:
+    - entity_reference_revisions
+id: block_content.text_card_collection.field_cards
+field_name: field_cards
+entity_type: block_content
+bundle: text_card_collection
+label: Cards
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      text_card: text_card
+    target_bundles_drag_drop:
+      accordion_builder:
+        weight: 10
+        enabled: false
+      column_container:
+        weight: 11
+        enabled: false
+      embed:
+        weight: 12
+        enabled: false
+      file_list:
+        weight: 13
+        enabled: false
+      formatted_text:
+        weight: 14
+        enabled: false
+      icon_card:
+        weight: 15
+        enabled: false
+      media_item:
+        weight: 16
+        enabled: false
+      promotion_reference:
+        weight: 17
+        enabled: false
+      text_card:
+        enabled: true
+        weight: 18
+field_type: entity_reference_revisions

--- a/ecms_base/features/custom/ecms_landing_page/config/install/field.field.block_content.text_card_collection.field_collection_card_style.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/field.field.block_content.text_card_collection.field_collection_card_style.yml
@@ -1,0 +1,22 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - block_content.type.text_card_collection
+    - field.storage.block_content.field_collection_card_style
+  module:
+    - options
+id: block_content.text_card_collection.field_collection_card_style
+field_name: field_collection_card_style
+entity_type: block_content
+bundle: text_card_collection
+label: 'Card Style'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: no-style
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/ecms_base/features/custom/ecms_landing_page/config/install/field.field.block_content.text_card_collection.field_collection_description.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/field.field.block_content.text_card_collection.field_collection_description.yml
@@ -1,0 +1,29 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - block_content.type.text_card_collection
+    - field.storage.block_content.field_collection_description
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    paragraph_text: paragraph_text
+    basic_html: '0'
+    embed: '0'
+    restricted_html: '0'
+    full_html: '0'
+    plain_text: '0'
+id: block_content.text_card_collection.field_collection_description
+field_name: field_collection_description
+entity_type: block_content
+bundle: text_card_collection
+label: 'Collection Description'
+description: '(Optional) A rich text field that displays under the collection title.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/ecms_base/features/custom/ecms_landing_page/config/install/field.storage.block_content.field_cards.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/field.storage.block_content.field_cards.yml
@@ -1,0 +1,20 @@
+langcode: es
+status: true
+dependencies:
+  module:
+    - block_content
+    - entity_reference_revisions
+    - paragraphs
+id: block_content.field_cards
+field_name: field_cards
+entity_type: block_content
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_landing_page/config/install/field.storage.block_content.field_collection_card_style.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/field.storage.block_content.field_collection_card_style.yml
@@ -1,0 +1,35 @@
+langcode: es
+status: true
+dependencies:
+  module:
+    - block_content
+    - options
+id: block_content.field_collection_card_style
+field_name: field_collection_card_style
+entity_type: block_content
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: no-style
+      label: None
+    -
+      value: primary-bg
+      label: 'Background: primary'
+    -
+      value: primary-light-bg
+      label: 'Background: light'
+    -
+      value: coffee-milk-bg
+      label: 'Background: coffee milk'
+    -
+      value: border-btwn
+      label: 'Border: in between'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_landing_page/config/install/field.storage.block_content.field_collection_description.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/field.storage.block_content.field_collection_description.yml
@@ -1,0 +1,18 @@
+langcode: es
+status: true
+dependencies:
+  module:
+    - block_content
+    - text
+id: block_content.field_collection_description
+field_name: field_collection_description
+entity_type: block_content
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_landing_page/config/install/field.storage.block_content.field_image.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/field.storage.block_content.field_image.yml
@@ -1,0 +1,19 @@
+langcode: es
+status: true
+dependencies:
+  module:
+    - block_content
+    - media
+id: block_content.field_image
+field_name: field_image
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_landing_page/config/install/language.content_settings.block_content.text_card_collection.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/language.content_settings.block_content.text_card_collection.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - block_content.type.text_card_collection
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: block_content.text_card_collection
+target_entity_type_id: block_content
+target_bundle: text_card_collection
+default_langcode: site_default
+language_alterable: false

--- a/ecms_base/features/custom/ecms_landing_page/ecms_landing_page.info.yml
+++ b/ecms_base/features/custom/ecms_landing_page/ecms_landing_page.info.yml
@@ -6,6 +6,7 @@ dependencies:
   - block_content
   - content_moderation
   - content_translation
+  - ecms_paragraphs
   - ecms_workflow
   - entity_reference_revisions
   - field

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.text_card.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.text_card.default.yml
@@ -1,0 +1,38 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.text_card.field_card_title
+    - field.field.paragraph.text_card.field_text
+    - paragraphs.paragraphs_type.text_card
+  module:
+    - text
+id: paragraph.text_card.default
+targetEntityType: paragraph
+bundle: text_card
+mode: default
+content:
+  field_card_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_text:
+    weight: 1
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  translation:
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.paragraph.text_card.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.paragraph.text_card.default.yml
@@ -1,0 +1,31 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.text_card.field_card_title
+    - field.field.paragraph.text_card.field_text
+    - paragraphs.paragraphs_type.text_card
+  module:
+    - text
+id: paragraph.text_card.default
+targetEntityType: paragraph
+bundle: text_card
+mode: default
+content:
+  field_card_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_text:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.paragraph.text_card.field_card_title.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.paragraph.text_card.field_card_title.yml
@@ -1,0 +1,18 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_card_title
+    - paragraphs.paragraphs_type.text_card
+id: paragraph.text_card.field_card_title
+field_name: field_card_title
+entity_type: paragraph
+bundle: text_card
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.paragraph.text_card.field_text.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.paragraph.text_card.field_text.yml
@@ -1,0 +1,29 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_text
+    - paragraphs.paragraphs_type.text_card
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    paragraph_text: paragraph_text
+    basic_html: '0'
+    embed: '0'
+    restricted_html: '0'
+    full_html: '0'
+    plain_text: '0'
+id: paragraph.text_card.field_text
+field_name: field_text
+entity_type: paragraph
+bundle: text_card
+label: Text
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.storage.paragraph.field_card_title.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.storage.paragraph.field_card_title.yml
@@ -1,0 +1,20 @@
+langcode: es
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_card_title
+field_name: field_card_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/paragraphs.paragraphs_type.text_card.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/paragraphs.paragraphs_type.text_card.yml
@@ -1,0 +1,9 @@
+langcode: es
+status: true
+dependencies: {  }
+id: text_card
+label: 'Text Card'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/ecms_base/modules/custom/ecms_blocks/src/Form/SearchBlockForm.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Form/SearchBlockForm.php
@@ -43,7 +43,7 @@ class SearchBlockForm extends FormBase {
 
     $form['actions']['submit'] = [
       '#type' => 'submit',
-      '#value' => $this->t('Search')
+      '#value' => $this->t('Search'),
     ];
 
     return $form;

--- a/ecms_base/themes/custom/ecms/templates/blocks/block--inline-block--page-title-with-photo.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/blocks/block--inline-block--page-title-with-photo.html.twig
@@ -1,0 +1,48 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a text card collection.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main content
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ *
+ * @ingroup themeable
+ */
+#}
+
+{% set cachebust = content|render %}
+
+{% set img = "" %}
+
+{% if content.field_image|render is not empty %}
+  {% set img_uri = content.field_image[0]['#media'].field_media_item_image.entity.uri.value %}
+  {% set img_alt = content.field_image[0]['#media'].field_media_item_image.alt %}
+  {% set img = drupal_image(img_uri, 'wide', {alt: img_alt}, true) %}
+{% endif %}
+
+{% include '@molecules/page_title_with_image/page_title_with_image.twig' with {
+  title: label,
+  img: img,
+  title_prefix: title_prefix,
+  title_suffix: title_suffix,
+} %}

--- a/ecms_base/themes/custom/ecms/templates/blocks/block--inline-block--text-card-collection.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/blocks/block--inline-block--text-card-collection.html.twig
@@ -1,0 +1,53 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a text card collection.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main content
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ *
+ * @ingroup themeable
+ */
+#}
+
+{% set cachebust = content|render %}
+
+{# Description #}
+{% if content.field_collection_description.isEmpty() %}
+  {% set description = "" %}
+{% else %}
+  {% set description = content.field_collection_description|render %}
+{% endif %}
+
+{# Card Style #}
+{% set card_style = content.field_collection_card_style|render|striptags|trim|clean_class %}
+
+{% include '@organisms/text-card-collection/text-card-collection.twig' with {
+  label: label,
+  cards: content.field_cards,
+  description: description,
+  card_style: card_style,
+  title_prefix: title_prefix,
+  title_suffix: title_suffix,
+} %}
+

--- a/ecms_base/themes/custom/ecms/templates/fields/field--field-collection-description.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/fields/field--field-collection-description.html.twig
@@ -1,0 +1,1 @@
+{% extends "@generic/blank-field-template.html.twig" %}

--- a/ecms_base/themes/custom/ecms/templates/fields/field--paragraph--field-text--text-card.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/fields/field--paragraph--field-text--text-card.html.twig
@@ -1,0 +1,1 @@
+{% extends "@generic/blank-field-template.html.twig" %}

--- a/ecms_base/themes/custom/ecms/templates/paragraphs/paragraph--text-card.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/paragraphs/paragraph--text-card.html.twig
@@ -1,0 +1,58 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a text card paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+
+{% set cachebust = content|render %}
+
+{# Description #}
+{% if content.field_text.isEmpty() %}
+  {% set text = "" %}
+{% else %}
+  {% set text = content.field_text|render %}
+{% endif %}
+
+{# Card Style #}
+{% set card_style = content.field_collection_card_style|render|striptags|trim|clean_class %}
+
+{% include "@molecules/text-card/text-card.twig" with {
+    title: paragraph.field_card_title.value,
+    text: text,
+  }
+%}


### PR DESCRIPTION
## Summary
This PR adds:

- Text Card paragraph bundle. 
- Text Card Collection block type.
- Page title with photo block type.

These were added to ecms_paragraphs and  ecms_landing_page respectively.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | no
| Risk level | Low, 
| Relevant links | https://thinkoomph.jira.com/browse/RIG-131