### PR TITLE
Add logic to use node's langcode for displaying notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
+- RIG-130: Changed notifications block to use node langcode rather than the current users.
 
 ### Deprecated
 

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -598,3 +598,19 @@ function ecms_base_update_9034(array &$sandbox): void {
   }
 
 }
+
+/**
+ * Updates to run for the 0.3.9 tag.
+ */
+function ecms_base_update_9039(array &$sandbox): void {
+  // Config updates.
+  $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
+
+  /** @var \Drupal\Core\Config\FileStorage $theme_source */
+  $theme_source = new FileStorage($path . "/themes/custom/ecms/config/optional/");
+
+  /** @var \Drupal\Core\Config\StorageInterface $active_storage */
+  $active_storage = \Drupal::service('config.storage');
+
+  $active_storage->write('block.block.sitenotifications', $theme_source->read('block.block.sitenotifications'));
+}

--- a/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SiteNotificationsBlock.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SiteNotificationsBlock.php
@@ -18,6 +18,9 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
  * @Block(
  *   id = "ecms_site_notifications",
  *   admin_label = @Translation("Site Notifications"),
+ *   context_definitions = {
+ *     "node" = @ContextDefinition("entity:node", label = @Translation("Node"))
+ *   }
  * )
  */
 class SiteNotificationsBlock extends BlockBase implements ContainerFactoryPluginInterface {
@@ -93,8 +96,16 @@ class SiteNotificationsBlock extends BlockBase implements ContainerFactoryPlugin
     // Load multiple nodes.
     $nodes = $node_storage->loadMultiple($nids);
 
-    // Get language code.
-    $language = $this->languageManager->getCurrentLanguage()->getId();
+    // Get language code from the current node.
+    $active_node = $this->getContextValue('node');
+
+    if ($active_node) {
+      $language = $active_node->get('langcode')->value;
+    }
+    else {
+      // Get site active language.
+      $language = $this->languageManager->getCurrentLanguage()->getId();
+    }
 
     // Return a list of rendered teaser nodes.
     $builder = $this->entityTypeManager->getViewBuilder('node');

--- a/ecms_base/themes/custom/ecms/config/optional/block.block.sitenotifications.yml
+++ b/ecms_base/themes/custom/ecms/config/optional/block.block.sitenotifications.yml
@@ -16,4 +16,6 @@ settings:
   label: 'Site Notifications'
   provider: ecms_blocks
   label_display: '0'
+  context_mapping:
+    node: '@node.node_route_context:node'
 visibility: {  }

--- a/ecms_base/themes/custom/ecms/templates/blocks/block--sitenotifications.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/blocks/block--sitenotifications.html.twig
@@ -32,6 +32,8 @@
  */
 #}
 
+{% set cachebust = content|render %}
+
 {% include '@organisms/notfications-block/notifications-block.twig' with {
   content: content
 } %}


### PR DESCRIPTION
## Summary
This PR adds logic to use the current node's langcode for displaying notifications

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | JIRA issue, bug reports, security alerts, etc.