### PR TITLE
Notification weighting and expiration functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ## [Unreleased]
 ### Added
 - RIG-239: Added logo only theme setting.
+- RIG-229: Added weight field to notifications.
+- RIG-244: Added hook_cron to unpublish expired notifications.
 
 ### Changed
 

--- a/ecms_base/config/install/editor.editor.minimal.yml
+++ b/ecms_base/config/install/editor.editor.minimal.yml
@@ -1,0 +1,44 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.minimal
+  module:
+    - ckeditor
+format: minimal
+editor: ckeditor
+settings:
+  toolbar:
+    rows:
+      -
+        -
+          name: Formatting
+          items:
+            - Bold
+            - Italic
+        -
+          name: Links
+          items:
+            - DrupalLink
+            - DrupalUnlink
+        -
+          name: Lists
+          items:
+            - BulletedList
+        -
+          name: Tools
+          items:
+            - Source
+  plugins:
+    stylescombo:
+      styles: ''
+    language:
+      language_list: un
+image_upload:
+  status: false
+  scheme: public
+  directory: inline-images
+  max_size: ''
+  max_dimensions:
+    width: null
+    height: null

--- a/ecms_base/config/install/user.role.authenticated.yml
+++ b/ecms_base/config/install/user.role.authenticated.yml
@@ -16,6 +16,7 @@ permissions:
   - 'create media'
   - 'use moderation dashboard'
   - 'use text format basic_html'
+  - 'use text format minimal'
   - 'view disabled languages'
   - 'view media'
   - 'view own unpublished media'

--- a/ecms_base/features/custom/ecms_notification/config/install/core.entity_form_display.node.notification.default.yml
+++ b/ecms_base/features/custom/ecms_notification/config/install/core.entity_form_display.node.notification.default.yml
@@ -5,6 +5,7 @@ dependencies:
     - field.field.node.notification.field_notification_expire_date
     - field.field.node.notification.field_notification_global
     - field.field.node.notification.field_notification_text
+    - field.field.node.notification.field_notification_weight
     - node.type.notification
     - workflows.workflow.editorial
   module:
@@ -43,6 +44,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
+    region: content
+  field_notification_weight:
+    weight: 125
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
     region: content
   langcode:
     type: language_select

--- a/ecms_base/features/custom/ecms_notification/config/install/core.entity_view_display.node.notification.default.yml
+++ b/ecms_base/features/custom/ecms_notification/config/install/core.entity_view_display.node.notification.default.yml
@@ -5,9 +5,11 @@ dependencies:
     - field.field.node.notification.field_notification_expire_date
     - field.field.node.notification.field_notification_global
     - field.field.node.notification.field_notification_text
+    - field.field.node.notification.field_notification_weight
     - node.type.notification
   module:
     - datetime
+    - options
     - text
     - user
 id: node.notification.default
@@ -45,6 +47,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: text_default
+    region: content
+  field_notification_weight:
+    weight: 3
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
     region: content
 hidden:
   langcode: true

--- a/ecms_base/features/custom/ecms_notification/config/install/core.entity_view_display.node.notification.teaser.yml
+++ b/ecms_base/features/custom/ecms_notification/config/install/core.entity_view_display.node.notification.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.notification.field_notification_expire_date
     - field.field.node.notification.field_notification_global
     - field.field.node.notification.field_notification_text
+    - field.field.node.notification.field_notification_weight
     - node.type.notification
   module:
     - text
@@ -26,6 +27,7 @@ hidden:
   content_moderation_control: true
   field_notification_expire_date: true
   field_notification_global: true
+  field_notification_weight: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/ecms_base/features/custom/ecms_notification/config/install/field.field.node.notification.field_notification_weight.yml
+++ b/ecms_base/features/custom/ecms_notification/config/install/field.field.node.notification.field_notification_weight.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_notification_weight
+    - node.type.notification
+  module:
+    - options
+id: node.notification.field_notification_weight
+field_name: field_notification_weight
+entity_type: node
+bundle: notification
+label: Weight
+description: 'Add a sorting weight to the notification. 9 being the highest priority and appearing first in the list. -9 being the lowest priority and appearing last.'
+required: true
+translatable: false
+default_value:
+  -
+    value: '0'
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/ecms_base/features/custom/ecms_notification/config/install/field.storage.node.field_notification_weight.yml
+++ b/ecms_base/features/custom/ecms_notification/config/install/field.storage.node.field_notification_weight.yml
@@ -1,0 +1,77 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_notification_weight
+field_name: field_notification_weight
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: '9'
+      label: '9'
+    -
+      value: '8'
+      label: '8'
+    -
+      value: '7'
+      label: '7'
+    -
+      value: '6'
+      label: '6'
+    -
+      value: '5'
+      label: '5'
+    -
+      value: '4'
+      label: '4'
+    -
+      value: '3'
+      label: '3'
+    -
+      value: '2'
+      label: '2'
+    -
+      value: '1'
+      label: '1'
+    -
+      value: '0'
+      label: '0'
+    -
+      value: '-1'
+      label: '-1'
+    -
+      value: '-2'
+      label: '-2'
+    -
+      value: '-3'
+      label: '-3'
+    -
+      value: '-4'
+      label: '-4'
+    -
+      value: '-5'
+      label: '-5'
+    -
+      value: '-6'
+      label: '-6'
+    -
+      value: '-7'
+      label: '-7'
+    -
+      value: '-8'
+      label: '-8'
+    -
+      value: '-9'
+      label: '-9'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_notification/ecms_notification.module
+++ b/ecms_base/features/custom/ecms_notification/ecms_notification.module
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @file
+ * Additional notification functionality for the site.
+ */
+
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+
+/**
+ * Implements hook_cron().
+ *
+ * Unplublishes any notification that has an expire date in the past.
+ */
+function ecms_notification_cron() {
+
+  // Query all notifications that have expired.
+  $now = new DrupalDateTime('now');
+  $now->setTimezone(new \DateTimeZone(DateTimeItemInterface::STORAGE_TIMEZONE));
+
+  $query = \Drupal::entityQuery("node");
+  $query->condition('type', 'notification')
+    ->condition('status',  1)
+    ->condition('field_notification_expire_date', $now->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT), '<');
+
+  $nids = $query->execute();
+
+  // Guard against no nodes.
+  if (empty($nids)) {
+    return [];
+  }
+
+  // Load multiple nodes.
+  $node_storage = \Drupal::entityTypeManager()->getStorage("node");
+  $nodes = $node_storage->loadMultiple($nids);
+
+  \Drupal::logger('ecms_notification')->notice('Unpublished notification node(s): %nids.',
+  array(
+    '%nids' => implode(", ", array_keys($nids)),
+  ));
+
+  // Unpublish nodes.
+  foreach($nodes as $node) {
+    $node->setUnpublished();
+    $node->save();
+  }
+}

