### PR TITLE
Upgrade the CI to allow for Drupal 9.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -132,7 +132,7 @@
     "drupal/auto_entitylabel": "^3.0@beta",
     "drupal/components": "^2.0",
     "drupal/content_moderation_notifications": "^3.2",
-    "drupal/core-recommended": "^9.0",
+    "drupal/core-recommended": "^9.1",
     "drupal/easy_breadcrumb": "^1.13",
     "drupal/extlink": "^1.5",
     "drupal/features": "^3.11",

--- a/scripts/ci-develop.sh
+++ b/scripts/ci-develop.sh
@@ -18,7 +18,7 @@ COMPOSER_BIN_DIR="$(composer config bin-dir)"
 DOCROOT="web"
 
 
-echo ${GITHUB_REF}
+#echo ${GITHUB_REF##*/}
 
 # Move up a directory.
 cd ..
@@ -67,7 +67,7 @@ else
 fi
 
 $COMPOSER config extra.enable-patching true
-$COMPOSER require "${REPOSITORY_NAME}:*" --no-progress
+$COMPOSER require "${REPOSITORY_NAME}:dev-RIG-164/drupal-9.1-upgrade" --no-progress
 
 # Require pattern lab master branch from Github.
 $COMPOSER config repositories.${PATTERN_LAB_DIRECTORY} '{"type": "git", "url": "https://github.com/State-of-Rhode-Island-eCMS/ecms_patternlab.git"}'

--- a/scripts/ci-develop.sh
+++ b/scripts/ci-develop.sh
@@ -29,6 +29,9 @@ composer create-project drupal/recommended-project:^9.1 $APP_NAME --no-install -
 # Move into the directory.
 cd $APP_NAME;
 
+# Change the minimum stability flag.
+$COMPOSER config minimum-stability "dev"
+
 $COMPOSER require "zaporylie/composer-drupal-optimizations:^1.1.2" --no-update
 
 # Add the development requirements for testing.
@@ -67,7 +70,7 @@ else
 fi
 
 $COMPOSER config extra.enable-patching true
-$COMPOSER require "${REPOSITORY_NAME}:dev-RIG-164/drupal-9.1-upgrade" --no-progress
+$COMPOSER require "${REPOSITORY_NAME}:*" --no-progress
 
 # Require pattern lab master branch from Github.
 $COMPOSER config repositories.${PATTERN_LAB_DIRECTORY} '{"type": "git", "url": "https://github.com/State-of-Rhode-Island-eCMS/ecms_patternlab.git"}'

--- a/scripts/ci-develop.sh
+++ b/scripts/ci-develop.sh
@@ -18,6 +18,8 @@ COMPOSER_BIN_DIR="$(composer config bin-dir)"
 DOCROOT="web"
 
 
+echo ${GITHUB_REF##*/}
+
 # Move up a directory.
 cd ..
 

--- a/scripts/ci-develop.sh
+++ b/scripts/ci-develop.sh
@@ -18,7 +18,7 @@ COMPOSER_BIN_DIR="$(composer config bin-dir)"
 DOCROOT="web"
 
 
-echo ${GITHUB_REF##*/}
+echo ${GITHUB_REF}
 
 # Move up a directory.
 cd ..

--- a/scripts/ci-develop.sh
+++ b/scripts/ci-develop.sh
@@ -22,7 +22,7 @@ DOCROOT="web"
 cd ..
 
 # Create a new Drupal project.
-composer create-project drupal/recommended-project:9.0.9 $APP_NAME --no-install --no-interaction
+composer create-project drupal/recommended-project:^9.1 $APP_NAME --no-install --no-interaction
 
 # Move into the directory.
 cd $APP_NAME;

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -114,11 +114,11 @@ echo " Initialize lando for local usage "
 echo "----------------------------------"
 cd ${DEST_DIR}
 
-echo "Lock Drupal core to 9.0 branch."
-$COMPOSER require "drupal/core-composer-scaffold:~9.0.9" --no-update
-$COMPOSER require "drupal/core-project-message:~9.0.9" --no-update
-$COMPOSER require "drupal/core-recommended:~9.0.9" --no-update
-$COMPOSER require "drupal/core-vendor-hardening:~9.0.9" --no-update
+#echo "Lock Drupal core to 9.0 branch."
+#$COMPOSER require "drupal/core-composer-scaffold:~9.0.9" --no-update
+#$COMPOSER require "drupal/core-project-message:~9.0.9" --no-update
+#$COMPOSER require "drupal/core-recommended:~9.0.9" --no-update
+#$COMPOSER require "drupal/core-vendor-hardening:~9.0.9" --no-update
 
 
 echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} $LANDO init --name $APP_NAME --recipe drupal9 --webroot $DOCROOT --source cwd\n\n"


### PR DESCRIPTION
## Summary
This is the initial fix for upgrading the CI process to allow Drupal 9.1.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes/
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | no
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | no
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | no
| Risk level | Low, Medium, High
| Relevant links | [RIG-164](https://thinkoomph.jira.com/browse/rig-164)