### PR TITLE
Publication node migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Changed
 
-### Changed
-
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIG-131: Add Search API and database index.
+- RIG-106: Added custom migrations from static websites.
+- RIG-141: Added Covid site specific publication migration from an RSS feed.
+
+### Changed
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
-- RIG-131: Add Search API and database index.
-- RIG-106: Added custom migrations from static websites.
 - RIG-141: Added Covid site specific publication migration from an RSS feed.
 
 ### Changed

--- a/ecms_base/features/custom/ecms_publications/config/install/views.view.publications.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/views.view.publications.yml
@@ -52,12 +52,17 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       pager:
-        type: mini
+        type: full
         options:
           items_per_page: 50
           offset: 0
           id: 0
           total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -66,9 +71,7 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
+          quantity: 4
       style:
         type: table
         options:
@@ -412,7 +415,7 @@ display:
           type: select
           limit: true
           vid: publication_type
-          hierarchy: false
+          hierarchy: true
           error_message: true
           plugin_id: taxonomy_index_tid
         langcode:
@@ -472,7 +475,7 @@ display:
           group_type: group
           admin_label: ''
           order: ASC
-          exposed: true
+          exposed: false
           expose:
             label: 'Sort by type'
           plugin_id: standard
@@ -490,8 +493,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - 'url.query_args:sort_by'
-        - 'url.query_args:sort_order'
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -513,8 +514,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - 'url.query_args:sort_by'
-        - 'url.query_args:sort_order'
         - user
         - 'user.node_grants:view'
         - user.permissions

--- a/ecms_base/features/custom/ecms_publications/config/install/views.view.publications.yml
+++ b/ecms_base/features/custom/ecms_publications/config/install/views.view.publications.yml
@@ -1,0 +1,523 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.storage.node.field_publication_types
+    - field.storage.node.field_publication_url
+    - node.type.publication
+    - taxonomy.vocabulary.publication_type
+  module:
+    - link
+    - node
+    - taxonomy
+    - user
+id: publications
+label: Publications
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            field_publication_url: field_publication_url
+            field_publication_types: field_publication_types
+          info:
+            field_publication_url:
+              align: views-align-left
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_publication_types:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: '-1'
+          empty_table: false
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      fields:
+        field_publication_url:
+          id: field_publication_url
+          table: node__field_publication_url
+          field: field_publication_url
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Publication
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: 80
+            url_only: false
+            url_plain: false
+            rel: '0'
+            target: _blank
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_publication_types:
+          id: field_publication_types
+          table: node__field_publication_types
+          field: field_publication_types
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Publication Types'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        langcode:
+          id: langcode
+          table: node
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Language
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: language
+          settings:
+            link_to_entity: false
+            native_language: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: langcode
+          plugin_id: field
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            publication: publication
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        default_langcode:
+          id: default_langcode
+          table: node_field_data
+          field: default_langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: default_langcode
+          plugin_id: boolean
+        field_publication_types_target_id:
+          id: field_publication_types_target_id
+          table: node__field_publication_types
+          field: field_publication_types_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_publication_types_target_id_op
+            label: 'Publication Type'
+            description: ''
+            use_operator: false
+            operator: field_publication_types_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_publication_types_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              drupal_admin: '0'
+              content_author: '0'
+              embed_author: '0'
+              form_author: '0'
+              content_publisher: '0'
+              site_admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: publication_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        langcode:
+          id: langcode
+          table: node
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: langcode_op
+            label: Language
+            description: ''
+            use_operator: false
+            operator: langcode_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              drupal_admin: '0'
+              content_author: '0'
+              embed_author: '0'
+              form_author: '0'
+              content_publisher: '0'
+              site_admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+      sorts:
+        field_publication_types_target_id:
+          id: field_publication_types_target_id
+          table: node__field_publication_types
+          field: field_publication_types_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: true
+          expose:
+            label: 'Sort by type'
+          plugin_id: standard
+      title: Publications
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - 'url.query_args:sort_order'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_publication_types'
+        - 'config:field.storage.node.field_publication_url'
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: publications
+      rendering_language: '***LANGUAGE_language_interface***'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - 'url.query_args:sort_order'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_publication_types'
+        - 'config:field.storage.node.field_publication_url'

