### PR TITLE
Added an h3 to the title search and a default value for the title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-192: Fixed some missing title errors during migration.
 
 ### Security
 

--- a/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page.yml
+++ b/ecms_base/modules/custom/ecms_migration/config/install/migrate_plus.migration.ecms_basic_page.yml
@@ -41,7 +41,7 @@ source:
   migration_tools:
     - source: url
       source_type: url
-      source_operation:
+      source_operations:
         - operation: modifier
           modifier: basicCleanup
       fields:
@@ -61,6 +61,12 @@ source:
               method: 'pluckSelector'
               arguments:
                 - h2
+            # Find the first h3 and use that as the page title
+            # if the h2 is empty.
+            - job: 'addSearch'
+              method: 'pluckSelector'
+              arguments:
+                - h3
         # Get the body content.
         css_selector_1:
           obtainer: ObtainBody
@@ -104,7 +110,10 @@ source:
 
 process:
   id: url
-  title: title
+  title:
+    plugin: default_value
+    source: title
+    default_value: "MISSING TITLE"
   status: status
   'field_basic_page_body/value':
     plugin: concat


### PR DESCRIPTION
## Summary
The eohhs migration was showing some missing title SQL errors during import. This adds an h3 search and a default value to the migration which will fix those.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-192](https://thinkoomph.jira.com/browse/rig-192)