### PR TITLE
Add the missing theme schema to allow translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-180: Fixed the theme settings to make them translatable.
 
 ### Security
+- RIG-180: Fixed an XSS issue with the output of the theme settings variables.
 
 ## [0.3.1] - 2020-12-11
 ### Fixed

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -524,9 +524,9 @@ function ecms_base_update_9030(array &$sandbox): void {
 }
 
 /**
- * Updates to run for the 0.3.1 tag.
+ * Updates to run for the 0.3.2 tag.
  */
-function ecms_base_update_9031(array &$sandbox): void {
+function ecms_base_update_9032(array &$sandbox): void {
   // Install the locale module for interface translations.
   $modules_to_install = [
     'locale',

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -522,3 +522,15 @@ function ecms_base_update_9030(array &$sandbox): void {
   $config->set('admin', 'ecms_claro');
   $config->save();
 }
+
+/**
+ * Updates to run for the 0.3.1 tag.
+ */
+function ecms_base_update_9031(array &$sandbox): void {
+  // Install the locale module for interface translations.
+  $modules_to_install = [
+    'locale',
+  ];
+
+  \Drupal::service('module_installer')->install($modules_to_install);
+}

--- a/ecms_base/themes/custom/ecms/config/install/ecms.settings.yml
+++ b/ecms_base/themes/custom/ecms/config/install/ecms.settings.yml
@@ -20,6 +20,6 @@ footer_state_info:
   value: "<p><strong>State of Rhode Island</strong></p>\r\n\r\n<p><a href=\"http://www.governor.ri.gov/\">Office of the Governor</a></p>\r\n\r\n<p><a href=\"https://www.ri.gov/\">RI.gov</a></p>\r\n\r\n<p><a href=\"https://www.ri.gov/guide/\">Elected Officials</a></p>\r\n\r\n<p><a href=\"https://www.ri.gov/guide/\">State Agencies (A-Z)</a></p>\r\n"
   format: basic_html
 color_palette: scarborough
-header_top_line: 'State of Rhode Island'
-header_main_line: 'Agency Name'
-header_bottom_line: ''
+header_top_line: "State of Rhode Island"
+header_main_line: "Agency Name"
+header_bottom_line: "Agency Slogan"

--- a/ecms_base/themes/custom/ecms/config/schema/ecms.schema.yml
+++ b/ecms_base/themes/custom/ecms/config/schema/ecms.schema.yml
@@ -1,0 +1,91 @@
+ecms.settings:
+  type: config_object
+  mapping:
+    features:
+      label: Features
+      type: mapping
+      mapping:
+        node_user_picture:
+          type: boolean
+          label: "Show author picture"
+        comment_user_picture:
+          type: boolean
+          label: "Show comment author's picture"
+        comment_user_verification:
+          type: boolean
+          label: "Show user verified in comments"
+        favicon:
+          type: integer
+          label: "Display the favicon"
+    logo:
+      type: mapping
+      mapping:
+        use_default:
+          type: integer
+          label: "Use the default logo"
+        path:
+          type: string
+          label: 'Logo path'
+    favicon:
+      type: mapping
+      mapping:
+        use_default:
+          type: integer
+          label: "Use the default favicon"
+        path:
+          type: string
+          label: 'Favicon path'
+        mimetype:
+          type: string
+          label: 'Favicon mimetype'
+    footer_left:
+      type: mapping
+      mapping:
+        value:
+          type: text
+          label: "Left footer column text"
+        format:
+          type: string
+          label: "Left footer column text format"
+    footer_center:
+      type: mapping
+      mapping:
+        value:
+          type: text
+          label: "Center footer column text"
+        format:
+          type: string
+          label: "Center footer column text format"
+    footer_right:
+      type: mapping
+      mapping:
+        value:
+          type: text
+          label: "Right footer column text"
+        format:
+          type: string
+          label: "Right footer column text format"
+    footer_state_info:
+      type: mapping
+      mapping:
+        value:
+          type: text
+          label: "State information text"
+        format:
+          type: string
+          label: "State information text format"
+    color_palette:
+      type: string
+      label: 'Color palette'
+    header_top_line:
+      type: text
+      label: 'Top line of the header'
+    header_main_line:
+      type: text
+      label: 'Center line of the header'
+    header_bottom_line:
+      type: text
+      label: 'Bottom line of the header'
+    langcode:
+      type: string
+      label: 'Language code'

--- a/ecms_base/themes/custom/ecms/config/schema/ecms.schema.yml
+++ b/ecms_base/themes/custom/ecms/config/schema/ecms.schema.yml
@@ -7,22 +7,22 @@ ecms.settings:
       mapping:
         node_user_picture:
           type: boolean
-          label: "Show author picture"
+          label: 'Show author picture'
         comment_user_picture:
           type: boolean
-          label: "Show comment author's picture"
+          label: 'Show comment author picture'
         comment_user_verification:
           type: boolean
-          label: "Show user verified in comments"
+          label: 'Show user verified in comments'
         favicon:
           type: integer
-          label: "Display the favicon"
+          label: 'Display the favicon'
     logo:
       type: mapping
       mapping:
         use_default:
           type: integer
-          label: "Use the default logo"
+          label: 'Use the default logo'
         path:
           type: string
           label: 'Logo path'
@@ -31,7 +31,7 @@ ecms.settings:
       mapping:
         use_default:
           type: integer
-          label: "Use the default favicon"
+          label: 'Use the default favicon'
         path:
           type: string
           label: 'Favicon path'
@@ -43,37 +43,37 @@ ecms.settings:
       mapping:
         value:
           type: text
-          label: "Left footer column text"
+          label: 'Left footer column text'
         format:
           type: string
-          label: "Left footer column text format"
+          label: 'Left footer column text format'
     footer_center:
       type: mapping
       mapping:
         value:
           type: text
-          label: "Center footer column text"
+          label: 'Center footer column text'
         format:
           type: string
-          label: "Center footer column text format"
+          label: 'Center footer column text format'
     footer_right:
       type: mapping
       mapping:
         value:
           type: text
-          label: "Right footer column text"
+          label: 'Right footer column text'
         format:
           type: string
-          label: "Right footer column text format"
+          label: 'Right footer column text format'
     footer_state_info:
       type: mapping
       mapping:
         value:
           type: text
-          label: "State information text"
+          label: 'State information text'
         format:
           type: string
-          label: "State information text format"
+          label: 'State information text format'
     color_palette:
       type: string
       label: 'Color palette'

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -26,15 +26,34 @@ function ecms_preprocess_page(array &$variables): void {
 
   // Attach header variables.
   $variables['header_preprocess_values']['site_logo'] = theme_get_setting('logo.url');
-  $variables['header_preprocess_values']['top_line'] = theme_get_setting('header_top_line');
-  $variables['header_preprocess_values']['main_line'] = theme_get_setting('header_main_line');
-  $variables['header_preprocess_values']['bottom_line'] = theme_get_setting('header_bottom_line');
+  $variables['header_preprocess_values']['top_line'] = ['#plain_text' => theme_get_setting('header_top_line')];
+  $variables['header_preprocess_values']['main_line'] = ['#plain_text' => theme_get_setting('header_main_line')];
+  $variables['header_preprocess_values']['bottom_line'] = ['#plain_text' => theme_get_setting('header_bottom_line')];
 
   // Attach footer variables.
-  $variables['footer_preprocess_values']['footer_left'] = theme_get_setting('footer_left')['value'];
-  $variables['footer_preprocess_values']['footer_center'] = theme_get_setting('footer_center')['value'];
-  $variables['footer_preprocess_values']['footer_right'] = theme_get_setting('footer_right')['value'];
-  $variables['footer_preprocess_values']['state_info'] = theme_get_setting('footer_state_info')['value'];
+  $variables['footer_preprocess_values']['footer_left'] = [
+    '#type' => 'processed_text',
+    '#text' => theme_get_setting('footer_left')['value'],
+    '#format' => theme_get_setting('footer_left')['format'],
+  ];
+
+  $variables['footer_preprocess_values']['footer_center'] = [
+    '#type' => 'processed_text',
+    '#text' => theme_get_setting('footer_center')['value'],
+    '#format' => theme_get_setting('footer_center')['format'],
+  ];
+
+  $variables['footer_preprocess_values']['footer_right'] = [
+    '#type' => 'processed_text',
+    '#text' => theme_get_setting('footer_right')['value'],
+    '#format' => theme_get_setting('footer_right')['format'],
+  ];
+
+  $variables['footer_preprocess_values']['state_info'] = [
+    '#type' => 'processed_text',
+    '#text' => theme_get_setting('footer_state_info')['value'],
+    '#format' => theme_get_setting('footer_state_info')['format'],
+  ];
 }
 
 /**

--- a/ecms_base/themes/custom/ecms/theme-settings.php
+++ b/ecms_base/themes/custom/ecms/theme-settings.php
@@ -62,7 +62,7 @@ function ecms_form_system_theme_settings_alter(&$form, FormStateInterface $form_
     '#type' => 'textfield',
     '#title' => t('Top Line'),
     '#default_value' => theme_get_setting('header_top_line'),
-    '#description' => t("(Optional) The top line of the header."),
+    '#description' => t("(Optional) The top line of the header. For translation, search for 'State of Rhode Island'"),
     '#maxlength' => 255,
   ];
 
@@ -70,7 +70,7 @@ function ecms_form_system_theme_settings_alter(&$form, FormStateInterface $form_
     '#type' => 'textfield',
     '#title' => t('Main Line'),
     '#default_value' => theme_get_setting('header_main_line'),
-    '#description' => t("The main line of the header."),
+    '#description' => t("The main line of the header. For translation, search for 'Agency Name'"),
     '#required' => TRUE,
     '#maxlength' => 255,
   ];
@@ -79,7 +79,7 @@ function ecms_form_system_theme_settings_alter(&$form, FormStateInterface $form_
     '#type' => 'textfield',
     '#title' => t('Bottom Line'),
     '#default_value' => theme_get_setting('header_bottom_line'),
-    '#description' => t("(Optional) The bottom line of the header."),
+    '#description' => t("(Optional) The bottom line of the header. For translation, search for 'Agency Slogan'"),
     '#maxlength' => 255,
   ];
 


### PR DESCRIPTION
## Summary
This adds the missing `ecms.schema.yml` which is required in order to translate the theme settings.

Also, while working on the translation, I discovered an XSS issue with the way the theme settings were being output. I fixed these to properly sanitize the output of the settings in the preprocess hook.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | yes
| Risk level | Medium
| Relevant links | [RIG-180](https://thinkoomph.jira.com/browse/rig-180)