### PR TITLE
iCal feeds config, parser, and item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIG-251: Add ecms_feeds module which includes iCal parser and item.
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -139,6 +139,7 @@
     "drupal/easy_breadcrumb": "^1.13",
     "drupal/extlink": "^1.5",
     "drupal/features": "^3.11",
+    "drupal/feeds": "^3.0@alpha",
     "drupal/google_tag": "^1.4",
     "drupal/honeypot": "^2.0",
     "drupal/jsonapi_extras": "^3.16",

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -31,6 +31,7 @@ dependencies:
   - entity_reference_revisions
   - extlink
   - features_ui
+  - feeds
   - field_ui
   - file
   - features

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_form_display.node.event.default.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_form_display.node.event.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.event.feeds_item
     - field.field.node.event.field_event_body
     - field.field.node.event.field_event_contact
     - field.field.node.event.field_event_date

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_form_display.node.event.default.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_form_display.node.event.default.yml
@@ -2,7 +2,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.node.event.feeds_item
     - field.field.node.event.field_event_body
     - field.field.node.event.field_event_contact
     - field.field.node.event.field_event_date

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_form_display.node.event.default.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_form_display.node.event.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.event.feeds_item
     - field.field.node.event.field_event_body
     - field.field.node.event.field_event_contact
     - field.field.node.event.field_event_date
@@ -180,4 +181,5 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
-hidden: {  }
+hidden:
+  feeds_item: true

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.default.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.event.feeds_item
     - field.field.node.event.field_event_body
     - field.field.node.event.field_event_contact
     - field.field.node.event.field_event_date
@@ -95,6 +96,7 @@ content:
     type: metatag_empty_formatter
     region: content
 hidden:
+  feeds_item: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.default.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.event.feeds_item
     - field.field.node.event.field_event_body
     - field.field.node.event.field_event_contact
     - field.field.node.event.field_event_date

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.default.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.default.yml
@@ -2,7 +2,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.node.event.feeds_item
     - field.field.node.event.field_event_body
     - field.field.node.event.field_event_contact
     - field.field.node.event.field_event_date

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.teaser.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.teaser.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.event.feeds_item
     - field.field.node.event.field_event_body
     - field.field.node.event.field_event_contact
     - field.field.node.event.field_event_date
@@ -30,6 +31,7 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  feeds_item: true
   field_event_body: true
   field_event_contact: true
   field_event_date: true

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.teaser.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.teaser.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.event.feeds_item
     - field.field.node.event.field_event_body
     - field.field.node.event.field_event_contact
     - field.field.node.event.field_event_date

--- a/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.teaser.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/core.entity_view_display.node.event.teaser.yml
@@ -3,7 +3,6 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
-    - field.field.node.event.feeds_item
     - field.field.node.event.field_event_body
     - field.field.node.event.field_event_contact
     - field.field.node.event.field_event_date

--- a/ecms_base/features/custom/ecms_event/config/install/feeds.feed_type.ical_feed.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/feeds.feed_type.ical_feed.yml
@@ -1,0 +1,76 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.base_field_override.node.event.created
+    - field.field.node.event.field_event_body
+    - field.field.node.event.field_event_date
+    - field.field.node.event.field_event_location
+    - node.type.event
+  module:
+    - ecms_feeds
+    - node
+id: ical_feed
+label: 'iCal Feed'
+description: ''
+help: ''
+import_period: 3600
+fetcher: http
+fetcher_configuration:
+  auto_detect_feeds: false
+  use_pubsubhubbub: false
+  always_download: false
+  fallback_hub: ''
+  request_timeout: 30
+parser: feeds_ecms_ical
+parser_configuration: {  }
+processor: 'entity:node'
+processor_configuration:
+  langcode: en
+  update_existing: 2
+  update_non_existent: _delete
+  expire: -1
+  owner_feed_author: false
+  owner_id: 0
+  authorize: true
+  skip_hash_check: true
+  values:
+    type: event
+custom_sources: {  }
+mappings:
+  -
+    target: title
+    map:
+      value: summary
+    unique: {  }
+    settings:
+      language: null
+  -
+    target: field_event_body
+    map:
+      value: description
+      summary: ''
+    settings:
+      language: null
+      format: plain_text
+  -
+    target: field_event_date
+    map:
+      value: dtstart
+      end_value: dtend
+    settings:
+      language: null
+  -
+    target: created
+    map:
+      value: created
+    settings:
+      language: null
+      timezone: UTC
+  -
+    target: field_event_location
+    map:
+      value: location
+    unique: {  }
+    settings:
+      language: null

