### PR TITLE
Add an admin sub-theme of Claro for eCMS customizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 !/gulpfile.js
 /**/*.map
 
+# Allow custom admin theme css to be committed.
+!/ecms_base/themes/custom/ecms_claro/**/*.css
+
 # Project dependencies
 /node_modules
 /vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIG-166: Added ecms_claro admin theme and set it as the default for the profile.
 
 ### Changed
 - RIG-168: Updated moderation dashboard and workflow state labels.

--- a/ecms_base/config/install/system.theme.yml
+++ b/ecms_base/config/install/system.theme.yml
@@ -1,2 +1,2 @@
-admin: claro
+admin: ecms_claro
 default: ecms

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -110,3 +110,4 @@ themes:
   - classy
   - claro
   - ecms
+  - ecms_claro

--- a/ecms_base/ecms_base.profile
+++ b/ecms_base/ecms_base.profile
@@ -360,12 +360,7 @@ function ecms_base_update_9030(array &$sandbox): void {
   foreach ($newConfig as $config) {
     $active_storage->write("{$config}", $install_source->read("{$config}"));
   }
-}
 
-/**
- * Updates to run for the 0.3.0 tag.
- */
-function ecms_base_update_9030(array &$sandbox): void {
   // Install the ecms_claro theme.
   /** @var \Drupal\Core\Extension\ThemeInstallerInterface $themeInstaller */
   $themeInstaller = \Drupal::service('theme_installer');

--- a/ecms_base/ecms_base.profile
+++ b/ecms_base/ecms_base.profile
@@ -361,3 +361,20 @@ function ecms_base_update_9030(array &$sandbox): void {
     $active_storage->write("{$config}", $install_source->read("{$config}"));
   }
 }
+
+/**
+ * Updates to run for the 0.3.0 tag.
+ */
+function ecms_base_update_9030(array &$sandbox): void {
+  // Install the ecms_claro theme.
+  /** @var \Drupal\Core\Extension\ThemeInstallerInterface $themeInstaller */
+  $themeInstaller = \Drupal::service('theme_installer');
+  $themeInstaller->install(['ecms_claro']);
+
+  // Set the ecms_claro theme as the admin theme.
+  /** @var \Drupal\Core\Config\ConfigFactoryInterface $configFactory */
+  $configFactory = \Drupal::service('config.factory');
+  $config = $configFactory->getEditable('system.theme');
+  $config->set('admin', 'ecms_claro');
+  $config->save();
+}

--- a/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_breadcrumbs.yml
+++ b/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_breadcrumbs.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - ecms_claro
+id: ecms_claro_breadcrumbs
+theme: ecms_claro
+region: breadcrumb
+weight: 0
+provider: null
+plugin: system_breadcrumb_block
+settings:
+  id: system_breadcrumb_block
+  label: Breadcrumbs
+  provider: system
+  label_display: '0'
+visibility: {  }

--- a/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_content.yml
+++ b/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_content.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - ecms_claro
+id: ecms_claro_content
+theme: ecms_claro
+region: content
+weight: 0
+provider: null
+plugin: system_main_block
+settings:
+  id: system_main_block
+  label: 'Main page content'
+  provider: system
+  label_display: visible
+visibility: {  }

--- a/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_help.yml
+++ b/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_help.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - help
+  theme:
+    - ecms_claro
+id: ecms_claro_help
+theme: ecms_claro
+region: help
+weight: 0
+provider: null
+plugin: help_block
+settings:
+  id: help_block
+  label: Help
+  provider: help
+  label_display: '0'
+visibility: {  }

--- a/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_local_actions.yml
+++ b/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_local_actions.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  theme:
+    - ecms_claro
+id: ecms_claro_local_actions
+theme: ecms_claro
+region: content
+weight: -10
+provider: null
+plugin: local_actions_block
+settings:
+  id: local_actions_block
+  label: 'Primary admin actions'
+  provider: core
+  label_display: '0'
+visibility: {  }

--- a/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_messages.yml
+++ b/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_messages.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - ecms_claro
+id: ecms_claro_messages
+theme: ecms_claro
+region: highlighted
+weight: 0
+provider: null
+plugin: system_messages_block
+settings:
+  id: system_messages_block
+  label: 'Status messages'
+  provider: system
+  label_display: '0'
+visibility: {  }

--- a/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_page_title.yml
+++ b/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_page_title.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  theme:
+    - ecms_claro
+id: ecms_claro_page_title
+theme: ecms_claro
+region: header
+weight: -30
+provider: null
+plugin: page_title_block
+settings:
+  id: page_title_block
+  label: 'Page title'
+  provider: core
+  label_display: '0'
+visibility: {  }

--- a/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_primary_local_tasks.yml
+++ b/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_primary_local_tasks.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  theme:
+    - ecms_claro
+id: ecms_claro_primary_local_tasks
+theme: ecms_claro
+region: header
+weight: 0
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: 'Primary tabs'
+  provider: core
+  label_display: '0'
+  primary: true
+  secondary: false
+visibility: {  }

--- a/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_secondary_local_tasks.yml
+++ b/ecms_base/themes/custom/ecms_claro/config/optional/block.block.ecms_claro_secondary_local_tasks.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  theme:
+    - ecms_claro
+id: ecms_claro_secondary_local_tasks
+theme: ecms_claro
+region: pre_content
+weight: 0
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: 'Secondary tabs'
+  provider: core
+  label_display: '0'
+  primary: false
+  secondary: true
+visibility: {  }

--- a/ecms_base/themes/custom/ecms_claro/css/style.css
+++ b/ecms_base/themes/custom/ecms_claro/css/style.css
@@ -1,0 +1,3 @@
+/**
+ * Custom styles for the ecms_claro theme.
+ */

--- a/ecms_base/themes/custom/ecms_claro/ecms_claro.info.yml
+++ b/ecms_base/themes/custom/ecms_claro/ecms_claro.info.yml
@@ -1,0 +1,22 @@
+name: Rhode Island eCMS Admin Theme
+description: "A custom administration theme for the Rhode Island eCMS system based on Claro."
+type: theme
+core_version_requirement: ^8 || ^9
+base theme: claro
+
+libraries:
+  - ecms_claro/global-styling
+
+regions:
+  header: 'Header'
+  pre_content: 'Pre-content'
+  breadcrumb: Breadcrumb
+  highlighted: Highlighted
+  help: Help
+  content: Content
+  page_top: 'Page top'
+  page_bottom: 'Page bottom'
+  sidebar_first: 'First sidebar'
+
+regions_hidden:
+  - sidebar_first

--- a/ecms_base/themes/custom/ecms_claro/ecms_claro.libraries.yml
+++ b/ecms_base/themes/custom/ecms_claro/ecms_claro.libraries.yml
@@ -1,0 +1,4 @@
+global-styling:
+  css:
+    component:
+      css/style.css: {}


### PR DESCRIPTION
## Summary
This adds a new `ecms_claro` administration theme to the profile and sets it as the default for the profile. The css was allowed to be committed as SASS is not going to be used in this theme.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-166](https://thinkoomph.jira.com/browse/rig-166)