--- a/ecms_base/features/custom/ecms_publications/ecms_publications.info.yml
+++ b/ecms_base/features/custom/ecms_publications/ecms_publications.info.yml
@@ -21,5 +21,6 @@ dependencies:
   - scheduled_transitions
   - taxonomy
   - user
+  - views
 version: 9.x-1.0
 package: eCMS

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/README.md
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/README.md
@@ -1,0 +1,6 @@
+# eCMS Covid Publication Migration
+
+The eCMS Covid Publication Migration is specific to the Covid-19 site and will
+create publication nodes with external links from an rss feed provided by the
+RI Department of Health. The migration will be setup on a cron job to run at
+regular intervals to keep the site updated with the latest Covid related publications.

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_subtypes.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_subtypes.yml
@@ -6,7 +6,7 @@ source:
   plugin: url
   data_fetcher_plugin: http
   urls:
-    - https://appserver/rss-covid-pub-list.xml
+    - https://health.ri.gov/rss/pubs/rss-covid-pub-list.php
   data_parser_plugin: simple_xml
   item_selector: /rss/channel/item
   fields:

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_subtypes.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_subtypes.yml
@@ -8,7 +8,6 @@ source:
   urls:
     - https://health.ri.gov/rss/pubs/rss-covid-pub-list.php
   data_parser_plugin: simple_xml
-
   item_selector: /rss/channel/item
   fields:
     - name: guid

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_subtypes.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_subtypes.yml
@@ -6,7 +6,7 @@ source:
   plugin: url
   data_fetcher_plugin: http
   urls:
-    - https://health.ri.gov/rss/pubs/rss-covid-pub-list.php
+    - https://appserver/rss-covid-pub-list.php
   data_parser_plugin: simple_xml
   item_selector: /rss/channel/item
   fields:

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_subtypes.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_subtypes.yml
@@ -6,7 +6,7 @@ source:
   plugin: url
   data_fetcher_plugin: http
   urls:
-    - https://appserver/rss-covid-pub-list.php
+    - https://appserver/rss-covid-pub-list.xml
   data_parser_plugin: simple_xml
   item_selector: /rss/channel/item
   fields:
@@ -39,14 +39,19 @@ destination:
 
 process:
   id: guid
-  name: subtype
+  name:
+    - plugin: callback
+      callable: urldecode
+      source: subtype
   parent:
+    - plugin: callback
+      callable: urldecode
+      source: type
     - plugin: entity_lookup
       entity_type: taxonomy_term
       value_key: name
       bundle_key: vid
       bundle: 'publication_type'
-      source: type
     - plugin: skip_on_empty
       method: row
 

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_subtypes.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_subtypes.yml
@@ -1,0 +1,68 @@
+id: ecms_covid_publication_subtypes
+label: 'Import publication subtypes from the RSS feed.'
+migration_group: ecms_covid_publications
+
+source:
+  plugin: url
+  data_fetcher_plugin: http
+  urls:
+    - https://health.ri.gov/rss/pubs/rss-covid-pub-list.php
+  data_parser_plugin: simple_xml
+
+  item_selector: /rss/channel/item
+  fields:
+    - name: guid
+      label: GUID
+      selector: guid
+    - name: title
+      label: Title
+      selector: title
+    - name: link
+      label: 'Origin link'
+      selector: link
+    - name: type
+      label: 'Publication type (rss description)'
+      selector: description
+    - name: subtype
+      label: 'Sub-type (rss category)'
+      selector: category
+    - name: language
+      label: 'Language'
+      selector: language
+
+  ids:
+    guid:
+      type: string
+
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: 'publication_type'
+
+process:
+  id: guid
+  name: subtype
+  parent:
+    - plugin: entity_lookup
+      entity_type: taxonomy_term
+      value_key: name
+      bundle_key: vid
+      bundle: 'publication_type'
+      source: type
+    - plugin: skip_on_empty
+      method: row
+
+  pseudo_lookup:
+    - plugin: skip_on_empty
+      source: subtype
+      method: row
+
+
+migration_dependencies:
+  required:
+    - ecms_covid_publication_types
+
+# Add an enforced dependency so the config uninstalls with the module.
+dependencies:
+  enforced:
+    module:
+      - ecms_covid_publication_migrate

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_types.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_types.yml
@@ -6,7 +6,7 @@ source:
   plugin: url
   data_fetcher_plugin: http
   urls:
-    - https://appserver/rss-covid-pub-list.xml
+    - https://health.ri.gov/rss/pubs/rss-covid-pub-list.php
   data_parser_plugin: simple_xml
   item_selector: /rss/channel/item
   fields:

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_types.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_types.yml
@@ -6,7 +6,7 @@ source:
   plugin: url
   data_fetcher_plugin: http
   urls:
-    - https://appserver/rss-covid-pub-list.php
+    - https://appserver/rss-covid-pub-list.xml
   data_parser_plugin: simple_xml
   item_selector: /rss/channel/item
   fields:
@@ -41,18 +41,23 @@ process:
   id: guid
 
   pseudo_check_exists:
+    - plugin: callback
+      callable: urldecode
+      source: type
     - plugin: entity_lookup
       entity_type: taxonomy_term
       value_key: name
       bundle_key: vid
       bundle: 'publication_type'
-      source: type
     - plugin: callback
       callable: is_null
     - plugin: skip_on_empty
       method: row
 
-  name: type
+  name:
+    - plugin: callback
+      callable: urldecode
+      source: type
 
 # Add an enforced dependency so the config uninstalls with the module.
 dependencies:

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_types.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_types.yml
@@ -8,7 +8,6 @@ source:
   urls:
     - https://health.ri.gov/rss/pubs/rss-covid-pub-list.php
   data_parser_plugin: simple_xml
-
   item_selector: /rss/channel/item
   fields:
     - name: guid

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_types.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_types.yml
@@ -1,0 +1,62 @@
+id: ecms_covid_publication_types
+label: 'Import publication types from the RSS feed.'
+migration_group: ecms_covid_publications
+
+source:
+  plugin: url
+  data_fetcher_plugin: http
+  urls:
+    - https://health.ri.gov/rss/pubs/rss-covid-pub-list.php
+  data_parser_plugin: simple_xml
+
+  item_selector: /rss/channel/item
+  fields:
+    - name: guid
+      label: GUID
+      selector: guid
+    - name: title
+      label: Title
+      selector: title
+    - name: link
+      label: 'Origin link'
+      selector: link
+    - name: type
+      label: 'Publication type (rss description)'
+      selector: description
+    - name: subtype
+      label: 'Sub-type (rss category)'
+      selector: category
+    - name: language
+      label: 'Language'
+      selector: language
+
+  ids:
+    guid:
+      type: string
+
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: 'publication_type'
+
+process:
+  id: guid
+
+  pseudo_check_exists:
+    - plugin: entity_lookup
+      entity_type: taxonomy_term
+      value_key: name
+      bundle_key: vid
+      bundle: 'publication_type'
+      source: type
+    - plugin: callback
+      callable: is_null
+    - plugin: skip_on_empty
+      method: row
+
+  name: type
+
+# Add an enforced dependency so the config uninstalls with the module.
+dependencies:
+  enforced:
+    module:
+      - ecms_covid_publication_migrate

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_types.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_types.yml
@@ -6,7 +6,7 @@ source:
   plugin: url
   data_fetcher_plugin: http
   urls:
-    - https://health.ri.gov/rss/pubs/rss-covid-pub-list.php
+    - https://appserver/rss-covid-pub-list.php
   data_parser_plugin: simple_xml
   item_selector: /rss/channel/item
   fields:

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publications_rss.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publications_rss.yml
@@ -6,7 +6,7 @@ source:
   plugin: url
   data_fetcher_plugin: http
   urls:
-    - https://appserver/rss-covid-pub-list.xml
+    - https://health.ri.gov/rss/pubs/rss-covid-pub-list.php
   data_parser_plugin: simple_xml
   item_selector: /rss/channel/item
   fields:

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publications_rss.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publications_rss.yml
@@ -6,7 +6,7 @@ source:
   plugin: url
   data_fetcher_plugin: http
   urls:
-    - https://appserver/rss-covid-pub-list.php
+    - https://appserver/rss-covid-pub-list.xml
   data_parser_plugin: simple_xml
   item_selector: /rss/channel/item
   fields:
@@ -39,16 +39,27 @@ destination:
 
 process:
   id: guid
