### PR TITLE
Allow layout builder blocks to be translated

### DIFF
--- a/ecms_base/features/custom/ecms_basic_page/config/install/core.base_field_override.node.basic_page.path.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/core.base_field_override.node.basic_page.path.yml
@@ -1,0 +1,19 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - node.type.basic_page
+  module:
+    - path
+id: node.basic_page.path
+field_name: path
+entity_type: node
+bundle: basic_page
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/ecms_base/features/custom/ecms_event/config/install/core.base_field_override.media.event_image.metatag.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.base_field_override.media.event_image.metatag.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.event_image
+id: media.event_image.metatag
+field_name: metatag
+entity_type: media
+bundle: event_image
+label: Metatags
+description: 'The meta tags for the entity.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: map

--- a/ecms_base/features/custom/ecms_event/config/install/core.base_field_override.node.event.path.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.base_field_override.node.event.path.yml
@@ -1,0 +1,19 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - node.type.event
+  module:
+    - path
+id: node.event.path
+field_name: path
+entity_type: node
+bundle: event
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.content_components.changed.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.content_components.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.content_components
+id: block_content.content_components.changed
+field_name: changed
+entity_type: block_content
+bundle: content_components
+label: Changed
+description: 'The time that the custom block was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.content_components.info.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.content_components.info.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.content_components
+id: block_content.content_components.info
+field_name: info
+entity_type: block_content
+bundle: content_components
+label: 'Block description'
+description: 'A brief description of your block.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.content_components.metatag.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.content_components.metatag.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - block_content.type.content_components
+id: block_content.content_components.metatag
+field_name: metatag
+entity_type: block_content
+bundle: content_components
+label: Metatags
+description: 'The meta tags for the entity.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: map

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.content_components.status.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.content_components.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.content_components
+id: block_content.content_components.status
+field_name: status
+entity_type: block_content
+bundle: content_components
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.page_title_with_photo.changed.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.page_title_with_photo.changed.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - block_content.type.page_title_with_photo
+id: block_content.page_title_with_photo.changed
+field_name: changed
+entity_type: block_content
+bundle: page_title_with_photo
+label: Changed
+description: 'The time that the custom block was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.page_title_with_photo.metatag.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.page_title_with_photo.metatag.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - block_content.type.page_title_with_photo
+id: block_content.page_title_with_photo.metatag
+field_name: metatag
+entity_type: block_content
+bundle: page_title_with_photo
+label: Metatags
+description: 'The meta tags for the entity.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: map

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.text_card_collection.changed.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.text_card_collection.changed.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - block_content.type.text_card_collection
+id: block_content.text_card_collection.changed
+field_name: changed
+entity_type: block_content
+bundle: text_card_collection
+label: Changed
+description: 'The time that the custom block was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.text_card_collection.metatag.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.block_content.text_card_collection.metatag.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - block_content.type.text_card_collection
+id: block_content.text_card_collection.metatag
+field_name: metatag
+entity_type: block_content
+bundle: text_card_collection
+label: Metatags
+description: 'The meta tags for the entity.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: map

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.node.landing_page.path.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.base_field_override.node.landing_page.path.yml
@@ -1,0 +1,19 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - node.type.landing_page
+  module:
+    - path
+id: node.landing_page.path
+field_name: path
+entity_type: node
+bundle: landing_page
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_form_display.block_content.content_components.default.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_form_display.block_content.content_components.default.yml
@@ -30,6 +30,11 @@ content:
     third_party_settings: {  }
     type: options_select
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   info: true
   langcode: true

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_form_display.block_content.page_title_with_photo.default.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_form_display.block_content.page_title_with_photo.default.yml
@@ -33,4 +33,9 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden: {  }

--- a/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_form_display.block_content.text_card_collection.default.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/core.entity_form_display.block_content.text_card_collection.default.yml
@@ -55,4 +55,9 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden: {  }

--- a/ecms_base/features/custom/ecms_landing_page/config/install/field.field.block_content.page_title_with_photo.field_image.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/field.field.block_content.page_title_with_photo.field_image.yml
@@ -12,7 +12,7 @@ bundle: page_title_with_photo
 label: Image
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/ecms_base/features/custom/ecms_landing_page/config/install/field.field.block_content.text_card_collection.field_collection_description.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/field.field.block_content.text_card_collection.field_collection_description.yml
@@ -22,7 +22,7 @@ bundle: text_card_collection
 label: 'Collection Description'
 description: '(Optional) A rich text field that displays under the collection title.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/ecms_base/features/custom/ecms_landing_page/config/install/language.content_settings.block_content.page_title_with_photo.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/language.content_settings.block_content.page_title_with_photo.yml
@@ -1,8 +1,8 @@
-langcode: en
+langcode: es
 status: true
 dependencies:
   config:
-    - block_content.type.content_components
+    - block_content.type.page_title_with_photo
   module:
     - content_translation
 third_party_settings:
@@ -10,8 +10,8 @@ third_party_settings:
     enabled: true
     bundle_settings:
       untranslatable_fields_hide: '1'
-id: block_content.content_components
+id: block_content.page_title_with_photo
 target_entity_type_id: block_content
-target_bundle: content_components
+target_bundle: page_title_with_photo
 default_langcode: site_default
 language_alterable: true

