### PR TITLE
Fixed url value of search result teasers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-130: Fixed url value of search result teasers.
 
 ### Security
 

--- a/ecms_base/themes/custom/ecms/templates/views/views-view-fields--site-search.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/views/views-view-fields--site-search.html.twig
@@ -31,8 +31,8 @@
 #}
 
 {% set path = '#' %}
-{% if view.field.nid.original_value|length > 0 %}
-  {% set path = path('entity.node.canonical', {'node': view.field.nid.original_value}) %}
+{% if fields.nid.content %}
+  {% set path = path('entity.node.canonical', {'node': fields.nid.content|striptags|trim|number_format}) %}
 {% endif %}
 
 {% if fields %}


### PR DESCRIPTION
## Summary
This PR fixes the url value of search result teasers. Screenshot shows correct url at bottom:

![Screen Shot 2020-12-14 at 3 00 10 PM](https://user-images.githubusercontent.com/2349061/102129366-3a6b0d00-3e1d-11eb-80e7-815d31b2bb8f.png)

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | 