### PR TITLE
Fix to allow drush to run migration tools migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-106: Added patch to allow drush to run migration tools migrations.
 
 ### Security
 

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,8 @@
         "3142997 - D9 readiness" : "https://www.drupal.org/files/issues/2020-06-05/3142997-20.patch"
       },
       "drupal_git/migration_tools": {
-        "3148135 - D9 readiness" : "https://www.drupal.org/files/issues/2020-11-17/automated-d9-compatibility-fixes-3148135-5.patch"
+        "3148135 - D9 readiness" : "https://www.drupal.org/files/issues/2020-11-17/automated-d9-compatibility-fixes-3148135-5.patch",
+        "3163830 - Fatal Error: Call to undefined function drush_print()": "https://www.drupal.org/files/issues/2020-08-06/migration_tools-drush-10-compatibility-13778991-3.patch"
       },
       "drupal_git/migrate_google_sheets": {
         "3138999 - D9 readiness" : "https://www.drupal.org/files/issues/2020-11-17/Drupal-9-readiness-3138999-6.patch"


### PR DESCRIPTION
## Summary
Running the ecms_migration with Drush on Acquia was throwing function not defined errors. This adds a patch to fix those errors.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | [RIG-106](https://thinkoomph.jira.com/browse/rig-106)