### PR TITLE
Add media file link behavior field and fix media library display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - RIG-130: Added gallery and gallery item paragraph bundles.
 - RIG-130: Added tiny-slider library.
+- RIG-125: Added link behavior field to media files.
 
 ### Changed
 
@@ -22,6 +23,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 - RIG-192: Fixed some missing title errors during migration.
 - RIG-207: Fixed the card component translation settings.
+- RIG-125: Fixed file display in media library.
 
 ### Security
 

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.default.yml
@@ -3,11 +3,13 @@ status: true
 dependencies:
   config:
     - field.field.media.file.field_file
+    - field.field.media.file.field_file_link_behavior
     - field.field.media.file.field_file_size
     - field.field.media.file.field_file_type
     - media.type.file
   module:
     - file
+    - path
 id: media.file.default
 targetEntityType: media
 bundle: file
@@ -20,15 +22,21 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_file:
-    weight: 5
+    weight: 7
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
     type: file_generic
     region: content
+  field_file_link_behavior:
+    weight: 26
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   langcode:
     type: language_select
-    weight: 1
+    weight: 2
     region: content
     settings:
       include_locked: true
@@ -41,17 +49,18 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  path:
+    type: path
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 4
+    weight: 5
     region: content
-    third_party_settings: {  }
-  translation:
-    weight: 6
-    region: content
-    settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
@@ -66,4 +75,3 @@ content:
 hidden:
   field_file_size: true
   field_file_type: true
-  path: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.media_library.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.media_library.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - core.entity_form_mode.media.media_library
     - field.field.media.file.field_file
+    - field.field.media.file.field_file_link_behavior
     - field.field.media.file.field_file_size
     - field.field.media.file.field_file_type
     - media.type.file
@@ -27,14 +28,10 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  translation:
-    weight: 10
-    settings: {  }
-    third_party_settings: {  }
-    region: content
 hidden:
   created: true
   field_file: true
+  field_file_link_behavior: true
   field_file_size: true
   field_file_type: true
   path: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.file.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.file.default.yml
@@ -3,14 +3,24 @@ status: true
 dependencies:
   config:
     - field.field.media.file.field_file
+    - field.field.media.file.field_file_link_behavior
     - field.field.media.file.field_file_size
     - field.field.media.file.field_file_type
     - media.type.file
+  module:
+    - options
 id: media.file.default
 targetEntityType: media
 bundle: file
 mode: default
 content:
+  field_file_link_behavior:
+    weight: 1
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
   name:
     type: string
     weight: 0
@@ -25,5 +35,6 @@ hidden:
   field_file_size: true
   field_file_type: true
   langcode: true
+  search_api_excerpt: true
   thumbnail: true
   uid: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.file.media_library.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.file.media_library.yml
@@ -4,9 +4,13 @@ dependencies:
   config:
     - core.entity_view_mode.media.media_library
     - field.field.media.file.field_file
+    - field.field.media.file.field_file_link_behavior
     - field.field.media.file.field_file_size
     - field.field.media.file.field_file_type
+    - image.style.media_library
     - media.type.file
+  module:
+    - svg_image
 id: media.file.media_library
 targetEntityType: media
 bundle: file
@@ -20,11 +24,25 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
+  thumbnail:
+    type: image
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      image_style: media_library
+      image_link: ''
+      svg_render_as_image: true
+      svg_attributes:
+        width: null
+        height: null
+    third_party_settings: {  }
 hidden:
   created: true
   field_file: true
+  field_file_link_behavior: true
   field_file_size: true
   field_file_type: true
   langcode: true
-  thumbnail: true
+  search_api_excerpt: true
   uid: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.file.field_file_link_behavior.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.file.field_file_link_behavior.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_file_link_behavior
+    - media.type.file
+  module:
+    - options
+id: media.file.field_file_link_behavior
+field_name: field_file_link_behavior
+entity_type: media
+bundle: file
+label: 'Link behavior'
+description: 'Select the link behavior for this file.'
+required: true
+translatable: false
+default_value:
+  -
+    value: new_tab
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.storage.media.field_file_link_behavior.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.storage.media.field_file_link_behavior.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - options
+id: media.field_file_link_behavior
+field_name: field_file_link_behavior
+entity_type: media
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: new_tab
+      label: 'Open in new tab'
+    -
+      value: download
+      label: 'Download file'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -119,6 +119,9 @@ function ecms_preprocess_media__file(array &$variables): void {
   // Grab file title.
   $variables['file_title'] = $media->get('field_file')->entity->getFilename();
 
+  // Grab link behavior.
+  $variables['link_behavior'] = $media->get('field_file_link_behavior')->value;
+
   // Determine file type.
   $file_type = pathinfo($variables['file_title'], PATHINFO_EXTENSION);
 

--- a/ecms_base/themes/custom/ecms/templates/content/media--file.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/content/media--file.html.twig
@@ -25,6 +25,7 @@
     file_type_icon: file_type_icon,
     file_type_readable: file_type_readable,
     file_url: file_url,
-    file_size: file_size
+    file_size: file_size,
+    link_behavior: link_behavior
   }
 %}


### PR DESCRIPTION
## Summary
This PR adds a field to file entities that allows content editors to select the link behavior. Either "Download file" or "Open in new tab".

It also resolves an issue that files were not displaying correctly in the media library.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIG-125