### PR TITLE
Promo reference block type, content components bg color, missing form settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-145: Install and Configure Metatag Module.
 - RIG-133: Install and configure simple XML sitemap module.
 - RIG-132: Install and configure GTM module.
+- RIG-130: Added promotion reference block type.
+- RIG-130: Added background color field to content components block type.
 
 ### Changed
 - RIG-161: Updated the default user role permissions.
@@ -22,6 +24,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-130: Fixed form settings missing for block types.
 
 ### Security
 

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_form_display.block_content.content_components.default.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_form_display.block_content.content_components.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - block_content.type.content_components
     - field.field.block_content.content_components.field_components
+    - field.field.block_content.content_components.field_components_bg_color
   module:
     - paragraphs
 id: block_content.content_components.default
@@ -13,7 +14,7 @@ mode: default
 content:
   field_components:
     type: entity_reference_paragraphs
-    weight: 0
+    weight: 1
     settings:
       title: 'Content Component'
       title_plural: 'Content Components'
@@ -22,6 +23,12 @@ content:
       form_display_mode: default
       default_paragraph_type: formatted_text
     third_party_settings: {  }
+    region: content
+  field_components_bg_color:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
     region: content
 hidden:
   info: true

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_form_display.block_content.page_title_with_photo.default.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_form_display.block_content.page_title_with_photo.default.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.page_title_with_photo
+    - field.field.block_content.page_title_with_photo.field_image
+  module:
+    - media_library
+id: block_content.page_title_with_photo.default
+targetEntityType: block_content
+bundle: page_title_with_photo
+mode: default
+content:
+  field_image:
+    type: media_library_widget
+    weight: 1
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+hidden: {  }

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_form_display.block_content.text_card_collection.default.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_form_display.block_content.text_card_collection.default.yml
@@ -1,0 +1,58 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.text_card_collection
+    - field.field.block_content.text_card_collection.field_cards
+    - field.field.block_content.text_card_collection.field_collection_card_style
+    - field.field.block_content.text_card_collection.field_collection_description
+  module:
+    - paragraphs
+    - text
+id: block_content.text_card_collection.default
+targetEntityType: block_content
+bundle: text_card_collection
+mode: default
+content:
+  field_cards:
+    type: entity_reference_paragraphs
+    weight: 3
+    region: content
+    settings:
+      title: Card
+      title_plural: Cards
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: text_card
+    third_party_settings: {  }
+  field_collection_card_style:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_collection_description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 4
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+hidden: {  }

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_view_display.block_content.content_components.default.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_view_display.block_content.content_components.default.yml
@@ -4,8 +4,10 @@ dependencies:
   config:
     - block_content.type.content_components
     - field.field.block_content.content_components.field_components
+    - field.field.block_content.content_components.field_components_bg_color
   module:
     - entity_reference_revisions
+    - options
 id: block_content.content_components.default
 targetEntityType: block_content
 bundle: content_components
@@ -20,5 +22,13 @@ content:
       link: ''
     third_party_settings: {  }
     region: content
+  field_components_bg_color:
+    weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: list_key
+    region: content
 hidden:
   langcode: true
+  search_api_excerpt: true

--- a/ecms_base/features/custom/ecms_landing_page/config/install/field.field.block_content.content_components.field_components_bg_color.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/field.field.block_content.content_components.field_components_bg_color.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.content_components
+    - field.storage.block_content.field_components_bg_color
+  module:
+    - options
+id: block_content.content_components.field_components_bg_color
+field_name: field_components_bg_color
+entity_type: block_content
+bundle: content_components
+label: 'Components background color'
+description: '(Optional) Select a background color for the content components block.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/ecms_base/features/custom/ecms_landing_page/config/install/field.storage.block_content.field_components_bg_color.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/field.storage.block_content.field_components_bg_color.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - options
+id: block_content.field_components_bg_color
+field_name: field_components_bg_color
+entity_type: block_content
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: primary
+      label: Primary
+    -
+      value: primary--light
+      label: 'Primary light'
+    -
+      value: coffee-milk
+      label: 'Coffee milk'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_landing_page/ecms_landing_page.info.yml
+++ b/ecms_base/features/custom/ecms_landing_page/ecms_landing_page.info.yml
@@ -16,6 +16,7 @@ dependencies:
   - layout_builder_restrictions
   - layout_discovery
   - media
+  - media_library
   - menu_ui
   - metatag
   - node