-  title: title
-  'field_publication_url/uri': link
-  'field_publication_url/title': title
+  title:
+   - plugin: callback
+     callable: urldecode
+     source: title
+  'field_publication_url/uri':
+    - plugin: callback
+      callable: urldecode
+      source: link
+  'field_publication_url/title':
+    - plugin: callback
+      callable: urldecode
+      source: title
   pseudo_publication_type:
+    - plugin: callback
+      callable: urldecode
+      source: type
     - plugin: entity_lookup
       entity_type: taxonomy_term
       value_key: name
       bundle_key: vid
       bundle: 'publication_type'
-      source: type
 
   pseudo_publication_subtype:
     - plugin: entity_lookup

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publications_rss.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publications_rss.yml
@@ -1,0 +1,108 @@
+id: ecms_covid_publications_rss
+label: 'Import publications from the Rhode Island RSS feed.'
+migration_group: ecms_covid_publications
+
+source:
+  plugin: url
+  data_fetcher_plugin: http
+  urls:
+    - https://health.ri.gov/rss/pubs/rss-covid-pub-list.php
+  data_parser_plugin: simple_xml
+
+  item_selector: /rss/channel/item
+  fields:
+    - name: guid
+      label: GUID
+      selector: guid
+    - name: title
+      label: Title
+      selector: title
+    - name: link
+      label: 'Origin link'
+      selector: link
+    - name: type
+      label: 'Publication type (rss description)'
+      selector: description
+    - name: subtype
+      label: 'Sub-type (rss category)'
+      selector: category
+    - name: language
+      label: 'Language'
+      selector: language
+
+  ids:
+    guid:
+      type: string
+
+destination:
+  plugin: 'entity:node'
+  default_bundle: 'publication'
+
+process:
+  id: guid
+  title: title
+  'field_publication_url/uri': link
+  'field_publication_url/title': title
+  pseudo_publication_type:
+    - plugin: entity_lookup
+      entity_type: taxonomy_term
+      value_key: name
+      bundle_key: vid
+      bundle: 'publication_type'
+      source: type
+
+  pseudo_publication_subtype:
+    - plugin: entity_lookup
+      entity_type: taxonomy_term
+      value_key: parent
+      bundle_key: vid
+      bundle: 'publication_type'
+      source: '@pseudo_publication_type'
+      ignore_case: true
+    - plugin: skip_on_empty
+      method: process
+    - plugin: entity_exists
+      entity_type: taxonomy_term
+
+  field_publication_types:
+    - plugin: null_coalesce
+      source:
+        - '@pseudo_publication_subtype'
+        - '@pseudo_publication_type'
+
+  langcode:
+    - plugin: static_map
+      source: language
+      map:
+        en-us: en
+        es: es
+        pt: pt-pt
+        zh-cn: zh-hans
+        sg: ht
+        ar: ar
+        fr: fr
+        sw: sw
+        lo: lo
+        km: km
+      default_value: en
+
+
+  moderation_state:
+    plugin: default_value
+    default_value: published
+
+  # Disable path auto.
+  'path/pathauto':
+    plugin: default_value
+    default_value: 0
+
+migration_dependencies:
+  required:
+    - ecms_covid_publication_types
+    - ecms_covid_publication_subtypes
+
+# Add an enforced dependency so the config uninstalls with the module.
+dependencies:
+  enforced:
+    module:
+      - ecms_covid_publication_migrate

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publications_rss.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publications_rss.yml
@@ -6,7 +6,7 @@ source:
   plugin: url
   data_fetcher_plugin: http
   urls:
-    - https://health.ri.gov/rss/pubs/rss-covid-pub-list.php
+    - https://appserver/rss-covid-pub-list.php
   data_parser_plugin: simple_xml
   item_selector: /rss/channel/item
   fields:

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publications_rss.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publications_rss.yml
@@ -8,7 +8,6 @@ source:
   urls:
     - https://health.ri.gov/rss/pubs/rss-covid-pub-list.php
   data_parser_plugin: simple_xml
-
   item_selector: /rss/channel/item
   fields:
     - name: guid
@@ -85,7 +84,6 @@ process:
         lo: lo
         km: km
       default_value: en
-
 
   moderation_state:
     plugin: default_value

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration_group.ecms_covid_publications.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration_group.ecms_covid_publications.yml
@@ -1,0 +1,18 @@
+# The machine name of the group, by which it is referenced in individual
+# migrations.
+id: ecms_covid_publications
+
+# A human-friendly label for the group.
+label: eCMS Covid Publications
+
+# More information about the group.
+description: Publication migrations for the Covid site.
+
+# Short description of the type of source.
+source_type: RSS Feed Import
+
+# Add an enforced dependency so the config uninstalls with the module.
+dependencies:
+  enforced:
+    module:
+      - ecms_covid_publication_migrate

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/ecms_covid_publication_migrate.info.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/ecms_covid_publication_migrate.info.yml
@@ -1,0 +1,9 @@
+name: 'eCMS Covid Publication Migration'
+type: module
+description: 'Migrate Covid publications from the DOH rss feed.'
+core_version_requirement: ^8 || ^9
+package: 'eCMS'
+dependencies:
+  - drupal:migration_tools
+  - drupal:migrate_tools
+  - drupal:migrate_process_trim

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/ecms_covid_publication_migrate.info.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/ecms_covid_publication_migrate.info.yml
@@ -7,3 +7,4 @@ dependencies:
   - drupal:migration_tools
   - drupal:migrate_tools
   - drupal:migrate_process_trim
+  - ecms_publications

--- a/ecms_base/modules/custom/ecms_migration/README.md
+++ b/ecms_base/modules/custom/ecms_migration/README.md
@@ -26,7 +26,7 @@ and will append that content to the `field_basic_page_body` field.
 
 ### eCMS Publications
 The eCMS Publication migration will generate `publication` nodes and will accept
-a Googe Sheet with the following columns:
+a Google Sheet with the following columns:
 - Title (The title of the link and node)
 - Language (The language of the publication)
 - Url (The link to the external publication)

--- a/ecms_base/modules/custom/ecms_migration/README.md
+++ b/ecms_base/modules/custom/ecms_migration/README.md
@@ -24,6 +24,14 @@ and will use the first _h1_ tag on the page as the title of the node. It will
 continue pulling the inner html from three user defined css selectors
 and will append that content to the `field_basic_page_body` field.
 
+### eCMS Publications
+The eCMS Publication migration will generate `publication` nodes and will accept
+a Googe Sheet with the following columns:
+- Title (The title of the link and node)
+- Language (The language of the publication)
+- Url (The link to the external publication)
+- Type (The type taxonomy for the publication)
+
 ## Google Sheets
 The Google Sheet that is created _MUST_ be publicly accessible and published to
 the web. This is accomplished by going to the `File > Publish to the web` menu.

--- a/ecms_base/modules/custom/ecms_migration/config/install/ecms_migration.migrations.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/ecms_migration.migrations.yml
@@ -5,3 +5,5 @@ ecms_file:
 ecms_basic_page:
   - migrate_plus.migration.ecms_basic_page
   - migrate_plus.migration.ecms_basic_page_url
+ecms_publications:
+  - migrate_plus.migration.ecms_publications

--- a/ecms_base/modules/custom/ecms_migration/config/install/ecms_migration.settings.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/ecms_migration.settings.yml
@@ -5,4 +5,5 @@ ecms_basic_page:
   css_selector_1: REDACTED
   css_selector_2: REDACTED
   css_selector_3: REDACTED
-
+ecms_publications:
+  google_sheet_id: REDACTED

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_publications.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_publications.yml
@@ -54,8 +54,18 @@ process:
   field_publication_types:
     - plugin: entity_generate
       entity_type: taxonomy_term
-      value_key: type
+      value_key: name
+      bundle_key: vid
       bundle: 'publication_type'
