### PR TITLE
Add audience tags to the Covid publication import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Changed
 - RIG-168: Updated moderation dashboard and workflow state labels.
+- RIG-169: Added the audience terms to the Covid migration.
 
 ### Deprecated
 

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_types.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_types.yml
@@ -6,7 +6,7 @@ source:
   plugin: url
   data_fetcher_plugin: http
   urls:
-    - https://health.ri.gov/rss/pubs/rss-covid-pub-list.php
+    - https://health.ri.gov/rss/pubs/all-rss-covid-pub-list.php
   data_parser_plugin: simple_xml
   item_selector: /rss/channel/item
   fields:
@@ -28,9 +28,17 @@ source:
     - name: language
       label: 'Language'
       selector: language
+    - name: language
+      label: 'Language'
+      selector: language
+    - name: audiences
+      label: 'Audiences'
+      selector: audience
 
   ids:
     guid:
+      type: string
+    language:
       type: string
 
 destination:
@@ -38,8 +46,6 @@ destination:
   default_bundle: 'publication_type'
 
 process:
-  id: guid
-
   pseudo_check_exists:
     - plugin: callback
       callable: urldecode

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_types.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publication_types.yml
@@ -28,9 +28,6 @@ source:
     - name: language
       label: 'Language'
       selector: language
-    - name: language
-      label: 'Language'
-      selector: language
     - name: audiences
       label: 'Audiences'
       selector: audience

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publications_rss.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publications_rss.yml
@@ -6,7 +6,7 @@ source:
   plugin: url
   data_fetcher_plugin: http
   urls:
-    - https://health.ri.gov/rss/pubs/rss-covid-pub-list.php
+    - https://health.ri.gov/rss/pubs/all-rss-covid-pub-list.php
   data_parser_plugin: simple_xml
   item_selector: /rss/channel/item
   fields:
@@ -28,9 +28,17 @@ source:
     - name: language
       label: 'Language'
       selector: language
+    - name: language
+      label: 'Language'
+      selector: language
+    - name: audiences
+      label: 'Audiences'
+      selector: audience
 
   ids:
     guid:
+      type: string
+    language:
       type: string
 
 destination:
@@ -38,11 +46,12 @@ destination:
   default_bundle: 'publication'
 
 process:
-  id: guid
   title:
    - plugin: callback
      callable: urldecode
      source: title
+   - plugin: callback
+     callable: trim
   'field_publication_url/uri':
     - plugin: callback
       callable: urldecode
@@ -51,6 +60,8 @@ process:
     - plugin: callback
       callable: urldecode
       source: title
+    - plugin: callback
+      callable: trim
   pseudo_publication_type:
     - plugin: callback
       callable: urldecode
@@ -70,6 +81,24 @@ process:
       value_key: name
       bundle_key: vid
       bundle: 'publication_type'
+
+  field_publication_audiences:
+    - plugin: callback
+      callable: urldecode
+    - plugin: skip_on_empty
+      source: audiences
+      method: process
+      message: 'No audience listed.'
+    - plugin: explode
+      delimiter: ','
+    - plugin: callback
+      callable: trim
+    - plugin: entity_generate
+      entity_type: taxonomy_term
+      value_key: name
+      bundle_key: vid
+      bundle: 'publication_audience'
+      ignore_case: true
 
   langcode:
     - plugin: static_map

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publications_rss.yml
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/config/install/migrate_plus.migration.ecms_covid_publications_rss.yml
@@ -28,9 +28,6 @@ source:
     - name: language
       label: 'Language'
       selector: language
-    - name: language
-      label: 'Language'
-      selector: language
     - name: audiences
       label: 'Audiences'
       selector: audience

--- a/ecms_base/modules/custom/ecms_covid_publication_migrate/ecms_covid_publication_migrate.install
+++ b/ecms_base/modules/custom/ecms_covid_publication_migrate/ecms_covid_publication_migrate.install
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @file
+ * ecms_covid_publication_migrate.install
+ */
+
+declare(strict_types = 1);
+
+use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Database\Database;
+
+/**
+ * Update existing Covid publication import configuration.
+ */
+function ecms_covid_publication_migrate_update_9000(array $sandbox): void {
+  // Add the sourceid2 to the migrate_map table.
+  $sourceId2Column = [
+    'type' => 'varchar',
+    'description' => 'sourceid2',
+    'length' => 255,
+    'not null' => FALSE,
+  ];
+
+  $schema = Database::getConnection()->schema();
+  $schema->addField('migrate_map_ecms_covid_publication_types', 'sourceid2', $sourceId2Column);
+  $schema->addField('migrate_map_ecms_covid_publications_rss', 'sourceid2', $sourceId2Column);
+
+  // Config updates.
+  $path = \Drupal::service('extension.list.module')->getPath('ecms_covid_publication_migrate');
+
+  /** @var \Drupal\Core\Config\FileStorage $install_source */
+  $install_source = new FileStorage($path . "/config/install/");
+
+  /** @var \Drupal\Core\Config\StorageInterface $active_storage */
+  $active_storage = \Drupal::service('config.storage');
+
+  $newConfig = [
+    'migrate_plus.migration.ecms_covid_publication_types',
+    'migrate_plus.migration.ecms_covid_publications_rss',
+  ];
+
+  foreach ($newConfig as $config) {
+    $active_storage->write("{$config}", $install_source->read("{$config}"));
+  }
+}


### PR DESCRIPTION
## Summary
This adds the audience tags to the publications during import. A hook_update function was included to add the new sourceid2 column to the migrate map tables and to import the new configuration.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Medium
| Relevant links | [RIG-169](https://thinkoomph.jira.com/browse/rig-169)