### PR TITLE
Add logo only theme setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIG-239: Added logo only theme setting.
 
 ### Changed
 

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -25,9 +25,12 @@ function ecms_theme_suggestions_page_alter(array &$suggestions, array $variables
  * Implements hook_preprocess_page().
  */
 function ecms_preprocess_page(array &$variables): void {
+  $config = \Drupal::config('system.site');
 
   // Attach header variables.
+  $variables['header_preprocess_values']['site_name'] = $config->get('name');
   $variables['header_preprocess_values']['site_logo'] = theme_get_setting('logo.url');
+  $variables['header_preprocess_values']['logo_only'] = theme_get_setting('logo_only');
   $variables['header_preprocess_values']['top_line'] = ['#plain_text' => theme_get_setting('header_top_line')];
   $variables['header_preprocess_values']['main_line'] = ['#plain_text' => theme_get_setting('header_main_line')];
   $variables['header_preprocess_values']['bottom_line'] = ['#plain_text' => theme_get_setting('header_bottom_line')];

--- a/ecms_base/themes/custom/ecms/theme-settings.php
+++ b/ecms_base/themes/custom/ecms/theme-settings.php
@@ -83,6 +83,12 @@ function ecms_form_system_theme_settings_alter(&$form, FormStateInterface $form_
     '#maxlength' => 255,
   ];
 
+  $form['ecms_header']['logo_only'] = [
+    '#type' => 'checkbox',
+    '#default_value' => theme_get_setting('logo_only'),
+    '#title' => t('Display logo only. Do not show any text.'),
+  ];
+
   // Footer settings.
   $form['ecms_footer'] = [
     '#type' => 'details',


### PR DESCRIPTION
## Summary
This PR adds a logo only theme setting. This will be used for the OHA site and any site that has a large logo.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIG-239