+      source: type
+
+  langcode:
+    plugin: static_map
+    source: language
+    map:
+      English: en
+      Spanish: es
+      Portuguese: pt-pt
 
   moderation_state:
     plugin: default_value

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_publications.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_publications.yml
@@ -1,0 +1,77 @@
+# Migrate a Google spreadsheet of URLs as basic pages into the eCMS system.
+id: ecms_publications
+label: Migrate publications into eCMS.
+migration_group: ecms
+source:
+  plugin: url
+  data_fetcher_plugin: http
+  data_parser_plugin: google_sheets
+  # The feed file for the spreadsheet. The Google Spreadsheet should be either “Public” or set to “Anyone with link can
+  # view” in order for the feed to work. Note that the <SHEET> param is the order of the tabs and WILL change if the
+  # tabs are re-ordered.
+  # Template: 'https://spreadsheets.google.com/feeds/list/<KEY>/<SHEET>/public/values?alt=json'
+  urls: 'https://spreadsheets.google.com/feeds/list/REDACTED/1/public/values?alt=json'
+  # Under 'fields', we list the data items to be imported. The first level keys
+  # are the source field names we want to populate (the names to be used as
+  # sources in the process configuration below). For each field we're importing,
+  # we provide a label (optional - this is for display in migration tools) and
+  # an selector (xpath) for retrieving that value. It's important to note that this xpath
+  # is relative to the elements retrieved by item_selector.
+  # For Google Spreadsheet XML feeds the actual columns are named with gsx: followed by the cleaned column name (lower,
+  # limited punctuation, etc).
+
+  # Use the URL as the key unique migration identifier.
+  keys:
+    - url
+
+  # What fields are in the google sheet.
+  fields:
+    - name: title
+      label: 'Title'
+      selector: 'title'
+
+    - name: language
+      label: 'Language'
+      selector: 'language'
+
+    - name: url
+      label: 'Url'
+      selector: 'url'
+
+    - name: type
+      label: 'Type'
+      selector: 'type'
+
+  ids:
+    url:
+      type: string
+
+process:
+  id: url
+  title: title
+  'field_publication_url/uri': url
+  'field_publication_url/title': title
+  field_publication_types:
+    - plugin: entity_generate
+      entity_type: taxonomy_term
+      value_key: type
+      bundle: 'publication_type'
+
+  moderation_state:
+    plugin: default_value
+    default_value: published
+
+  # Disable path auto.
+  'path/pathauto':
+    plugin: default_value
+    default_value: 0
+
+destination:
+  plugin: 'entity:node'
+  default_bundle: 'publication'
+
+# Add an enforced dependency so the config uninstalls with the module.
+dependencies:
+  enforced:
+    module:
+      - ecms_migration

--- a/ecms_base/modules/custom/ecms_migration/config/schema/ecms_migration.schema.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/schema/ecms_migration.schema.yml
@@ -24,6 +24,13 @@ ecms_migration.settings:
         css_selector_3:
           type: string
           label: "Third CSS Selector"
+    ecms_publication:
+      type: mapping
+      label: 'Settings for the Publication migration'
+      mapping:
+        google_sheet_id:
+          type: string
+          label: "Google Sheet ID for the Publication Migration"
 
 ecms_migration.migrations:
   type: config_object
@@ -34,3 +41,6 @@ ecms_migration.migrations:
     ecms_basic_page:
       type: sequence
       label: 'Migration configuration objects for the ecms_basic_page migration'
+    ecms_publication:
+      type: sequence
+      label: 'Migration configuration objects for the ecms_publication migration'

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -113,6 +113,14 @@ echo "----------------------------------"
 echo " Initialize lando for local usage "
 echo "----------------------------------"
 cd ${DEST_DIR}
+
+echo "Lock Drupal core to 9.0 branch."
+$COMPOSER require "drupal/core-composer-scaffold:~9.0.9" --no-update
+$COMPOSER require "drupal/core-project-message:~9.0.9" --no-update
+$COMPOSER require "drupal/core-recommended:~9.0.9" --no-update
+$COMPOSER require "drupal/core-vendor-hardening:~9.0.9" --no-update
+
+
 echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} $LANDO init --name $APP_NAME --recipe drupal9 --webroot $DOCROOT --source cwd\n\n"
 $LANDO init --name ${APP_NAME} --recipe drupal9 --webroot ${DOCROOT} --source cwd
 


### PR DESCRIPTION
## Summary
This PR adds a new `ecms_covid_publication_migrate` module that is specific to the Covid site. This module sets up a migration that pulls data from an RSS feed and creates publication nodes and the associated taxonomy terms for the nodes.

This also adds a Google Sheet migration to the ecms_migration module to allow for other sites to migrate in publications if necessary.

The `ecms_publications` feature also added a new publications view that will collect all of the publications and display them in a table with an exposed filter on the type and language.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-141](https://thinkoomph.jira.com/browse/rig-141)