### PR TITLE
Resolve commas breaking search teaser paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-130: Fixed search url errors with NIDs of 4 digits.
 
 ### Security
 

--- a/ecms_base/themes/custom/ecms/templates/views/views-view-fields--site-search.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/views/views-view-fields--site-search.html.twig
@@ -32,7 +32,7 @@
 
 {% set path = '#' %}
 {% if fields.nid.content %}
-  {% set path = path('entity.node.canonical', {'node': fields.nid.content|striptags|trim|number_format}) %}
+  {% set path = path('entity.node.canonical', {'node': fields.nid.content|striptags|trim|number_format(0,'',''}) %}
 {% endif %}
 
 {% if fields %}


### PR DESCRIPTION
## Summary
This PR updates the number_format twig function to not include commas which was throwing an error with the path function.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Risk level | Low, Medium, High
| Relevant links | 