### PR TITLE
Refactor the ecms_api_publisher module to handle entity references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-176: Allowed the syndication to handle multiple referenced entities.
 
 ### Security
 

--- a/ecms_base/modules/custom/ecms_api_notification_publisher/src/NotificationPublisher.php
+++ b/ecms_base/modules/custom/ecms_api_notification_publisher/src/NotificationPublisher.php
@@ -78,7 +78,7 @@ class NotificationPublisher extends EcmsApiBase {
     }
 
     if (in_array(self::MODERATION_PUBLISHED, $moderatedState, TRUE)) {
-      $this->ecmsApiSyndicate->syndicateNode($node);
+      $this->ecmsApiSyndicate->syndicateEntity($node);
     }
   }
 

--- a/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiPublisher.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiPublisher.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\ecms_api_publisher;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountSwitcherInterface;
 use Drupal\Core\Url;
@@ -79,13 +80,13 @@ class EcmsApiPublisher extends EcmsApiBase {
    *
    * @param \Drupal\Core\Url $recipientUrl
    *   The URL of the API receiving the node.
-   * @param \Drupal\node\NodeInterface $node
+   * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The node to submit.
    *
    * @return bool
    *   True if successfully saved.
    */
-  public function syndicateNode(Url $recipientUrl, NodeInterface $node): bool {
+  public function syndicateEntity(Url $recipientUrl, EntityInterface $entity): bool {
 
     $clientId = $this->getClientId();
     $clientSecret = $this->getClientSecret();
@@ -110,7 +111,7 @@ class EcmsApiPublisher extends EcmsApiBase {
     $this->accountSwitcher->switchTo($publisherAccount);
 
     // Submit the entity to the API.
-    $result = $this->submitEntity($accessToken, $recipientUrl, $node);
+    $result = $this->submitEntity($accessToken, $recipientUrl, $entity);
 
     $this->accountSwitcher->switchBack();
 

--- a/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiPublisher.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiPublisher.php
@@ -12,7 +12,6 @@ use Drupal\Core\Url;
 use Drupal\ecms_api\EcmsApiBase;
 use Drupal\ecms_api\EcmsApiHelper;
 use Drupal\jsonapi_extras\EntityToJsonApi;
-use Drupal\node\NodeInterface;
 use Drupal\user\UserInterface;
 use GuzzleHttp\ClientInterface;
 

--- a/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSyndicate.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSyndicate.php
@@ -91,10 +91,10 @@ class EcmsApiSyndicate {
       $this->processEntity($entity, $site);
     }
 
-    // Notify the user that the node will be posted on the next cron run.
+    // Notify the user that the entity will be posted on the next cron run.
     $this->messenger->addMessage($this->t('Successfully queued the @type "%title" to get posted to @number sites on the next cron run.', [
       '@type' => $type,
-      '%title' => $entity->getTitle(),
+      '%title' => $entity->label(),
       '@number' => count($sites),
     ]));
 

--- a/ecms_base/modules/custom/ecms_api_publisher/src/Form/EcmsApiBatchSendUpdatesForm.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/Form/EcmsApiBatchSendUpdatesForm.php
@@ -150,7 +150,7 @@ class EcmsApiBatchSendUpdatesForm extends ConfirmFormBase {
     );
 
     // Post the entity.
-    $result = $ecmsApiPublisher->syndicateNode($url, $node);
+    $result = $ecmsApiPublisher->syndicateEntity($url, $node);
 
     // If an error occurs, re-queue the item.
     if (!$result) {

--- a/ecms_base/modules/custom/ecms_api_publisher/src/Plugin/QueueWorker/EcmsApiSyndicateQueueWorker.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/Plugin/QueueWorker/EcmsApiSyndicateQueueWorker.php
@@ -74,7 +74,7 @@ class EcmsApiSyndicateQueueWorker extends QueueWorkerBase implements ContainerFa
     $ecmsApiSiteEntity = $data['site_entity'];
     $apiUrl = $ecmsApiSiteEntity->getApiEndpoint()->getUrl();
 
-    /** @var \Drupal\node\NodeInterface $entity */
+    /** @var \Drupal\Core\Entity\EntityInterface $entity */
     $entity = $data['syndicated_content_entity'];
 
     $result = $this->ecmsApiPublisher->syndicateEntity($apiUrl, $entity);

--- a/ecms_base/modules/custom/ecms_api_publisher/src/Plugin/QueueWorker/EcmsApiSyndicateQueueWorker.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/Plugin/QueueWorker/EcmsApiSyndicateQueueWorker.php
@@ -67,17 +67,17 @@ class EcmsApiSyndicateQueueWorker extends QueueWorkerBase implements ContainerFa
    * @param mixed $data
    *   Data should be an array with the following keys:
    *   - site_entity: \Drupal\ecms_api_publisher\Entity\EcmsApiSiteInterface.
-   *   - syndicated_content_entity: \Drupal\node\NodeInterface.
+   *   - syndicated_content_entity: \Drupal\Core\Entity\EntityInterface.
    */
   public function processItem($data): void {
     /** @var \Drupal\ecms_api_publisher\Entity\EcmsApiSiteInterface $ecmsApiSiteEntity */
     $ecmsApiSiteEntity = $data['site_entity'];
     $apiUrl = $ecmsApiSiteEntity->getApiEndpoint()->getUrl();
 
-    /** @var \Drupal\node\NodeInterface $node */
-    $node = $data['syndicated_content_entity'];
+    /** @var \Drupal\node\NodeInterface $entity */
+    $entity = $data['syndicated_content_entity'];
 
-    $result = $this->ecmsApiPublisher->syndicateNode($apiUrl, $node);
+    $result = $this->ecmsApiPublisher->syndicateEntity($apiUrl, $entity);
 
     // If the submission was not successful, requeue the task.
     if (!$result) {

--- a/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/EcmsApiPublisherTest.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/EcmsApiPublisherTest.php
@@ -166,7 +166,7 @@ class EcmsApiPublisherTest extends UnitTestCase {
         ->willReturn($userAccountArray);
     }
 
-    $result = $this->ecmsApiPublisher->syndicateNode($url, $node);
+    $result = $this->ecmsApiPublisher->syndicateEntity($url, $node);
 
     $this->assertEquals($expected, $result);
   }

--- a/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/EcmsApiSyndicateTest.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/EcmsApiSyndicateTest.php
@@ -130,7 +130,7 @@ class EcmsApiSyndicateTest extends UnitTestCase {
       ->method('addWarning');
 
     $ecmsApiSyndicate = new EcmsApiSyndicate($this->entityTypeManager, $this->queueFactory, $this->messenger);
-    $ecmsApiSyndicate->syndicateNode($entity);
+    $ecmsApiSyndicate->syndicateEntity($entity);
   }
 
   /**
@@ -164,7 +164,7 @@ class EcmsApiSyndicateTest extends UnitTestCase {
       ->method('addWarning');
 
     $ecmsApiSyndicate = new EcmsApiSyndicate($this->entityTypeManager, $this->queueFactory, $this->messenger);
-    $ecmsApiSyndicate->syndicateNode($entity);
+    $ecmsApiSyndicate->syndicateEntity($entity);
 
   }
 

--- a/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/Form/EcmsApiBatchSendUpdateFormTest.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/Form/EcmsApiBatchSendUpdateFormTest.php
@@ -105,7 +105,7 @@ class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
 
     $this->ecmsApiPublisher = $this->getMockBuilder(EcmsApiPublisher::class)
       ->disableOriginalConstructor()
-      ->onlyMethods(['syndicateNode'])
+      ->onlyMethods(['syndicateEntity'])
       ->getMock();
 
     $this->mockGlobalTFunction = $mockGlobalTFunction->build();
@@ -446,7 +446,7 @@ class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
    * Test the postSyndicateContent method.
    *
    * @param bool $result
-   *   Mock the result of the EcmsApiPublisher::syndicateNode method.
+   *   Mock the result of the EcmsApiPublisher::syndicateEntity method.
    *
    * @dataProvider dataProviderForTestPostSyndicateContent
    */
@@ -493,7 +493,7 @@ class EcmsApiBatchSendUpdateFormTest extends UnitTestCase {
       ->method('getTitle');
 
     $this->ecmsApiPublisher->expects($this->once())
-      ->method('syndicateNode')
+      ->method('syndicateEntity')
       ->willReturn($result);
 
     $context = [];

--- a/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/Plugin/QueueWorker/EcmsApiSyndicateQueueWorkerTest.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/tests/src/Unit/Plugin/QueueWorker/EcmsApiSyndicateQueueWorkerTest.php
@@ -47,7 +47,7 @@ class EcmsApiSyndicateQueueWorkerTest extends UnitTestCase {
     parent::setUp();
 
     $this->ecmsApiPublisher = $this->getMockBuilder(EcmsApiPublisher::class)
-      ->onlyMethods(['syndicateNode'])
+      ->onlyMethods(['syndicateEntity'])
       ->disableOriginalConstructor()
       ->getMock();
 
@@ -83,7 +83,7 @@ class EcmsApiSyndicateQueueWorkerTest extends UnitTestCase {
       ->willReturn($linkItem);
 
     $this->ecmsApiPublisher->expects($this->once())
-      ->method('syndicateNode')
+      ->method('syndicateEntity')
       ->with($url, $node)
       ->willReturn($expected);
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,8 @@
         <env name="DTT_BASE_URL" value="http://appserver/"/>
         <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
         <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
+        <const name="XDEBUG_CC_DEAD_CODE" value="2" />
+        <const name="XDEBUG_CC_UNUSED" value="1" />
     </php>
     <testsuites>
         <testsuite name="unit">


### PR DESCRIPTION
## Summary
This refactors the ecms_api_publisher to handle multiple entity references which will allow any content type to be be syndicated to other sites regardless of the entity references currently for the content type.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | n/a
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Mediua
| Relevant links | [RIG-176](https://thinkoomph.jira.com/browse/rig-176)