### PR TITLE
Fix "Call to a member function getEntityTypeId() on null (Layout Builder)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-217: Added patch to fix "Call to a member function getEntityTypeId() on null (Layout Builder)";
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
-- RIG-217: Added patch to fix "Call to a member function getEntityTypeId() on null (Layout Builder)";
+- RIG-217: Added patch to fix "Call to a member function getEntityTypeId() on null (Layout Builder)".
 
 ### Security
 

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
         "1832818 - Allow a queue item to be postponed": "https://www.drupal.org/files/issues/2020-03-24/1832818.80-requeue.patch",
         "2259567 - Unnecessary restrictions on logo format: Can't upload replacement SVG logo": "https://www.drupal.org/files/issues/2019-06-24/2259567-113_0.patch",
         "3020876 - Contextual links of reusable content blocks are not displayed when rendering entities built via Layout Builder": "https://www.drupal.org/files/issues/2020-09-25/contextual_links_with_LB-3020876-38.patch",
-        "3049332 - PHP message: Error: Call to a member function getEntityTypeId() on null (Layout Builder)": "https://www.drupal.org/files/issues/2020-08-05/3049332-inline-35.patch"
+        "3049332 - PHP message: Error: Call to a member function getEntityTypeId() on null (Layout Builder)": "https://www.drupal.org/files/issues/2020-08-05/3049332-inline-35.patch",
+        "2827921 - Exception thrown by responsive srcset images when the image is not yet in the file system (such as with Stage File Proxy)": "https://www.drupal.org/files/issues/2827921-remove-missing-responsive-image-width-exception.patch"
       },
       "drupal/openid_connect_windows_aad": {
         "3169996 - Incorrect configuration schema file": "https://www.drupal.org/files/issues/2020-09-09/openid_connect_windows_aad-schema-update-3169996-3.patch"

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,8 @@
         "3083051 - Remove tabledrag.js replacement when core issues are resolved": "https://www.drupal.org/files/issues/2020-10-02/3083051-21.patch",
         "1832818 - Allow a queue item to be postponed": "https://www.drupal.org/files/issues/2020-03-24/1832818.80-requeue.patch",
         "2259567 - Unnecessary restrictions on logo format: Can't upload replacement SVG logo": "https://www.drupal.org/files/issues/2019-06-24/2259567-113_0.patch",
-        "3020876 - Contextual links of reusable content blocks are not displayed when rendering entities built via Layout Builder": "https://www.drupal.org/files/issues/2020-09-25/contextual_links_with_LB-3020876-38.patch"
+        "3020876 - Contextual links of reusable content blocks are not displayed when rendering entities built via Layout Builder": "https://www.drupal.org/files/issues/2020-09-25/contextual_links_with_LB-3020876-38.patch",
+        "3049332 - PHP message: Error: Call to a member function getEntityTypeId() on null (Layout Builder)": "https://www.drupal.org/files/issues/2020-08-05/3049332-inline-35.patch"
       },
       "drupal/openid_connect_windows_aad": {
         "3169996 - Incorrect configuration schema file": "https://www.drupal.org/files/issues/2020-09-09/openid_connect_windows_aad-schema-update-3169996-3.patch"

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -447,7 +447,7 @@ function ecms_preprocess_block(array &$variables): void {
   // Block labels are not translated properly.
   // @see: https://www.drupal.org/project/drupal/issues/2810457#comment-12625567
   if ($variables['elements']['#base_plugin_id'] === 'inline_block' || $variables['elements']['#base_plugin_id'] === 'block_content') {
-    if (!empty($variables['label'])) {
+    if (!empty($variables['label']) && !empty($variables['content']['#block_content'])) {
       // Use the correct language for the block label.
       $variables['label'] = $variables['content']['#block_content']->label();
     }


### PR DESCRIPTION
## Summary
This PR adds a patch to fix "Call to a member function getEntityTypeId() on null (Layout Builder)". It also updated the preprocess_block to check if block content exists before accessing the label

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | yes/no
| Risk level | Low, Medium, High
| Relevant links | https://thinkoomph.jira.com/browse/RIG-217