--- a/ecms_base/features/custom/ecms_landing_page/config/install/language.content_settings.block_content.text_card_collection.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/language.content_settings.block_content.text_card_collection.yml
@@ -7,11 +7,11 @@ dependencies:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: false
+    enabled: true
     bundle_settings:
       untranslatable_fields_hide: '0'
 id: block_content.text_card_collection
 target_entity_type_id: block_content
 target_bundle: text_card_collection
 default_langcode: site_default
-language_alterable: false
+language_alterable: true

--- a/ecms_base/features/custom/ecms_landing_page/config/install/language.content_settings.block_content.text_card_collection.yml
+++ b/ecms_base/features/custom/ecms_landing_page/config/install/language.content_settings.block_content.text_card_collection.yml
@@ -9,7 +9,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: block_content.text_card_collection
 target_entity_type_id: block_content
 target_bundle: text_card_collection

--- a/ecms_base/features/custom/ecms_location/config/install/core.base_field_override.node.location.path.yml
+++ b/ecms_base/features/custom/ecms_location/config/install/core.base_field_override.node.location.path.yml
@@ -1,0 +1,19 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - node.type.location
+  module:
+    - path
+id: node.location.path
+field_name: path
+entity_type: node
+bundle: location
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/ecms_base/features/custom/ecms_notification/config/install/core.base_field_override.node.notification.path.yml
+++ b/ecms_base/features/custom/ecms_notification/config/install/core.base_field_override.node.notification.path.yml
@@ -1,0 +1,19 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - node.type.notification
+  module:
+    - path
+id: node.notification.path
+field_name: path
+entity_type: node
+bundle: notification
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/ecms_base/features/custom/ecms_notification/config/install/core.entity_form_display.node.notification.default.yml
+++ b/ecms_base/features/custom/ecms_notification/config/install/core.entity_form_display.node.notification.default.yml
@@ -6,10 +6,12 @@ dependencies:
     - field.field.node.notification.field_notification_global
     - field.field.node.notification.field_notification_text
     - node.type.notification
+    - workflows.workflow.editorial
   module:
     - content_moderation
     - datetime
     - path
+    - text
 id: node.notification.default
 targetEntityType: node
 bundle: notification
@@ -105,4 +107,9 @@ content:
       match_limit: 10
     region: content
     third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden: {  }

--- a/ecms_base/features/custom/ecms_notification/config/install/core.entity_view_display.node.notification.default.yml
+++ b/ecms_base/features/custom/ecms_notification/config/install/core.entity_view_display.node.notification.default.yml
@@ -8,12 +8,18 @@ dependencies:
     - node.type.notification
   module:
     - datetime
+    - text
     - user
 id: node.notification.default
 targetEntityType: node
 bundle: notification
 mode: default
 content:
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   field_notification_expire_date:
     weight: 102
     label: above
@@ -47,3 +53,4 @@ content:
     region: content
 hidden:
   langcode: true
+  search_api_excerpt: true

--- a/ecms_base/features/custom/ecms_notification/config/install/core.entity_view_display.node.notification.teaser.yml
+++ b/ecms_base/features/custom/ecms_notification/config/install/core.entity_view_display.node.notification.teaser.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.notification.field_notification_text
     - node.type.notification
   module:
+    - text
     - user
 id: node.notification.teaser
 targetEntityType: node
@@ -27,3 +28,4 @@ hidden:
   field_notification_global: true
   langcode: true
   links: true
+  search_api_excerpt: true

--- a/ecms_base/features/custom/ecms_notification/config/install/rabbit_hole.behavior_settings.node_type_notification.yml
+++ b/ecms_base/features/custom/ecms_notification/config/install/rabbit_hole.behavior_settings.node_type_notification.yml
@@ -1,10 +1,11 @@
 langcode: en
 status: true
-dependencies:
-  config:
-    - node.type.notification
+dependencies: {  }
 id: node_type_notification
+entity_type_id: null
+entity_id: null
 action: access_denied
 allow_override: 0
 redirect: ''
 redirect_code: 301
+redirect_fallback_action: null

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.changed.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.changed.yml
@@ -2,17 +2,16 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.media.field_file_size
     - media.type.file
-id: media.file.field_file_size
-field_name: field_file_size
+id: media.file.changed
+field_name: changed
 entity_type: media
 bundle: file
-label: 'File size'
-description: ''
+label: Changed
+description: 'The time the media item was last edited.'
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string
+field_type: changed

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.created.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.file
+id: media.file.created
+field_name: created
+entity_type: media
+bundle: file
+label: 'Authored on'
+description: 'The time the media item was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getRequestTime'
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.metatag.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.metatag.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.file
+id: media.file.metatag
+field_name: metatag
+entity_type: media
+bundle: file
+label: Metatags
+description: 'The meta tags for the entity.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: map

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.name.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.name.yml
@@ -2,17 +2,18 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.media.field_file_size
     - media.type.file
-id: media.file.field_file_size
-field_name: field_file_size
+id: media.file.name
+field_name: name
 entity_type: media
 bundle: file
-label: 'File size'
+label: Name
 description: ''
-required: false
+required: true
 translatable: true
-default_value: {  }
+default_value:
+  -
+    value: ''
 default_value_callback: ''
 settings: {  }
 field_type: string

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.path.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.path.yml
@@ -2,17 +2,18 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.media.field_file_size
     - media.type.file
-id: media.file.field_file_size
-field_name: field_file_size
+  module:
+    - path
+id: media.file.path
+field_name: path
 entity_type: media
 bundle: file