--- a/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.feeds_item.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.feeds_item.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.feeds_item
+    - node.type.event
+  module:
+    - feeds
+id: node.event.feeds_item
+field_name: feeds_item
+entity_type: node
+bundle: event
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.feeds_item.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.field.node.event.feeds_item.yml
@@ -13,7 +13,7 @@ bundle: event
 label: 'Feeds item'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/ecms_base/features/custom/ecms_event/config/install/field.storage.node.feeds_item.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.storage.node.feeds_item.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - feeds
+    - node
+id: node.feeds_item
+field_name: feeds_item
+entity_type: node
+type: feeds_item
+settings:
+  target_type: feeds_feed
+module: feeds
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_event/ecms_event.info.yml
+++ b/ecms_base/features/custom/ecms_event/ecms_event.info.yml
@@ -5,8 +5,10 @@ core_version_requirement: ^9
 dependencies:
   - content_moderation
   - content_translation
+  - ecms_feeds
   - ecms_promotions
   - ecms_workflow
+  - feeds
   - field
   - file
   - image

--- a/ecms_base/modules/custom/ecms_feeds/ecms_feeds.info.yml
+++ b/ecms_base/modules/custom/ecms_feeds/ecms_feeds.info.yml
@@ -1,0 +1,8 @@
+name: 'eCMS Feeds'
+description: 'Provides eCMS functionality to interface with the feeds module.'
+type: module
+core_version_requirement: ^9
+package: eCMS
+version: 9.x-1.0
+dependencies:
+  - feeds

--- a/ecms_base/modules/custom/ecms_feeds/src/Feeds/Item/EcmsIcalItem.php
+++ b/ecms_base/modules/custom/ecms_feeds/src/Feeds/Item/EcmsIcalItem.php
@@ -5,22 +5,69 @@ namespace Drupal\ecms_feeds\Feeds\Item;
 use Drupal\feeds\Feeds\Item\BaseItem;
 
 /**
- * Defines an item class for use with an Ical document.
+ * {@inheritdoc}
  */
 class EcmsIcalItem extends BaseItem {
 
   // ICAL Variables.
+  /**
+   * {@inheritdoc}
+   */
   protected $dtstart;
+
+  /**
+   * {@inheritdoc}
+   */
   protected $dtend;
+
+  /**
+   * {@inheritdoc}
+   */
   protected $dtstamp;
+
+  /**
+   * {@inheritdoc}
+   */
   protected $uid;
+
+  /**
+   * {@inheritdoc}
+   */
   protected $created;
+
+  /**
+   * {@inheritdoc}
+   */
   protected $description;
+
+  /**
+   * {@inheritdoc}
+   */
   protected $lastmodified;
+
+  /**
+   * {@inheritdoc}
+   */
   protected $location;
+
+  /**
+   * {@inheritdoc}
+   */
   protected $sequence;
+
+  /**
+   * {@inheritdoc}
+   */
   protected $status;
+
+  /**
+   * {@inheritdoc}
+   */
   protected $summary;
+
+  /**
+   * {@inheritdoc}
+   */
   protected $transp;
 
 }

--- a/ecms_base/modules/custom/ecms_feeds/src/Feeds/Item/EcmsIcalItem.php
+++ b/ecms_base/modules/custom/ecms_feeds/src/Feeds/Item/EcmsIcalItem.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\ecms_feeds\Feeds\Item;
+
+use Drupal\feeds\Feeds\Item\BaseItem;
+
+/**
+ * Defines an item class for use with an Ical document.
+ */
+class EcmsIcalItem extends BaseItem {
+
+  // ICAL Variables.
+  protected $dtstart;
+  protected $dtend;
+  protected $dtstamp;
+  protected $uid;
+  protected $created;
+  protected $description;
+  protected $lastmodified;
+  protected $location;
+  protected $sequence;
+  protected $status;
+  protected $summary;
+  protected $transp;
+
+}

--- a/ecms_base/modules/custom/ecms_feeds/src/Feeds/Item/EcmsIcalItem.php
+++ b/ecms_base/modules/custom/ecms_feeds/src/Feeds/Item/EcmsIcalItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\ecms_feeds\Feeds\Item;
 
 use Drupal\feeds\Feeds\Item\BaseItem;