--- a/ecms_base/features/custom/ecms_promotions/config/install/block_content.type.promotion_reference.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/block_content.type.promotion_reference.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: promotion_reference
+label: 'Promotion reference'
+revision: 0
+description: 'A block that allows multiple promotion references.'

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.entity_form_display.block_content.promotion_reference.default.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.entity_form_display.block_content.promotion_reference.default.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.promotion_reference
+    - field.field.block_content.promotion_reference.field_promotions
+id: block_content.promotion_reference.default
+targetEntityType: block_content
+bundle: promotion_reference
+mode: default
+content:
+  field_promotions:
+    weight: 26
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  info:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+hidden: {  }

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.entity_view_display.block_content.promotion_reference.default.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.entity_view_display.block_content.promotion_reference.default.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.promotion_reference
+    - field.field.block_content.promotion_reference.field_promotions
+id: block_content.promotion_reference.default
+targetEntityType: block_content
+bundle: promotion_reference
+mode: default
+content:
+  field_promotions:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: teaser
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/ecms_base/features/custom/ecms_promotions/config/install/field.field.block_content.promotion_reference.field_promotions.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/field.field.block_content.promotion_reference.field_promotions.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.promotion_reference
+    - field.storage.block_content.field_promotions
+    - node.type.promotions
+id: block_content.promotion_reference.field_promotions
+field_name: field_promotions
+entity_type: block_content
+bundle: promotion_reference
+label: Promotions
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      promotions: promotions
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_promotions/config/install/field.storage.block_content.field_promotions.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/field.storage.block_content.field_promotions.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - node
+id: block_content.field_promotions
+field_name: field_promotions
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_promotions/config/install/language.content_settings.block_content.promotion_reference.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/language.content_settings.block_content.promotion_reference.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.promotion_reference
+id: block_content.promotion_reference
+target_entity_type_id: block_content
+target_bundle: promotion_reference
+default_langcode: site_default
+language_alterable: false

--- a/ecms_base/features/custom/ecms_promotions/config/install/language.content_settings.paragraph.promotion_reference.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/language.content_settings.paragraph.promotion_reference.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.promotion_reference
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: paragraph.promotion_reference
+target_entity_type_id: paragraph
+target_bundle: promotion_reference
+default_langcode: site_default
+language_alterable: false

--- a/ecms_base/features/custom/ecms_promotions/ecms_promotions.info.yml
+++ b/ecms_base/features/custom/ecms_promotions/ecms_promotions.info.yml
@@ -4,6 +4,7 @@ type: module
 core_version_requirement: ^9
 dependencies:
   - allowed_formats
+  - block_content
   - content_moderation
   - content_translation
   - ecms_distribution
@@ -17,6 +18,7 @@ dependencies:
   - media_library
   - menu_ui
   - node
+  - paragraphs
   - path
   - rabbit_hole
   - responsive_image

--- a/ecms_base/themes/custom/ecms/templates/blocks/block--inline-block--content-components.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/blocks/block--inline-block--content-components.html.twig
@@ -33,7 +33,7 @@
 {% set cachebust = content|render %}
 
 {% set bg_color_class = '' %}
-{% if content['#block_content'].get('field_components_bg_color').value != '' %}
+{% if content.field_components_bg_color|render is not empty %}
   {% set bg_color_class = 'qh__t__' ~ content['#block_content'].get('field_components_bg_color').value|clean_class %}
 {% endif %}
 

--- a/ecms_base/themes/custom/ecms/templates/blocks/block--inline-block--content-components.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/blocks/block--inline-block--content-components.html.twig
@@ -1,0 +1,46 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a content components block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main content
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ *
+ * @ingroup themeable
+ */
+#}
+
+{% set cachebust = content|render %}
+
+{% set bg_color_class = '' %}
+{% if content['#block_content'].get('field_components_bg_color').value != '' %}
+  {% set bg_color_class = 'qh__t__' ~ content['#block_content'].get('field_components_bg_color').value|clean_class %}
+{% endif %}
+
+{% include '@organisms/content-components-block/content-components-block.twig' with {
+  label: label,
+  title_prefix: title_prefix,
+  title_suffix: title_suffix,
+  rendered_components: content|without('field_components_bg_color'),
+  bg_color_class: bg_color_class
+} %}

--- a/ecms_base/themes/custom/ecms/templates/fields/field--block-content--field-promotions.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/fields/field--block-content--field-promotions.html.twig
@@ -1,0 +1,1 @@
+{% extends "@generic/blank-field-template.html.twig" %}


### PR DESCRIPTION
## Summary
This PR:
- includes the new block type: promo reference
- Adds background color field to content components
- Adds in the missing form settings for the block types added previously

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | JIRA issue, bug reports, security alerts, etc.