-label: 'File size'
+label: 'URL alias'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string
+field_type: path

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.status.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.status.yml
@@ -2,11 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - paragraphs.paragraphs_type.media_item
-id: paragraph.media_item.status
+    - media.type.file
+id: media.file.status
 field_name: status
-entity_type: paragraph
-bundle: media_item
+entity_type: media
+bundle: file
 label: Published
 description: ''
 required: false

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.thumbnail.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.thumbnail.yml
@@ -2,8 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.paragraph.field_icon
-    - paragraphs.paragraphs_type.icon_card
+    - media.type.file
   module:
     - content_translation
     - image
@@ -12,33 +11,33 @@ third_party_settings:
     translation_sync:
       alt: alt
       title: title
-      file: '0'
-id: paragraph.icon_card.field_icon
-field_name: field_icon
-entity_type: paragraph
-bundle: icon_card
-label: Icon
-description: ''
-required: true
+      file: 0
+id: media.file.thumbnail
+field_name: thumbnail
+entity_type: media
+bundle: file
+label: Thumbnail
+description: 'The thumbnail of the media item.'
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: svg
-  max_filesize: ''
-  max_resolution: ''
-  min_resolution: ''
+  file_extensions: 'png gif jpg jpeg'
   alt_field: true
   alt_field_required: true
   title_field: false
   title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
   default_image:
-    uuid: ''
+    uuid: null
     alt: ''
     title: ''
     width: null
     height: null
-  handler: 'default:file'
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: default
   handler_settings: {  }
 field_type: image

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.uid.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.file.uid.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.file
+id: media.file.uid
+field_name: uid
+entity_type: media
+bundle: file
+label: 'Authored by'
+description: 'The user ID of the author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getDefaultEntityOwner'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_audio.changed.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_audio.changed.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.media_item_audio
+id: media.media_item_audio.changed
+field_name: changed
+entity_type: media
+bundle: media_item_audio
+label: Changed
+description: 'The time the media item was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_audio.created.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_audio.created.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.media_item_audio
+id: media.media_item_audio.created
+field_name: created
+entity_type: media
+bundle: media_item_audio
+label: 'Authored on'
+description: 'The time the media item was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getRequestTime'
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_audio.metatag.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_audio.metatag.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.media_item_audio
+id: media.media_item_audio.metatag
+field_name: metatag
+entity_type: media
+bundle: media_item_audio
+label: Metatags
+description: 'The meta tags for the entity.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: map

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_audio.path.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_audio.path.yml
@@ -1,0 +1,19 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.media_item_audio
+  module:
+    - path
+id: media.media_item_audio.path
+field_name: path
+entity_type: media
+bundle: media_item_audio
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_audio.uid.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_audio.uid.yml
@@ -1,0 +1,19 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.media_item_audio
+id: media.media_item_audio.uid
+field_name: uid
+entity_type: media
+bundle: media_item_audio
+label: 'Authored by'
+description: 'The user ID of the author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getDefaultEntityOwner'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.changed.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.media_item_image
+id: media.media_item_image.changed
+field_name: changed
+entity_type: media
+bundle: media_item_image
+label: Changed
+description: 'The time the media item was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.created.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.media_item_image
+id: media.media_item_image.created
+field_name: created
+entity_type: media
+bundle: media_item_image
+label: 'Authored on'
+description: 'The time the media item was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getRequestTime'
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.metatag.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.metatag.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.media_item_image
+id: media.media_item_image.metatag
+field_name: metatag
+entity_type: media
+bundle: media_item_image
+label: Metatags
+description: 'The meta tags for the entity.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: map

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.name.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.name.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.media_item_image
+id: media.media_item_image.name
+field_name: name
+entity_type: media
+bundle: media_item_image
+label: Name
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.path.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.path.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.media_item_image
+  module:
+    - path
+id: media.media_item_image.path
+field_name: path
+entity_type: media
+bundle: media_item_image
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.status.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.status.yml
@@ -2,11 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - paragraphs.paragraphs_type.media_item
-id: paragraph.media_item.status
+    - media.type.media_item_image
+id: media.media_item_image.status
 field_name: status
-entity_type: paragraph
-bundle: media_item
+entity_type: media
+bundle: media_item_image
 label: Published
 description: ''
 required: false

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.thumbnail.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.thumbnail.yml
@@ -2,8 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.paragraph.field_icon
-    - paragraphs.paragraphs_type.icon_card
+    - media.type.media_item_image
   module:
     - content_translation
     - image
@@ -12,33 +11,33 @@ third_party_settings:
     translation_sync:
       alt: alt
       title: title
-      file: '0'
-id: paragraph.icon_card.field_icon
-field_name: field_icon
-entity_type: paragraph
-bundle: icon_card
-label: Icon
-description: ''
-required: true
+      file: 0
+id: media.media_item_image.thumbnail
+field_name: thumbnail
+entity_type: media
+bundle: media_item_image
+label: Thumbnail
+description: 'The thumbnail of the media item.'
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: svg
-  max_filesize: ''
-  max_resolution: ''
-  min_resolution: ''
+  file_extensions: 'png gif jpg jpeg'
   alt_field: true
   alt_field_required: true
   title_field: false
   title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
   default_image:
-    uuid: ''
+    uuid: null
     alt: ''
     title: ''
     width: null
     height: null
