### PR TITLE
Lock PHP version for CI workflows

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          php-version: '7.3'
 
       - name: Run the develop CI script.
         run: ./scripts/ci-develop.sh
@@ -93,6 +95,7 @@ jobs:
         with:
           name: drupal-build.tar.gz
           path: /var/www/
+          php-version: '7.3'
 
       - name: Expand the build artifact.
         run: tar -xzf /var/www/drupal-build.tar.gz -C /var/www

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -157,9 +157,9 @@ jobs:
 #        working-directory: ${{ env.DRUPAL_DIRECTORY }}
 #        run: sudo -u www-data -E ../vendor/bin/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml --testsuite=functional
 
-      - name: Run functional tests with fastest.
-        working-directory: ${{ env.ECMS_PROFILE_DIRECTORY }}
-        run: find . -type f -iname "*Test.php" | grep "Functional" | sudo -u www-data -E /var/www/vendor/liuggio/fastest/fastest "/var/www/vendor/phpunit/phpunit/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml {};"
+#      - name: Run functional tests with fastest.
+#        working-directory: ${{ env.ECMS_PROFILE_DIRECTORY }}
+#        run: find . -type f -iname "*Test.php" | grep "Functional" | sudo -u www-data -E /var/www/vendor/liuggio/fastest/fastest "/var/www/vendor/phpunit/phpunit/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml {};"
 
 #      - name: Run existing site tests.
 #        working-directory: ${{ env.ECMS_PROFILE_DIRECTORY }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -17,8 +17,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
         with:
           php-version: '7.3'
+
+      - name: Check PHP Version
+        run: php -v
 
       - name: Run the develop CI script.
         run: ./scripts/ci-develop.sh
@@ -90,12 +96,19 @@ jobs:
       ECMS_PROFILE_DIRECTORY: /var/www/html/profiles/contrib/ecms_profile
       ENCRYPTION_PRIVATE_KEY: ''
     steps:
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.3'
+
+      - name: Check PHP Version
+        run: php -v
+
       - name: Retrieve the build artifact.
         uses: actions/download-artifact@v2
         with:
           name: drupal-build.tar.gz
           path: /var/www/
-          php-version: '7.3'
 
       - name: Expand the build artifact.
         run: tar -xzf /var/www/drupal-build.tar.gz -C /var/www

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -157,9 +157,9 @@ jobs:
 #        working-directory: ${{ env.DRUPAL_DIRECTORY }}
 #        run: sudo -u www-data -E ../vendor/bin/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml --testsuite=functional
 
-#      - name: Run functional tests with fastest.
-#        working-directory: ${{ env.ECMS_PROFILE_DIRECTORY }}
-#        run: find . -type f -iname "*Test.php" | grep "Functional" | sudo -u www-data -E /var/www/vendor/liuggio/fastest/fastest "/var/www/vendor/phpunit/phpunit/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml {};"
+      - name: Run functional tests with fastest.
+        working-directory: ${{ env.ECMS_PROFILE_DIRECTORY }}
+        run: find . -type f -iname "*Test.php" | grep "Functional" | sudo -u www-data -E /var/www/vendor/liuggio/fastest/fastest "/var/www/vendor/phpunit/phpunit/phpunit --configuration=${{ env.ECMS_PROFILE_DIRECTORY }}/phpunit-ci.xml {};"
 
 #      - name: Run existing site tests.
 #        working-directory: ${{ env.ECMS_PROFILE_DIRECTORY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIG-177: Added the publisher module for publication nodes to go from hub to syndicated sites.
+- RIG-6: Added shivammathur/setup-php PHP setup action to develop workflow to lock php at 7.3.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
-- RIG-177: Added the publisher module for publication nodes to go from hub to syndicated sites.
 - RIG-6: Added shivammathur/setup-php PHP setup action to develop workflow to lock php at 7.3.
 
 ### Changed


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
<!-- Include a summary of your changes that expands upon the title. -->
Adds a github action and associated config that supports PHP setup for the CI workflow. Locks PHP at 7.3 to mimic the target environments.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://github.com/shivammathur/setup-php
https://stackoverflow.com/questions/57965588/how-to-test-with-different-versions-of-php-in-a-github-action