### PR TITLE
Allow the 'Card' paragraph to be translatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Fixed
 - RIG-192: Fixed some missing title errors during migration.
-- RIG-207: Fixed the cardcomponent translation settings.
+- RIG-207: Fixed the card component translation settings.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Fixed
 - RIG-192: Fixed some missing title errors during migration.
+- RIG-207: Fixed the cardcomponent translation settings.
 
 ### Security
 

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.card.created.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.base_field_override.paragraph.card.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.card
+id: paragraph.card.created
+field_name: created
+entity_type: paragraph
+bundle: card
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.card.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.card.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.card
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: paragraph.card
+target_entity_type_id: paragraph
+target_bundle: card
+default_langcode: site_default
+language_alterable: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.card.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.paragraph.card.yml
@@ -9,7 +9,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.card
 target_entity_type_id: paragraph
 target_bundle: card


### PR DESCRIPTION
## Summary
The 'Card' paragraph component was not translatable, causing the media items to not show the translated versions.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIG-207](https://thinkoomph.jira.com/browse/rig-207)