-  handler: 'default:file'
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: default
   handler_settings: {  }
 field_type: image

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.uid.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_image.uid.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.media_item_image
+id: media.media_item_image.uid
+field_name: uid
+entity_type: media
+bundle: media_item_image
+label: 'Authored by'
+description: 'The user ID of the author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getDefaultEntityOwner'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.changed.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.media_item_video
+id: media.media_item_video.changed
+field_name: changed
+entity_type: media
+bundle: media_item_video
+label: Changed
+description: 'The time the media item was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.created.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.media_item_video
+id: media.media_item_video.created
+field_name: created
+entity_type: media
+bundle: media_item_video
+label: 'Authored on'
+description: 'The time the media item was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getRequestTime'
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.metatag.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.metatag.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.media_item_video
+id: media.media_item_video.metatag
+field_name: metatag
+entity_type: media
+bundle: media_item_video
+label: Metatags
+description: 'The meta tags for the entity.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: map

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.name.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.name.yml
@@ -2,17 +2,18 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.media.field_media_item_video_url
     - media.type.media_item_video
-id: media.media_item_video.field_media_item_video_url
-field_name: field_media_item_video_url
+id: media.media_item_video.name
+field_name: name
 entity_type: media
 bundle: media_item_video
-label: 'Video URL'
+label: Name
 description: ''
 required: true
 translatable: true
-default_value: {  }
+default_value:
+  -
+    value: ''
 default_value_callback: ''
 settings: {  }
 field_type: string

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.path.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.path.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.media_item_video
+  module:
+    - path
+id: media.media_item_video.path
+field_name: path
+entity_type: media
+bundle: media_item_video
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.status.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.status.yml
@@ -2,11 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - paragraphs.paragraphs_type.media_item
-id: paragraph.media_item.status
+    - media.type.media_item_video
+id: media.media_item_video.status
 field_name: status
-entity_type: paragraph
-bundle: media_item
+entity_type: media
+bundle: media_item_video
 label: Published
 description: ''
 required: false

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.thumbnail.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.thumbnail.yml
@@ -2,8 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.paragraph.field_icon
-    - paragraphs.paragraphs_type.icon_card
+    - media.type.media_item_video
   module:
     - content_translation
     - image
@@ -12,33 +11,33 @@ third_party_settings:
     translation_sync:
       alt: alt
       title: title
-      file: '0'
-id: paragraph.icon_card.field_icon
-field_name: field_icon
-entity_type: paragraph
-bundle: icon_card
-label: Icon
-description: ''
-required: true
+      file: 0
+id: media.media_item_video.thumbnail
+field_name: thumbnail
+entity_type: media
+bundle: media_item_video
+label: Thumbnail
+description: 'The thumbnail of the media item.'
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: svg
-  max_filesize: ''
-  max_resolution: ''
-  min_resolution: ''
+  file_extensions: 'png gif jpg jpeg'
   alt_field: true
   alt_field_required: true
   title_field: false
   title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
   default_image:
-    uuid: ''
+    uuid: null
     alt: ''
     title: ''
     width: null
     height: null
-  handler: 'default:file'
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: default
   handler_settings: {  }
 field_type: image

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.uid.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.media.media_item_video.uid.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.media_item_video
+id: media.media_item_video.uid
+field_name: uid
+entity_type: media
+bundle: media_item_video
+label: 'Authored by'
+description: 'The user ID of the author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getDefaultEntityOwner'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.accordion_builder.created.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.accordion_builder.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.accordion_builder
+id: paragraph.accordion_builder.created
+field_name: created
+entity_type: paragraph
+bundle: accordion_builder
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.accordion_builder.status.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.accordion_builder.status.yml
@@ -2,11 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - paragraphs.paragraphs_type.media_item
-id: paragraph.media_item.status
+    - paragraphs.paragraphs_type.accordion_builder
+id: paragraph.accordion_builder.status
 field_name: status
 entity_type: paragraph
-bundle: media_item
+bundle: accordion_builder
 label: Published
 description: ''
 required: false

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.column_container.created.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.column_container.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.column_container
+id: paragraph.column_container.created
+field_name: created
+entity_type: paragraph
+bundle: column_container
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.column_container.status.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.column_container.status.yml
@@ -2,11 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - paragraphs.paragraphs_type.media_item
-id: paragraph.media_item.status
+    - paragraphs.paragraphs_type.column_container
+id: paragraph.column_container.status
 field_name: status
 entity_type: paragraph
-bundle: media_item
+bundle: column_container
 label: Published
 description: ''
 required: false

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.embed.created.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.embed.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.embed
+id: paragraph.embed.created
+field_name: created
+entity_type: paragraph
+bundle: embed
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.embed.status.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.embed.status.yml
@@ -2,11 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - paragraphs.paragraphs_type.media_item
-id: paragraph.media_item.status
+    - paragraphs.paragraphs_type.embed
+id: paragraph.embed.status
 field_name: status
 entity_type: paragraph
-bundle: media_item
+bundle: embed
 label: Published
 description: ''
 required: false

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.file_list.created.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.file_list.created.yml
@@ -2,17 +2,16 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.paragraph.field_list_title
     - paragraphs.paragraphs_type.file_list
-id: paragraph.file_list.field_list_title
-field_name: field_list_title
+id: paragraph.file_list.created
+field_name: created
 entity_type: paragraph
 bundle: file_list
