### PR TITLE
Add row loop variable to both instances of article listing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ## [0.4.4] - 2021-01-19
 ### Fixed
 - RIG-220: Missing translation error in template files.
-- RIG-420: Fixed article listing to work with views-view and views-unformatted.
+- RIG-242: Fixed article listing to work with views-view and views-unformatted.
 
 ## [0.4.3] - 2021-01-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ## [0.4.4] - 2021-01-19
 ### Fixed
 - RIG-220: Missing translation error in template files.
+- RIG-420: Fixed article listing to work with views-view and views-unformatted.
 
 ## [0.4.3] - 2021-01-15
 ### Added

--- a/ecms_base/themes/custom/ecms/templates/views/views-view--press-releases--page_1.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/views/views-view--press-releases--page_1.html.twig
@@ -45,6 +45,7 @@
     {% include '@organisms/articles-list/articles-list.twig' with {
       title: title,
       rows: rows,
+      rows_loop: FALSE,
       exposed: exposed,
       pager: pager,
       more: more,
@@ -52,6 +53,6 @@
     } %}
 
   {% elseif empty %}
-      {{ empty }}
+    {{ empty }}
   {% endif %}
 

--- a/ecms_base/themes/custom/ecms/templates/views/views-view-unformatted--site-search.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/views/views-view-unformatted--site-search.html.twig
@@ -50,6 +50,7 @@
     {% include '@organisms/articles-list/articles-list.twig' with {
       title: title,
       rows: rows,
+      rows_loop: TRUE
     } %}
 
   {% elseif empty %}


### PR DESCRIPTION
## Summary
This PR fixes an issue where press release view was blank after resolving the search view throwing warnings re: row content.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIG-242