--- a/ecms_base/features/custom/ecms_notification/ecms_notification.module
+++ b/ecms_base/features/custom/ecms_notification/ecms_notification.module
@@ -5,6 +5,8 @@
  * Additional notification functionality for the site.
  */
 
+declare(strict_types = 1);
+
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 
@@ -13,7 +15,7 @@ use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
  *
  * Unplublishes any notification that has an expire date in the past.
  */
-function ecms_notification_cron() {
+function ecms_notification_cron(): void {
 
   // Query all notifications that have expired.
   $now = new DrupalDateTime('now');
@@ -28,7 +30,7 @@ function ecms_notification_cron() {
 
   // Guard against no nodes.
   if (empty($nids)) {
-    return [];
+    return;
   }
 
   // Load multiple nodes.
@@ -37,7 +39,7 @@ function ecms_notification_cron() {
 
   \Drupal::logger('ecms_notification')->notice('Unpublished notification node(s): %nids.',
   [
-    '%nids' => implode(", ", array_keys($nids))
+    '%nids' => implode(", ", array_keys($nids)),
   ]);
 
   // Unpublish nodes.

--- a/ecms_base/features/custom/ecms_notification/ecms_notification.module
+++ b/ecms_base/features/custom/ecms_notification/ecms_notification.module
@@ -21,7 +21,7 @@ function ecms_notification_cron() {
 
   $query = \Drupal::entityQuery("node");
   $query->condition('type', 'notification')
-    ->condition('status',  1)
+    ->condition('status', 1)
     ->condition('field_notification_expire_date', $now->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT), '<');
 
   $nids = $query->execute();
@@ -36,12 +36,12 @@ function ecms_notification_cron() {
   $nodes = $node_storage->loadMultiple($nids);
 
   \Drupal::logger('ecms_notification')->notice('Unpublished notification node(s): %nids.',
-  array(
-    '%nids' => implode(", ", array_keys($nids)),
-  ));
+  [
+    '%nids' => implode(", ", array_keys($nids))
+  ]);
 
   // Unpublish nodes.
-  foreach($nodes as $node) {
+  foreach ($nodes as $node) {
     $node->setUnpublished();
     $node->save();
   }

--- a/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SiteNotificationsBlock.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SiteNotificationsBlock.php
@@ -91,8 +91,9 @@ class SiteNotificationsBlock extends BlockBase implements ContainerFactoryPlugin
     $query = $node_storage->getQuery();
     $query->condition('type', 'notification')
       ->condition('status', 1)
-      ->sort('field_notification_global', "DESC");
       ->condition('field_notification_expire_date', $now->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT), '>')
+      ->sort('field_notification_global', "DESC")
+      ->sort('field_notification_weight', "DESC");
 
     $nids = $query->execute();
 

--- a/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SiteNotificationsBlock.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SiteNotificationsBlock.php
@@ -11,6 +11,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 use Drupal\Core\Cache\Cache;
 
 /**
@@ -81,11 +83,16 @@ class SiteNotificationsBlock extends BlockBase implements ContainerFactoryPlugin
 
     $node_storage = $this->entityTypeManager->getStorage('node');
 
+    // Get the current date object.
+    $now = new DrupalDateTime('now');
+    $now->setTimezone(new \DateTimeZone(DateTimeItemInterface::STORAGE_TIMEZONE));
+
     // Query all notifications.
     $query = $node_storage->getQuery();
     $query->condition('type', 'notification')
       ->condition('status', 1)
       ->sort('field_notification_global', "DESC");
+      ->condition('field_notification_expire_date', $now->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT), '>')
 
     $nids = $query->execute();
 
@@ -110,7 +117,12 @@ class SiteNotificationsBlock extends BlockBase implements ContainerFactoryPlugin
 
     // Return a list of rendered teaser nodes.
     $builder = $this->entityTypeManager->getViewBuilder('node');
-    return $builder->viewMultiple($nodes, 'teaser', $language);
+    $build = $builder->viewMultiple($nodes, 'teaser', $language);
+
+    // Set a cache of an hour on the render array.
+    $build['#cache']['max-age'] = 3600;
+
+    return $build;
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR is primarily centered around notifications. 

- A new field was added that lets content editors set a weight to a notification which will control where it appears in the list.
- The notification block was updated to only fetch notifications that haven't expired.
- A hook_cron was added to unpublish notifications that are expired. 

Also included is some small config changes that were missed in the last deployment. All 3 of the sites have had these changes manually done on production so a hook_update is not required.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIG-229, https://thinkoomph.jira.com/browse/RIG-244