-label: 'List Title'
-description: ''
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string
+field_type: created

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.file_list.status.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.file_list.status.yml
@@ -2,11 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - paragraphs.paragraphs_type.media_item
-id: paragraph.media_item.status
+    - paragraphs.paragraphs_type.file_list
+id: paragraph.file_list.status
 field_name: status
 entity_type: paragraph
-bundle: media_item
+bundle: file_list
 label: Published
 description: ''
 required: false

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.formatted_text.created.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.formatted_text.created.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.formatted_text
+id: paragraph.formatted_text.created
+field_name: created
+entity_type: paragraph
+bundle: formatted_text
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.icon_card.created.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.icon_card.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.icon_card
+id: paragraph.icon_card.created
+field_name: created
+entity_type: paragraph
+bundle: icon_card
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.icon_card.status.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.icon_card.status.yml
@@ -2,11 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - paragraphs.paragraphs_type.media_item
-id: paragraph.media_item.status
+    - paragraphs.paragraphs_type.icon_card
+id: paragraph.icon_card.status
 field_name: status
 entity_type: paragraph
-bundle: media_item
+bundle: icon_card
 label: Published
 description: ''
 required: false

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.text_card.created.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.text_card.created.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.text_card
+id: paragraph.text_card.created
+field_name: created
+entity_type: paragraph
+bundle: text_card
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.default.yml
@@ -55,6 +55,11 @@ content:
     weight: 5
     region: content
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 2

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.media_library.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.media_library.yml
@@ -27,6 +27,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_file: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_audio.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_audio.default.yml
@@ -53,6 +53,11 @@ content:
     weight: 5
     region: content
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 2

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_audio.media_library.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_audio.media_library.yml
@@ -27,6 +27,11 @@ content:
     weight: 0
     third_party_settings: {  }
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   langcode: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_image.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_image.default.yml
@@ -55,6 +55,11 @@ content:
     weight: 100
     region: content
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_video.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.media_item_video.default.yml
@@ -46,6 +46,11 @@ content:
     weight: 100
     region: content
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.accordion_builder.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.accordion_builder.default.yml
@@ -32,6 +32,11 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   status: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.column_container.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.column_container.default.yml
@@ -23,6 +23,11 @@ content:
       default_paragraph_type: ''
     third_party_settings: {  }
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   status: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.embed.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.embed.default.yml
@@ -19,6 +19,11 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   status: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.file_list.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.file_list.default.yml
@@ -27,6 +27,11 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   status: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.icon_card.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.paragraph.icon_card.default.yml
@@ -39,6 +39,11 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   status: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/editor.editor.paragraph_text.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/editor.editor.paragraph_text.yml
@@ -50,10 +50,10 @@ settings:
             - RemoveFormat
             - Source
   plugins:
-    stylescombo:
-      styles: ''
     language:
       language_list: un
+    stylescombo:
+      styles: ''
 image_upload:
   status: false
   scheme: public

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.file.field_file.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.file.field_file.yml
@@ -13,7 +13,7 @@ bundle: file
 label: File
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.file.field_file_type.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.file.field_file_type.yml
@@ -11,7 +11,7 @@ bundle: file
 label: 'File type'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.media_item_audio.field_media_item_audio_file.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.media_item_audio.field_media_item_audio_file.yml
@@ -13,7 +13,7 @@ bundle: media_item_audio
 label: 'Audio File'
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.media_item_image.field_media_item_image.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.media_item_image.field_media_item_image.yml
@@ -5,7 +5,14 @@ dependencies:
     - field.storage.media.field_media_item_image
     - media.type.media_item_image
   module:
+    - content_translation
     - image
+third_party_settings:
+  content_translation:
+    translation_sync:
+      alt: alt
+      title: title
+      file: '0'
 id: media.media_item_image.field_media_item_image
 field_name: field_media_item_image
 entity_type: media
@@ -13,7 +20,7 @@ bundle: media_item_image
 label: Image
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.paragraph.accordion_builder.field_item_flexible_text.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.paragraph.accordion_builder.field_item_flexible_text.yml
@@ -13,7 +13,7 @@ bundle: accordion_builder
 label: 'Item Flexible Text'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.media.media_item_audio.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.media.media_item_audio.yml
@@ -3,8 +3,15 @@ status: true
 dependencies:
   config:
     - media.type.media_item_audio
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
 id: media.media_item_audio
 target_entity_type_id: media
 target_bundle: media_item_audio
 default_langcode: site_default
-language_alterable: false
+language_alterable: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.media.media_item_image.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.media.media_item_image.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - media.type.file
+    - media.type.media_item_image
   module:
     - content_translation
 third_party_settings:
@@ -10,8 +10,8 @@ third_party_settings:
     enabled: true
     bundle_settings:
       untranslatable_fields_hide: '1'
-id: media.file
+id: media.media_item_image
 target_entity_type_id: media
-target_bundle: file
+target_bundle: media_item_image
 default_langcode: site_default
 language_alterable: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.media.media_item_video.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.media.media_item_video.yml
@@ -2,16 +2,16 @@ langcode: en
 status: true
 dependencies:
   config:
-    - media.type.file
+    - media.type.media_item_video
   module:
     - content_translation
 third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '1'
-id: media.file
+      untranslatable_fields_hide: '0'
+id: media.media_item_video
 target_entity_type_id: media
-target_bundle: file
+target_bundle: media_item_video
 default_langcode: site_default
 language_alterable: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.accordion_builder.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.accordion_builder.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - media.type.file
