### PR TITLE
Add interface translation permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Fixed
 - RIG-180: Fixed the theme settings to make them translatable.
+- RIG-181: Gave the content author 'view all revisions' permission by default.
+- RIG-184: Gave the site admin 'translate interface' permission by default.
 
 ### Security
 - RIG-180: Fixed an XSS issue with the output of the theme settings variables.

--- a/ecms_base/config/install/user.role.content_author.yml
+++ b/ecms_base/config/install/user.role.content_author.yml
@@ -122,4 +122,5 @@ permissions:
   - 'use editorial transition create_new_draft'
   - 'use editorial transition review'
   - 'use text format paragraph_text'
+  - 'view all revisions'
   - 'view own unpublished content'

--- a/ecms_base/config/install/user.role.site_admin.yml
+++ b/ecms_base/config/install/user.role.site_admin.yml
@@ -245,6 +245,7 @@ permissions:
   - 'translate event_image media'
   - 'translate event_taxonomy taxonomy_term'
   - 'translate file media'
+  - 'translate interface'
   - 'translate landing_page node'
   - 'translate location node'
   - 'translate media_item_audio media'

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -43,6 +43,7 @@ dependencies:
   - layout_builder_restrictions
   - language_cookie
   - layout_discovery
+  - locale
   - media
   - media_library
   - media_library_theme_reset

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -524,13 +524,31 @@ function ecms_base_update_9030(array &$sandbox): void {
 }
 
 /**
- * Updates to run for the 0.3.2 tag.
+ * Updates to run for the 0.3.3 tag.
  */
-function ecms_base_update_9032(array &$sandbox): void {
+function ecms_base_update_9033(array &$sandbox): void {
   // Install the locale module for interface translations.
   $modules_to_install = [
     'locale',
   ];
 
   \Drupal::service('module_installer')->install($modules_to_install);
+
+  // Config updates for new modules.
+  $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
+
+  /** @var \Drupal\Core\Config\FileStorage $install_source */
+  $install_source = new FileStorage($path . "/config/install/");
+
+  /** @var \Drupal\Core\Config\StorageInterface $active_storage */
+  $active_storage = \Drupal::service('config.storage');
+
+  $newConfig = [
+    'user.role.content_author',
+    'user.role.site_admin',
+  ];
+
+  foreach ($newConfig as $config) {
+    $active_storage->write("{$config}", $install_source->read("{$config}"));
+  }
 }


### PR DESCRIPTION
## Summary
This updates the site_admin role to have the 'interface translation' permission. This also updates the content_author role to have the 'view all revisions' permission. Also, the 9032 hook was renamed to 9033 to reflect the next tag that it will run with.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-184](https://thinkoomph.jira.com/browse/rig-184), [RIG-181](https://thinkoomph.jira.com/browse/rig-181)