### PR TITLE
Added the missing cache context for publications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-198: Removed base field override config from ecms_promotions (metatag and menu_link).
 
 ### Fixed
+- RIG-200: Fixed the cache contexts for the publication listing paragraph.
 
 ### Security
 

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -340,6 +340,9 @@ function ecms_preprocess_node__publication(array &$variables): void {
 function ecms_preprocess_paragraph__publication_list(array &$variables): void {
   $paragraph = $variables['paragraph'];
 
+  // Set the cache contexts to the audience_restriction query parameter.
+  $variables['#cache']['contexts'][] = 'url.query_args:audience_restriction';
+
   // Get ?audience_restriction value.
   $audience_url_restriction = \Drupal::request()->get('audience_restriction');
 


### PR DESCRIPTION
## Summary
The cache contexts for the publication paragraph list wasn't set, causing the audience query parameter to get cached improperly, rendering it ineffective.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-200](https://thinkoomph.jira.com/browse/rig-200)