+    - paragraphs.paragraphs_type.accordion_builder
   module:
     - content_translation
 third_party_settings:
@@ -10,8 +10,8 @@ third_party_settings:
     enabled: true
     bundle_settings:
       untranslatable_fields_hide: '1'
-id: media.file
-target_entity_type_id: media
-target_bundle: file
+id: paragraph.accordion_builder
+target_entity_type_id: paragraph
+target_bundle: accordion_builder
 default_langcode: site_default
 language_alterable: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.column_container.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.column_container.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - media.type.file
+    - paragraphs.paragraphs_type.column_container
   module:
     - content_translation
 third_party_settings:
@@ -10,8 +10,8 @@ third_party_settings:
     enabled: true
     bundle_settings:
       untranslatable_fields_hide: '1'
-id: media.file
-target_entity_type_id: media
-target_bundle: file
+id: paragraph.column_container
+target_entity_type_id: paragraph
+target_bundle: column_container
 default_langcode: site_default
 language_alterable: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.embed.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.embed.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - media.type.file
+    - paragraphs.paragraphs_type.embed
   module:
     - content_translation
 third_party_settings:
@@ -10,8 +10,8 @@ third_party_settings:
     enabled: true
     bundle_settings:
       untranslatable_fields_hide: '1'
-id: media.file
-target_entity_type_id: media
-target_bundle: file
+id: paragraph.embed
+target_entity_type_id: paragraph
+target_bundle: embed
 default_langcode: site_default
 language_alterable: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.file_list.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.file_list.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - media.type.file
+    - paragraphs.paragraphs_type.file_list
   module:
     - content_translation
 third_party_settings:
@@ -10,8 +10,8 @@ third_party_settings:
     enabled: true
     bundle_settings:
       untranslatable_fields_hide: '1'
-id: media.file
-target_entity_type_id: media
-target_bundle: file
+id: paragraph.file_list
+target_entity_type_id: paragraph
+target_bundle: file_list
 default_langcode: site_default
 language_alterable: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.icon_card.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.icon_card.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - media.type.file
+    - paragraphs.paragraphs_type.icon_card
   module:
     - content_translation
 third_party_settings:
@@ -10,8 +10,8 @@ third_party_settings:
     enabled: true
     bundle_settings:
       untranslatable_fields_hide: '1'
-id: media.file
-target_entity_type_id: media
-target_bundle: file
+id: paragraph.icon_card
+target_entity_type_id: paragraph
+target_bundle: icon_card
 default_langcode: site_default
 language_alterable: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.text_card.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.text_card.yml
@@ -1,8 +1,8 @@
-langcode: en
+langcode: es
 status: true
 dependencies:
   config:
-    - media.type.file
+    - paragraphs.paragraphs_type.text_card
   module:
     - content_translation
 third_party_settings:
@@ -10,8 +10,8 @@ third_party_settings:
     enabled: true
     bundle_settings:
       untranslatable_fields_hide: '1'
-id: media.file
-target_entity_type_id: media
-target_bundle: file
+id: paragraph.text_card
+target_entity_type_id: paragraph
+target_bundle: text_card
 default_langcode: site_default
 language_alterable: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/user.role.embed_author.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/user.role.embed_author.yml
@@ -5,5 +5,3 @@ id: embed_author
 label: 'Embed Author'
 weight: 4
 is_admin: null
-permissions:
-  - 'use text format embed'

--- a/ecms_base/features/custom/ecms_paragraphs/ecms_paragraphs.features.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/ecms_paragraphs.features.yml
@@ -1,2 +1,1 @@
 bundle: ecms
-required: true

--- a/ecms_base/features/custom/ecms_paragraphs/ecms_paragraphs.info.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/ecms_paragraphs.info.yml
@@ -16,6 +16,7 @@ dependencies:
   - link
   - media
   - media_library
+  - metatag
   - options
   - paragraphs
   - path

--- a/ecms_base/features/custom/ecms_person/config/install/core.base_field_override.media.person_headshot.metatag.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.base_field_override.media.person_headshot.metatag.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.person_headshot
+id: media.person_headshot.metatag
+field_name: metatag
+entity_type: media
+bundle: person_headshot
+label: Metatags
+description: 'The meta tags for the entity.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: map

--- a/ecms_base/features/custom/ecms_person/config/install/core.base_field_override.node.person.menu_link.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.base_field_override.node.person.menu_link.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.person
+id: node.person.menu_link
+field_name: menu_link
+entity_type: node
+bundle: person
+label: 'Menu link'
+description: 'Computed menu link for the node (only available during node saving).'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_person/config/install/core.base_field_override.node.person.moderation_state.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.base_field_override.node.person.moderation_state.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.person
+id: node.person.moderation_state
+field_name: moderation_state
+entity_type: node
+bundle: person
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_person/config/install/core.base_field_override.node.person.path.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.base_field_override.node.person.path.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.person
+  module:
+    - path
+id: node.person.path
+field_name: path
+entity_type: node
+bundle: person
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/ecms_base/features/custom/ecms_person/config/install/core.base_field_override.node.person.status.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.base_field_override.node.person.status.yml
@@ -2,11 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - media.type.person_headshot
-id: media.person_headshot.status
+    - node.type.person
+id: node.person.status
 field_name: status
-entity_type: media
-bundle: person_headshot
+entity_type: node
+bundle: person
 label: Published
 description: ''
 required: false