--- a/ecms_base/modules/custom/ecms_feeds/src/Feeds/Parser/EcmsIcalParser.php
+++ b/ecms_base/modules/custom/ecms_feeds/src/Feeds/Parser/EcmsIcalParser.php
@@ -46,12 +46,12 @@ class EcmsIcalParser extends PluginBase implements ParserInterface {
 
       // Create ical parsing object.
       $ical = new ICal('ICal.ics', [
-          'defaultSpan'                 => 2,     // Default value
-          'defaultTimeZone'             => 'UTC',
-          'defaultWeekStart'            => 'MO',  // Default value
-          'disableCharacterReplacement' => false, // Default value
-          'skipRecurrence'              => false, // Default value
-          'useTimeZoneWithRRules'       => false, // Default value
+        'defaultSpan'                 => 2,
+        'defaultTimeZone'             => 'UTC',
+        'defaultWeekStart'            => 'MO',
+        'disableCharacterReplacement' => FALSE,
+        'skipRecurrence'              => FALSE,
+        'useTimeZoneWithRRules'       => FALSE,
       ]);
 
       $ical->initString($rawResponseString);

--- a/ecms_base/modules/custom/ecms_feeds/src/Feeds/Parser/EcmsIcalParser.php
+++ b/ecms_base/modules/custom/ecms_feeds/src/Feeds/Parser/EcmsIcalParser.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\ecms_feeds\Feeds\Parser;
+
+use Drupal\feeds\Component\XmlParserTrait;
+use Drupal\feeds\Exception\EmptyFeedException;
+use Drupal\feeds\FeedInterface;
+use Drupal\feeds\Plugin\Type\Parser\ParserInterface;
+use Drupal\feeds\Plugin\Type\PluginBase;
+use Drupal\feeds\Result\FetcherResultInterface;
+use Drupal\feeds\Result\ParserResult;
+use Drupal\feeds\StateInterface;
+use Drupal\ecms_feeds\Feeds\Item\EcmsIcalItem;
+use ICal\ICal;
+
+/**
+ * Defines an Ical Feeds parser.
+ *
+ * @FeedsParser(
+ *   id = "feeds_ecms_ical",
+ *   title = @Translation("eCMS iCal Parser"),
+ *   description = @Translation("Parse iCal Feed.")
+ * )
+ */
+class EcmsIcalParser extends PluginBase implements ParserInterface {
+  use XmlParserTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function parse(FeedInterface $feed, FetcherResultInterface $fetcher_result, StateInterface $state) {
+
+    // Look at our response.
+    $rawResponseString = trim($fetcher_result->getRaw());
+    if (!strlen($rawResponseString)) {
+      throw new EmptyFeedException();
+    }
+
+    // Create our result object to add to.
+    $result = new ParserResult();
+
+    // Use our ical class to parse the feed.
+    try {
+
+      // Create ical parsing object.
+      $ical = new ICal('ICal.ics', [
+          'defaultSpan'                 => 2,     // Default value
+          'defaultTimeZone'             => 'UTC',
+          'defaultWeekStart'            => 'MO',  // Default value
+          'disableCharacterReplacement' => false, // Default value
+          'skipRecurrence'              => false, // Default value
+          'useTimeZoneWithRRules'       => false, // Default value
+      ]);
+
+      $ical->initString($rawResponseString);
+
+      // Get and loop over events.
+      $events = $ical->events();
+      foreach ($events as $eventIndex => $event) {
+
+        // Create item to return for processing.
+        $itemObject = new EcmsIcalItem();
+
+        // Loop over information from feed and add to item.
+        foreach ($event as $eventProperty => $eventPropertyValue) {
+
+          switch ($eventProperty) {
+            case 'dtstart':
+              $itemObject->set($eventProperty, $event->dtstart_array[2]);
+              break;
+
+            case 'dtend':
+              $itemObject->set($eventProperty, $event->dtend_array[2]);
+              break;
+
+            default:
+              $itemObject->set($eventProperty, $eventPropertyValue);
+
+          }
+        }
+
+        // Add item to results.
+        $result->addItem($itemObject);
+
+      }
+
+    }
+
+    catch (\Exception $e) {
+      \Drupal::logger('ecms_feeds')->error($e);
+    }
+
+    return $result;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMappingSources(): array {
+    return [
+      'dtstart' => [
+        'label' => $this->t('DTSTART'),
+      ],
+      'dtend' => [
+        'label' => $this->t('DTEND'),
+      ],
+      'dtstamp' => [
+        'label' => $this->t('DTSTAMP'),
+      ],
+      'uid' => [
+        'label' => $this->t('UID'),
+        'suggestions' => [
+          'targets' => ['guid'],
+        ],
+      ],
+      'created' => [
+        'label' => $this->t('CREATED'),
+      ],
+      'description' => [
+        'label' => $this->t('DESCRIPTION'),
+      ],
+      'lastmodified' => [
+        'label' => $this->t('LAST-MODIFIED'),
+      ],
+      'location' => [
+        'label' => $this->t('LOCATION'),
+      ],
+      'sequence' => [
+        'label' => $this->t('SEQUENCE'),
+      ],
+      'status' => [
+        'label' => $this->t('STATUS'),
+      ],
+      'summary' => [
+        'label' => $this->t('SUMMARY'),
+        'suggestions' => [
+          'targets' => ['title'],
+        ],
+      ],
+      'transp' => [
+        'label' => $this->t('TRANSP'),
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
## Summary
This PR adds a custom iCal parser included in a custom module ecms_feeds. This also includes the necessary config to add the feed type to existing ecms_event feature package.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIG-251