### PR TITLE
Site admin role permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIG-163: Added the role delegation module and updated site admin permissions.
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -156,6 +156,7 @@
     "drupal/rabbit_hole": "^1.0",
     "drupal/real_aes": "^2.3",
     "drupal/redirect": "^1.6",
+    "drupal/role_delegation": "^1.1",
     "drupal/scheduled_transitions": "^2.0",
     "drupal/search_api": "^1.18",
     "drupal/simple_oauth": "^4.5",

--- a/ecms_base/config/install/user.role.site_admin.yml
+++ b/ecms_base/config/install/user.role.site_admin.yml
@@ -24,6 +24,8 @@ permissions:
   - 'administer site configuration'
   - 'administer themes'
   - 'administer users'
+  - 'assign content_author role'
+  - 'assign content_publisher role'
   - 'bypass paragraphs type content access'
   - 'configure any layout'
   - 'configure editable landing_page node layout overrides'

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -69,6 +69,7 @@ dependencies:
   - rh_taxonomy
   - responsive_image
   - rdf
+  - role_delegation
   - scheduled_transitions
   - search_api
   - search_api_db

--- a/ecms_base/ecms_base.profile
+++ b/ecms_base/ecms_base.profile
@@ -306,3 +306,32 @@ function ecms_base_update_9028(array &$sandbox): void {
     $active_storage->write("{$config}", $install_source->read("{$config}"));
   }
 }
+
+/**
+ * Updates to run for the 0.2.9 tag.
+ */
+function ecms_base_update_9029(array &$sandbox): void {
+  // Install the newly introduced role delegation module.
+  $modules_to_install = [
+    'role_delegation',
+  ];
+
+  \Drupal::service('module_installer')->install($modules_to_install);
+
+  // Config updates for new modules.
+  $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
+
+  /** @var \Drupal\Core\Config\FileStorage $install_source */
+  $install_source = new FileStorage($path . "/config/install/");
+
+  /** @var \Drupal\Core\Config\StorageInterface $active_storage */
+  $active_storage = \Drupal::service('config.storage');
+
+  $newConfig = [
+    'user.role.site_admin',
+  ];
+
+  foreach ($newConfig as $config) {
+    $active_storage->write("{$config}", $install_source->read("{$config}"));
+  }
+}


### PR DESCRIPTION
## Summary
This adds the role_delegation module and configures it to allow the site admin role to assign the content author and content publisher roles. No other roles can be assigned by the site admin.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-163](https://thinkoomph.jira.com/browse/rig-163)