--- a/ecms_base/features/custom/ecms_person/config/install/core.entity_view_display.media.person_headshot.default.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.entity_view_display.media.person_headshot.default.yml
@@ -25,5 +25,6 @@ hidden:
   created: true
   langcode: true
   name: true
+  search_api_excerpt: true
   thumbnail: true
   uid: true

--- a/ecms_base/features/custom/ecms_person/config/install/core.entity_view_display.media.person_headshot.media_library.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.entity_view_display.media.person_headshot.media_library.yml
@@ -27,4 +27,5 @@ hidden:
   field_media_image: true
   langcode: true
   name: true
+  search_api_excerpt: true
   uid: true

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.base_field_override.node.press_release.menu_link.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.base_field_override.node.press_release.menu_link.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.press_release
+id: node.press_release.menu_link
+field_name: menu_link
+entity_type: node
+bundle: press_release
+label: 'Menu link'
+description: 'Computed menu link for the node (only available during node saving).'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.base_field_override.node.press_release.moderation_state.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.base_field_override.node.press_release.moderation_state.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.press_release
+id: node.press_release.moderation_state
+field_name: moderation_state
+entity_type: node
+bundle: press_release
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.base_field_override.node.press_release.path.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.base_field_override.node.press_release.path.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.press_release
+  module:
+    - path
+id: node.press_release.path
+field_name: path
+entity_type: node
+bundle: press_release
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.base_field_override.node.press_release.status.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.base_field_override.node.press_release.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.press_release
+id: node.press_release.status
+field_name: status
+entity_type: node
+bundle: press_release
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.base_field_override.node.press_release.title.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.base_field_override.node.press_release.title.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.press_release
+id: node.press_release.title
+field_name: title
+entity_type: node
+bundle: press_release
+label: Title
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.entity_view_display.taxonomy_term.press_release_topics.default.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.entity_view_display.taxonomy_term.press_release_topics.default.yml
@@ -19,3 +19,4 @@ content:
     third_party_settings: {  }
 hidden:
   langcode: true
+  search_api_excerpt: true

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.block_content.promotion_reference.changed.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.block_content.promotion_reference.changed.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - block_content.type.promotion_reference
+id: block_content.promotion_reference.changed
+field_name: changed
+entity_type: block_content
+bundle: promotion_reference
+label: Changed
+description: 'The time that the custom block was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.block_content.promotion_reference.metatag.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.block_content.promotion_reference.metatag.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - block_content.type.promotion_reference
+id: block_content.promotion_reference.metatag
+field_name: metatag
+entity_type: block_content
+bundle: promotion_reference
+label: Metatags
+description: 'The meta tags for the entity.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: map

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.changed.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.promotional_image
+id: media.promotional_image.changed
+field_name: changed
+entity_type: media
+bundle: promotional_image
+label: Changed
+description: 'The time the media item was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.created.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.promotional_image
+id: media.promotional_image.created
+field_name: created
+entity_type: media
+bundle: promotional_image
+label: 'Authored on'
+description: 'The time the media item was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getRequestTime'
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.metatag.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.metatag.yml
@@ -1,0 +1,17 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - media.type.promotional_image
+id: media.promotional_image.metatag
+field_name: metatag
+entity_type: media
+bundle: promotional_image
+label: Metatags
+description: 'The meta tags for the entity.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: map

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.name.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.name.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.promotional_image
+id: media.promotional_image.name
+field_name: name
+entity_type: media
+bundle: promotional_image
+label: Name
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.path.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.path.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.promotional_image
+  module:
+    - path
+id: media.promotional_image.path
+field_name: path
+entity_type: media
+bundle: promotional_image
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.status.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.promotional_image
+id: media.promotional_image.status
+field_name: status
+entity_type: media
+bundle: promotional_image
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.thumbnail.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.thumbnail.yml
@@ -2,7 +2,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.media.field_promotion_image
     - media.type.promotional_image
   module:
     - content_translation
@@ -10,35 +9,35 @@ dependencies:
 third_party_settings:
   content_translation:
     translation_sync:
-      alt: alt
-      title: title
-      file: '0'
-id: media.promotional_image.field_promotion_image
-field_name: field_promotion_image
+      file: file
+      alt: 0
+      title: 0
+id: media.promotional_image.thumbnail
+field_name: thumbnail
 entity_type: media
 bundle: promotional_image
-label: Image
-description: ''
-required: true
+label: Thumbnail
+description: 'The thumbnail of the media item.'
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
-  max_filesize: ''
-  max_resolution: ''
-  min_resolution: ''
   alt_field: true
   alt_field_required: true
   title_field: false
   title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
   default_image:
-    uuid: ''
+    uuid: null
     alt: ''
     title: ''
     width: null
     height: null
-  handler: 'default:file'
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: default
   handler_settings: {  }
 field_type: image

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.uid.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.media.promotional_image.uid.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.promotional_image
+id: media.promotional_image.uid
+field_name: uid
+entity_type: media
+bundle: promotional_image
+label: 'Authored by'
+description: 'The user ID of the author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getDefaultEntityOwner'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.node.promotions.menu_link.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.node.promotions.menu_link.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.promotions
+id: node.promotions.menu_link
+field_name: menu_link
+entity_type: node
+bundle: promotions
+label: 'Menu link'
+description: 'Computed menu link for the node (only available during node saving).'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.node.promotions.moderation_state.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.node.promotions.moderation_state.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.promotions
+id: node.promotions.moderation_state
+field_name: moderation_state
+entity_type: node
+bundle: promotions
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.node.promotions.path.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.node.promotions.path.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.promotions
+  module:
+    - path
+id: node.promotions.path
+field_name: path
+entity_type: node
+bundle: promotions
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.node.promotions.status.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.node.promotions.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.promotions
+id: node.promotions.status
+field_name: status
+entity_type: node
+bundle: promotions
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.node.promotions.title.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.node.promotions.title.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.promotions
+id: node.promotions.title
+field_name: title
+entity_type: node
+bundle: promotions
+label: Title
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.paragraph.promotion_reference.created.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.paragraph.promotion_reference.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.promotion_reference
+id: paragraph.promotion_reference.created
+field_name: created
+entity_type: paragraph
+bundle: promotion_reference
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.paragraph.promotion_reference.status.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.base_field_override.paragraph.promotion_reference.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.promotion_reference
+id: paragraph.promotion_reference.status
+field_name: status
+entity_type: paragraph
+bundle: promotion_reference
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.entity_form_display.block_content.promotion_reference.default.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.entity_form_display.block_content.promotion_reference.default.yml
@@ -34,4 +34,9 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden: {  }

--- a/ecms_base/features/custom/ecms_promotions/config/install/core.entity_form_display.paragraph.promotion_reference.default.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/core.entity_form_display.paragraph.promotion_reference.default.yml
@@ -19,6 +19,11 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   status: true

--- a/ecms_base/features/custom/ecms_promotions/config/install/language.content_settings.block_content.promotion_reference.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/language.content_settings.block_content.promotion_reference.yml
@@ -3,8 +3,15 @@ status: true
 dependencies:
   config:
     - block_content.type.promotion_reference
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
 id: block_content.promotion_reference
 target_entity_type_id: block_content
 target_bundle: promotion_reference
 default_langcode: site_default
-language_alterable: false
+language_alterable: true

--- a/ecms_base/features/custom/ecms_promotions/config/install/language.content_settings.paragraph.promotion_reference.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/language.content_settings.paragraph.promotion_reference.yml
@@ -7,11 +7,11 @@ dependencies:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: false
+    enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.promotion_reference
 target_entity_type_id: paragraph
 target_bundle: promotion_reference
 default_langcode: site_default
-language_alterable: false
+language_alterable: true

--- a/ecms_base/features/custom/ecms_promotions/config/install/rabbit_hole.behavior_settings.node_type_promotions.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/rabbit_hole.behavior_settings.node_type_promotions.yml
@@ -2,7 +2,10 @@ langcode: en
 status: true
 dependencies: {  }
 id: node_type_promotions
+entity_type_id: null
+entity_id: null
 action: access_denied
 allow_override: 0
 redirect: ''
 redirect_code: 301
+redirect_fallback_action: null

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -376,7 +376,7 @@ function ecms_preprocess_paragraph__publication_list(array &$variables): void {
 /**
  * Implements hook_preprocess_block().
  */
-function ecms_preprocess_block(&$variables): void {
+function ecms_preprocess_block(array &$variables): void {
   // Block labels are not translated properly.
   // @see: https://www.drupal.org/project/drupal/issues/2810457#comment-12625567
   if ($variables['elements']['#base_plugin_id'] === 'inline_block' || $variables['elements']['#base_plugin_id'] === 'block_content') {

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -63,7 +63,7 @@ function ecms_theme(array $existing, string $type, string $theme, string $path):
 }
 
 /**
- * Implements hook_preprocess_paragaph().
+ * Implements hook_preprocess_HOOK() for the paragraph__media_item.
  */
 function ecms_preprocess_paragraph__media_item(array &$variables): void {
   $paragraph = $variables['paragraph'];
@@ -86,7 +86,7 @@ function ecms_preprocess_paragraph__media_item(array &$variables): void {
 }
 
 /**
- * Implements hook_preprocess_paragaph().
+ * Implements hook_preprocess_HOOK() for the media__file element.
  */
 function ecms_preprocess_media__file(array &$variables): void {
   $media = $variables['media'];
@@ -173,7 +173,7 @@ function _filesize_formatted(int $bytes): array {
 }
 
 /**
- * Implements hook_theme_suggestions_hook() for container templates.
+ * Implements hook_theme_suggestions_HOOK_alter() for container templates.
  *
  * Add suggestions, as by default none are provided.
  */

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -372,3 +372,17 @@ function ecms_preprocess_paragraph__publication_list(array &$variables): void {
 
   $variables['publications'] = $publications_types;
 }
+
+/**
+ * Implements hook_preprocess_block().
+ */
+function ecms_preprocess_block(&$variables): void {
+  // Block labels are not translated properly.
+  // @see: https://www.drupal.org/project/drupal/issues/2810457#comment-12625567
+  if ($variables['elements']['#base_plugin_id'] === 'inline_block' || $variables['elements']['#base_plugin_id'] === 'block_content') {
+    if (!empty($variables['label'])) {
+      // Use the correct language for the block label.
+      $variables['label'] = $variables['content']['#block_content']->label();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This updates the custom block types to be translatable. This also updates all custom paragraph entities to be translatable. I re-exported the features with the most recent Covid database to capture any overrides that were showing.

A `hook_preprocess_block` was added to allow the custom and inline block labels to be translated.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-160](https://thinkoomph.jira.com/browse/rig-160)