### PR TITLE
Add Acquia Solr Search and related theming, config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-253: Add rrule library.
 - RIG-188: Add virtual meeting and registration url fields to event.
 - RIG-188: Add twig template for event full display.
+- RIG-222: Add Acquia Solr Search modules, templates, and config.
 
 ### Changed
 - RIG-257: Updated translation settings for misc paragraphs.

--- a/composer.json
+++ b/composer.json
@@ -127,7 +127,9 @@
   "require": {
     "composer/installers": "^1.9",
     "cweagans/composer-patches": "^1.6",
+    "drupal/acquia_connector": "^2.0@RC",
     "drupal/acquia_purge": "^1.1",
+    "drupal/acquia_search_solr": "^1.0@beta",
     "drupal/acsf": "^2.67",
     "drupal/address": "^1.8",
     "drupal/admin_toolbar": "^2.3",

--- a/ecms_acquia/config/install/search_api.index.acquia_search_solr_search_api_solr_index.yml
+++ b/ecms_acquia/config/install/search_api.index.acquia_search_solr_search_api_solr_index.yml
@@ -1,0 +1,190 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - acquia_search_solr
+    - search_api_solr
+    - node
+    - search_api
+  config:
+    - field.storage.node.body
+    - field.storage.node.field_basic_page_body
+    - field.storage.node.field_landing_page_body
+    - search_api.server.acquia_search_solr_search_api_solr_server
+    - core.entity_view_mode.node.full
+third_party_settings:
+  acquia_search_solr:
+    use_edismax: 1
+  search_api_solr:
+    finalize: false
+    commit_before_finalize: false
+    commit_after_finalize: false
+    multilingual:
+      limit_to_content_language: false
+      include_language_independent: true
+    highlighter:
+      maxAnalyzedChars: 51200
+      fragmenter: gap
+      regex:
+        slop: 0.5
+        pattern: blank
+        maxAnalyzedChars: 10000
+      usePhraseHighlighter: true
+      highlightMultiTerm: true
+      preserveMulti: false
+      highlight:
+        mergeContiguous: false
+        requireFieldMatch: false
+        snippets: 3
+        fragsize: 0
+    mlt:
+      mintf: 1
+      mindf: 1
+      maxdf: 0
+      maxdfpct: 0
+      minwl: 0
+      maxwl: 0
+      maxqt: 100
+      maxntp: 2000
+      boost: false
+      interestingTerms: none
+    term_modifiers:
+      slop: 3
+      fuzzy: 1
+    advanced:
+      index_prefix: ''
+      collection: ''
+      timezone: ''
+id: acquia_search_solr_search_api_solr_index
+name: 'Acquia Search Solr Search API Solr index'
+description: ''
+read_only: false
+field_settings:
+  body:
+    label: Body
+    datasource_id: 'entity:node'
+    property_path: body
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.body
+  field_basic_page_body:
+    label: 'Intro text'
+    datasource_id: 'entity:node'
+    property_path: field_basic_page_body
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_basic_page_body
+  field_landing_page_body:
+    label: 'Intro text'
+    datasource_id: 'entity:node'
+    property_path: field_landing_page_body
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_landing_page_body
+  node_grants:
+    label: 'Node access information'
+    property_path: search_api_node_grants
+    type: string
+    indexed_locked: true
+    type_locked: true
+    hidden: true
+  rendered_item:
+    label: 'Rendered HTML output'
+    property_path: rendered_item
+    type: text
+    configuration:
+      roles:
+        anonymous: anonymous
+      view_mode:
+        'entity:node':
+          basic_page: default
+          event: default
+          landing_page: full
+          location: default
+          person: default
+          press_release: default
+          webform: default
+  status:
+    label: status
+    datasource_id: 'entity:node'
+    property_path: status
+    type: boolean
+    indexed_locked: true
+    type_locked: true
+    dependencies:
+      module:
+        - node
+  title:
+    label: Title
+    datasource_id: 'entity:node'
+    property_path: title
+    type: text
+    boost: !!float 5
+    dependencies:
+      module:
+        - node
+  type:
+    label: 'Content type'
+    datasource_id: 'entity:node'
+    property_path: type
+    type: string
+    dependencies:
+      module:
+        - node
+  uid:
+    label: uid
+    datasource_id: 'entity:node'
+    property_path: uid
+    type: integer
+    indexed_locked: true
+    type_locked: true
+    dependencies:
+      module:
+        - node
+datasource_settings:
+  'entity:node':
+    bundles:
+      default: false
+      selected:
+        - basic_page
+        - event
+        - landing_page
+        - location
+        - person
+        - press_release
+        - webform
+    languages:
+      default: true
+      selected: {  }
+processor_settings:
+  add_url: {  }
+  aggregated_field: {  }
+  content_access:
+    weights:
+      preprocess_query: -30
+  entity_status: {  }
+  highlight:
+    highlight: always
+    highlight_partial: false
+    excerpt: true
+    excerpt_length: 256
+    exclude_fields: {  }
+    prefix: '<strong>'
+    suffix: '</strong>'
+    weights:
+      postprocess_query: 0
+  language_with_fallback: {  }
+  rendered_item: {  }
+  solr_date_range:
+    weights:
+      preprocess_index: 0
+tracker_settings:
+  default:
+    indexing_order: fifo
+options:
+  index_directly: false
+  cron_limit: 50
+server: acquia_search_solr_search_api_solr_server

--- a/ecms_acquia/config/install/search_api.server.acquia_search_solr_search_api_solr_server.yml
+++ b/ecms_acquia/config/install/search_api.server.acquia_search_solr_search_api_solr_server.yml
@@ -1,0 +1,57 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api_solr.solr_cache.cache_document_default_7_0_0
+    - search_api_solr.solr_cache.cache_fieldvalue_default_7_0_0
+    - search_api_solr.solr_cache.cache_filter_default_7_0_0
+    - search_api_solr.solr_cache.cache_persegfilter_default_7_0_0
+    - search_api_solr.solr_cache.cache_queryresult_default_7_0_0
+    - search_api_solr.solr_field_type.text_ar_6_0_0
+    - search_api_solr.solr_field_type.text_edge_und_6_0_0
+    - search_api_solr.solr_field_type.text_edgestring_und_6_0_0
+    - search_api_solr.solr_field_type.text_en_6_0_0
+    - search_api_solr.solr_field_type.text_es_6_0_0
+    - search_api_solr.solr_field_type.text_fr_6_0_0
+    - search_api_solr.solr_field_type.text_ngram_und_6_0_0
+    - search_api_solr.solr_field_type.text_ngramstring_und_6_0_0
+    - search_api_solr.solr_field_type.text_phonetic_en_7_0_0
+    - search_api_solr.solr_field_type.text_phonetic_es_7_0_0
+    - search_api_solr.solr_field_type.text_phonetic_fr_7_0_0
+    - search_api_solr.solr_field_type.text_phonetic_und_7_0_0
+    - search_api_solr.solr_field_type.text_pt-pt_7_0_0
+    - search_api_solr.solr_field_type.text_und_6_0_0
+    - search_api_solr.solr_field_type.text_zh-hans_7_0_0
+    - search_api_solr.solr_request_dispatcher.request_dispatcher_httpcachingnever_default_7_0_0
+    - search_api_solr.solr_request_handler.request_handler_autocomplete_default_7_0_0
+    - search_api_solr.solr_request_handler.request_handler_extract_default_7_0_0
+    - search_api_solr.solr_request_handler.request_handler_mlt_default_7_0_0
+    - search_api_solr.solr_request_handler.request_handler_select_default_7_0_0
+    - search_api_solr.solr_request_handler.request_handler_spell_default_7_0_0
+    - search_api_solr.solr_request_handler.request_handler_suggest_default_7_0_0
+    - search_api_solr.solr_request_handler.request_handler_tvrh_default_7_0_0
+  module:
+    - acquia_search_solr
+    - search_api_solr
+id: acquia_search_solr_search_api_solr_server
+name: 'Acquia Search Solr Search API Solr server'
+description: ''
+backend: search_api_solr
+backend_config:
+  connector: solr_acquia_search_solr
+  connector_config:
+    scheme: https
+    timeout: '10'
+    index_timeout: '10'
+    optimize_timeout: '10'
+    finalize_timeout: '30'
+    commit_within: '1000'
+    solr_version: ''
+    http_method: AUTO
+    jmx: 0
+  retrieve_data: true
+  highlight_data: true
+  skip_schema_check: true
+  server_prefix: ''
+  domain: generic
+  site_hash: true

--- a/ecms_acquia/config/install/search_api_solr.solr_cache.cache_document_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_cache.cache_document_default_7_0_0.yml
@@ -1,0 +1,14 @@
+langcode: en
+status: true
+dependencies: {  }
+id: cache_document_default_7_0_0
+label: 'Document Cache'
+minimum_solr_version: 7.0.0
+environments: {  }
+cache:
+  name: document
+  class: solr.LRUCache
+  size: 512
+  initialSize: 512
+  autowarmCount: 0
+solr_configs: null

--- a/ecms_acquia/config/install/search_api_solr.solr_cache.cache_fieldvalue_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_cache.cache_fieldvalue_default_7_0_0.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies: {  }
+id: cache_fieldvalue_default_7_0_0
+label: 'Field Value Cache'
+minimum_solr_version: 7.0.0
+environments: {  }
+cache:
+  name: fieldValue
+  class: solr.FastLRUCache
+  size: 512
+  autowarmCount: 128
+  showItems: 32
+solr_configs:
+  query:
+    -
+      name: enableLazyFieldLoading
+      VALUE: 'true'

--- a/ecms_acquia/config/install/search_api_solr.solr_cache.cache_filter_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_cache.cache_filter_default_7_0_0.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies: {  }
+id: cache_filter_default_7_0_0
+label: 'Filter Cache'
+minimum_solr_version: 7.0.0
+environments: {  }
+cache:
+  name: filter
+  class: solr.FastLRUCache
+  size: 512
+  initialSize: 512
+  autowarmCount: 0
+solr_configs:
+  query:
+    -
+      name: useFilterForSortedQuery
+      VALUE: 'false'

--- a/ecms_acquia/config/install/search_api_solr.solr_cache.cache_persegfilter_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_cache.cache_persegfilter_default_7_0_0.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies: {  }
+id: cache_persegfilter_default_7_0_0
+label: 'Per Segment Filter Cache'
+minimum_solr_version: 7.0.0
+environments: {  }
+cache:
+  name: perSegFilter
+  class: solr.search.LRUCache
+  size: 10
+  initialSize: 0
+  autowarmCount: 10
+  regenerator: solr.NoOpRegenerator
+solr_configs: null

--- a/ecms_acquia/config/install/search_api_solr.solr_cache.cache_queryresult_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_cache.cache_queryresult_default_7_0_0.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies: {  }
+id: cache_queryresult_default_7_0_0
+label: 'Query Result Cache'
+minimum_solr_version: 7.0.0
+environments: {  }
+cache:
+  name: queryResult
+  class: solr.LRUCache
+  size: 512
+  initialSize: 512
+  autowarmCount: 0
+solr_configs:
+  query:
+    -
+      name: queryResultWindowSize
+      VALUE: '20'
+    -
+      name: queryResultMaxDocsCached
+      VALUE: '200'
+    -
+      name: maxBooleanClauses
+      VALUE: '1024'

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_ar_6_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_ar_6_0_0.yml
@@ -1,0 +1,174 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_ar_6_0_0
+label: 'Arabic Text Field'
+minimum_solr_version: 6.0.0
+custom_code: null
+field_type_language_code: ar
+domains: {  }
+field_type:
+  name: text_ar
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_ar.txt
+        -
+          class: solr.ArabicNormalizationFilterFactory
+        -
+          class: solr.ArabicStemFilterFactory
+    -
+      type: query
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_ar.txt
+        -
+          class: solr.ArabicNormalizationFilterFactory
+        -
+          class: solr.SynonymFilterFactory
+          synonyms: synonyms_ar.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.ArabicStemFilterFactory
+unstemmed_field_type:
+  name: text_unstemmed_ar
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_ar.txt
+        -
+          class: solr.ArabicNormalizationFilterFactory
+    -
+      type: query
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_ar.txt
+        -
+          class: solr.ArabicNormalizationFilterFactory
+        -
+          class: solr.SynonymFilterFactory
+          synonyms: synonyms_ar.txt
+          expand: true
+          ignoreCase: true
+spellcheck_field_type: null
+collated_field_type:
+  name: collated_ar
+  class: solr.ICUCollationField
+  locale: ar
+  strength: primary
+  caseLevel: false
+solr_configs:
+  searchComponents:
+    -
+      name: spellcheck
+      class: solr.SpellCheckComponent
+      lst:
+        -
+          name: spellchecker
+          str:
+            -
+              name: name
+              VALUE: ar
+            -
+              name: field
+              VALUE: spellcheck_ar
+            -
+              name: classname
+              VALUE: solr.DirectSolrSpellChecker
+            -
+              name: distanceMeasure
+              VALUE: internal
+            -
+              name: accuracy
+              VALUE: '0.5'
+            -
+              name: maxEdits
+              VALUE: '2'
+            -
+              name: minPrefix
+              VALUE: '1'
+            -
+              name: maxInspections
+              VALUE: '5'
+            -
+              name: minQueryLength
+              VALUE: '4'
+            -
+              name: maxQueryFrequency
+              VALUE: '0.01'
+            -
+              name: thresholdTokenFrequency
+              VALUE: '.01'
+            -
+              name: onlyMorePopular
+              VALUE: 'true'
+    -
+      name: suggest
+      class: solr.SuggestComponent
+      lst:
+        -
+          name: suggester
+          str:
+            -
+              name: name
+              VALUE: ar
+            -
+              name: lookupImpl
+              VALUE: AnalyzingInfixLookupFactory
+            -
+              name: dictionaryImpl
+              VALUE: DocumentDictionaryFactory
+            -
+              name: field
+              VALUE: twm_suggest
+            -
+              name: suggestAnalyzerFieldType
+              VALUE: text_ar
+            -
+              name: contextField
+              VALUE: sm_context_tags
+            -
+              name: buildOnCommit
+              VALUE: 'true'
+            -
+              name: buildOnStartup
+              VALUE: 'false'
+text_files:
+  stopwords: "من\nومن\nمنها\nمنه\nفي\nوفي\nفيها\nفيه\nو\nف\nثم\nاو\nأو\nب\nبها\nبه\nا\nأ\nاى\nاي\nأي\nأى\nلا\nولا\nالا\nألا\nإلا\nلكن\nما\nوما\nكما\nفما\nعن\nمع\nاذا\nإذا\nان\nأن\nإن\nانها\nأنها\nإنها\nانه\nأنه\nإنه\nبان\nبأن\nفان\nفأن\nوان\nوأن\nوإن\nالتى\nالتي\nالذى\nالذي\nالذين\nالى\nالي\nإلى\nإلي\nعلى\nعليها\nعليه\nاما\nأما\nإما\nايضا\nأيضا\nكل\nوكل\nلم\nولم\nلن\nولن\nهى\nهي\nهو\nوهى\nوهي\nوهو\nفهى\nفهي\nفهو\nانت\nأنت\nلك\nلها\nله\nهذه\nهذا\nتلك\nذلك\nهناك\nكانت\nكان\nيكون\nتكون\nوكانت\nوكان\nغير\nبعض\nقد\nنحو\nبين\nبينما\nمنذ\nضمن\nحيث\nالان\nالآن\nخلال\nبعد\nقبل\nحتى\nعند\nعندما\nلدى\nجميع\n"
+  synonyms: "drupal, durpal\n"
+  nouns: ''
+  protwords: ''
+  accents: ''

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_ar_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_ar_7_0_0.yml
@@ -1,0 +1,174 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_ar_7_0_0
+label: 'Arabic Text Field'
+minimum_solr_version: 7.0.0
+custom_code: null
+field_type_language_code: ar
+domains: {  }
+field_type:
+  name: text_ar
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_ar.txt
+        -
+          class: solr.ArabicNormalizationFilterFactory
+        -
+          class: solr.ArabicStemFilterFactory
+    -
+      type: query
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_ar.txt
+        -
+          class: solr.ArabicNormalizationFilterFactory
+        -
+          class: solr.SynonymGraphFilterFactory
+          synonyms: synonyms_ar.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.ArabicStemFilterFactory
+unstemmed_field_type:
+  name: text_unstemmed_ar
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_ar.txt
+        -
+          class: solr.ArabicNormalizationFilterFactory
+    -
+      type: query
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_ar.txt
+        -
+          class: solr.ArabicNormalizationFilterFactory
+        -
+          class: solr.SynonymGraphFilterFactory
+          synonyms: synonyms_ar.txt
+          expand: true
+          ignoreCase: true
+spellcheck_field_type: null
+collated_field_type:
+  name: collated_ar
+  class: solr.ICUCollationField
+  locale: ar
+  strength: primary
+  caseLevel: false
+solr_configs:
+  searchComponents:
+    -
+      name: spellcheck
+      class: solr.SpellCheckComponent
+      lst:
+        -
+          name: spellchecker
+          str:
+            -
+              name: name
+              VALUE: ar
+            -
+              name: field
+              VALUE: spellcheck_ar
+            -
+              name: classname
+              VALUE: solr.DirectSolrSpellChecker
+            -
+              name: distanceMeasure
+              VALUE: internal
+            -
+              name: accuracy
+              VALUE: '0.5'
+            -
+              name: maxEdits
+              VALUE: '2'
+            -
+              name: minPrefix
+              VALUE: '1'
+            -
+              name: maxInspections
+              VALUE: '5'
+            -
+              name: minQueryLength
+              VALUE: '4'
+            -
+              name: maxQueryFrequency
+              VALUE: '0.01'
+            -
+              name: thresholdTokenFrequency
+              VALUE: '.01'
+            -
+              name: onlyMorePopular
+              VALUE: 'true'
+    -
+      name: suggest
+      class: solr.SuggestComponent
+      lst:
+        -
+          name: suggester
+          str:
+            -
+              name: name
+              VALUE: ar
+            -
+              name: lookupImpl
+              VALUE: AnalyzingInfixLookupFactory
+            -
+              name: dictionaryImpl
+              VALUE: DocumentDictionaryFactory
+            -
+              name: field
+              VALUE: twm_suggest
+            -
+              name: suggestAnalyzerFieldType
+              VALUE: text_ar
+            -
+              name: contextField
+              VALUE: sm_context_tags
+            -
+              name: buildOnCommit
+              VALUE: 'true'
+            -
+              name: buildOnStartup
+              VALUE: 'false'
+text_files:
+  stopwords: "من\nومن\nمنها\nمنه\nفي\nوفي\nفيها\nفيه\nو\nف\nثم\nاو\nأو\nب\nبها\nبه\nا\nأ\nاى\nاي\nأي\nأى\nلا\nولا\nالا\nألا\nإلا\nلكن\nما\nوما\nكما\nفما\nعن\nمع\nاذا\nإذا\nان\nأن\nإن\nانها\nأنها\nإنها\nانه\nأنه\nإنه\nبان\nبأن\nفان\nفأن\nوان\nوأن\nوإن\nالتى\nالتي\nالذى\nالذي\nالذين\nالى\nالي\nإلى\nإلي\nعلى\nعليها\nعليه\nاما\nأما\nإما\nايضا\nأيضا\nكل\nوكل\nلم\nولم\nلن\nولن\nهى\nهي\nهو\nوهى\nوهي\nوهو\nفهى\nفهي\nفهو\nانت\nأنت\nلك\nلها\nله\nهذه\nهذا\nتلك\nذلك\nهناك\nكانت\nكان\nيكون\nتكون\nوكانت\nوكان\nغير\nبعض\nقد\nنحو\nبين\nبينما\nمنذ\nضمن\nحيث\nالان\nالآن\nخلال\nبعد\nقبل\nحتى\nعند\nعندما\nلدى\nجميع\n"
+  synonyms: "drupal, durpal\n"
+  nouns: ''
+  protwords: ''
+  accents: ''

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_edge_und_6_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_edge_und_6_0_0.yml
@@ -1,0 +1,71 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_edge_und_6_0_0
+label: 'Edge NGram Text Field'
+minimum_solr_version: 6.0.0
+custom_code: edge
+field_type_language_code: und
+domains: {  }
+field_type:
+  name: text_edge
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_und.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_und.txt
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_und.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+        -
+          class: solr.EdgeNGramFilterFactory
+          minGramSize: 2
+          maxGramSize: 25
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_und.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+solr_configs: {  }
+text_files: {  }

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_edge_und_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_edge_und_7_0_0.yml
@@ -1,0 +1,71 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_edge_und_7_0_0
+label: 'Edge NGram Text Field'
+minimum_solr_version: 7.0.0
+custom_code: edge
+field_type_language_code: und
+domains: {  }
+field_type:
+  name: text_edge
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_und.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_und.txt
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_und.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+        -
+          class: solr.EdgeNGramFilterFactory
+          minGramSize: 2
+          maxGramSize: 25
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_und.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+solr_configs: {  }
+text_files: {  }

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_edgestring_und_6_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_edgestring_und_6_0_0.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_edgestring_und_6_0_0
+label: 'Edge NGram String Field'
+minimum_solr_version: 6.0.0
+custom_code: edgestring
+field_type_language_code: und
+domains: {  }
+field_type:
+  name: text_edgenstring
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      tokenizer:
+        class: solr.KeywordTokenizerFactory
+      filters:
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+        -
+          class: solr.EdgeNGramFilterFactory
+          minGramSize: 2
+          maxGramSize: 25
+    -
+      type: query
+      tokenizer:
+        class: solr.KeywordTokenizerFactory
+      filters:
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+solr_configs: {  }
+text_files: {  }

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_en_6_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_en_6_0_0.yml
@@ -1,0 +1,249 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_en_6_0_0
+label: 'English Text Field'
+minimum_solr_version: 6.0.0
+custom_code: ''
+field_type_language_code: en
+domains: {  }
+field_type:
+  name: text_en
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_en.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_en.txt
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_en.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.SnowballPorterFilterFactory
+          language: English
+          protected: protwords_en.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_en.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.SynonymFilterFactory
+          synonyms: synonyms_en.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_en.txt
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 1
+          protected: protwords_en.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.SnowballPorterFilterFactory
+          language: English
+          protected: protwords_en.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type:
+  name: text_unstemmed_en
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_en.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_en.txt
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_en.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_en.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.SynonymFilterFactory
+          synonyms: synonyms_en.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_en.txt
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 1
+          protected: protwords_en.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+spellcheck_field_type: null
+collated_field_type:
+  name: collated_en
+  class: solr.ICUCollationField
+  locale: en
+  strength: primary
+  caseLevel: false
+solr_configs:
+  searchComponents:
+    -
+      name: spellcheck
+      class: solr.SpellCheckComponent
+      lst:
+        -
+          name: spellchecker
+          str:
+            -
+              name: name
+              VALUE: en
+            -
+              name: field
+              VALUE: spellcheck_en
+            -
+              name: classname
+              VALUE: solr.DirectSolrSpellChecker
+            -
+              name: distanceMeasure
+              VALUE: internal
+            -
+              name: accuracy
+              VALUE: '0.5'
+            -
+              name: maxEdits
+              VALUE: '2'
+            -
+              name: minPrefix
+              VALUE: '1'
+            -
+              name: maxInspections
+              VALUE: '5'
+            -
+              name: minQueryLength
+              VALUE: '4'
+            -
+              name: maxQueryFrequency
+              VALUE: '0.01'
+            -
+              name: thresholdTokenFrequency
+              VALUE: '.01'
+            -
+              name: onlyMorePopular
+              VALUE: 'true'
+    -
+      name: suggest
+      class: solr.SuggestComponent
+      lst:
+        -
+          name: suggester
+          str:
+            -
+              name: name
+              VALUE: en
+            -
+              name: lookupImpl
+              VALUE: AnalyzingInfixLookupFactory
+            -
+              name: dictionaryImpl
+              VALUE: DocumentDictionaryFactory
+            -
+              name: field
+              VALUE: twm_suggest
+            -
+              name: suggestAnalyzerFieldType
+              VALUE: text_en
+            -
+              name: contextField
+              VALUE: sm_context_tags
+            -
+              name: buildOnCommit
+              VALUE: 'true'
+            -
+              name: buildOnStartup
+              VALUE: 'false'
+text_files:
+  stopwords: "a\nan\nand\nare\nas\nat\nbe\nbut\nby\nfor\nif\nin\ninto\nis\nit\nno\nnot\nof\non\nor\ns\nsuch\nt\nthat\nthe\ntheir\nthen\nthere\nthese\nthey\nthis\nto\nwas\nwill\nwith\n"
+  synonyms: "drupal, durpal\n"
+  protwords: ''
+  accents: "# À => A\n\"\\u00C0\" => \"A\"\n# Á => A\n\"\\u00C1\" => \"A\"\n# Â => A\n\"\\u00C2\" => \"A\"\n# Ã => A\n\"\\u00C3\" => \"A\"\n# Ä => A\n\"\\u00C4\" => \"A\"\n# Å => A\n\"\\u00C5\" => \"A\"\n# Ą => A\n\"\\u0104\" => \"A\"\n# Æ => AE\n\"\\u00C6\" => \"AE\"\n# Ç => C\n\"\\u00C7\" => \"C\"\n# Ć => C\n\"\\U0106\" => \"C\"\n# È => E\n\"\\u00C8\" => \"E\"\n# É => E\n\"\\u00C9\" => \"E\"\n# Ê => E\n\"\\u00CA\" => \"E\"\n# Ë => E\n\"\\u00CB\" => \"E\"\n# Ę => E\n\"\\u0118\" => \"E\"\n# Ì => I\n\"\\u00CC\" => \"I\"\n# Í => I\n\"\\u00CD\" => \"I\"\n# Î => I\n\"\\u00CE\" => \"I\"\n# Ï => I\n\"\\u00CF\" => \"I\"\n# Ĳ => IJ\n\"\\u0132\" => \"IJ\"\n# Ð => D\n\"\\u00D0\" => \"D\"\n# Ł => L\n\"\\u0141\" => \"L\"\n# Ñ => N\n\"\\u00D1\" => \"N\"\n# Ń => N\n\"\\u0143\" => \"N\"\n# Ò => O\n\"\\u00D2\" => \"O\"\n# Ó => O\n\"\\u00D3\" => \"O\"\n# Ô => O\n\"\\u00D4\" => \"O\"\n# Õ => O\n\"\\u00D5\" => \"O\"\n# Ö => O\n\"\\u00D6\" => \"O\"\n# Ø => O\n\"\\u00D8\" => \"O\"\n# Œ => OE\n\"\\u0152\" => \"OE\"\n# Þ\n\"\\u00DE\" => \"TH\"\n# Ù => U\n\"\\u00D9\" => \"U\"\n# Ú => U\n\"\\u00DA\" => \"U\"\n# Û => U\n\"\\u00DB\" => \"U\"\n# Ü => U\n\"\\u00DC\" => \"U\"\n# Ý => Y\n\"\\u00DD\" => \"Y\"\n# Ÿ => Y\n\"\\u0178\" => \"Y\"\n# à => a\n\"\\u00E0\" => \"a\"\n# á => a\n\"\\u00E1\" => \"a\"\n# â => a\n\"\\u00E2\" => \"a\"\n# ã => a\n\"\\u00E3\" => \"a\"\n# ä => a\n\"\\u00E4\" => \"a\"\n# å => a\n\"\\u00E5\" => \"a\"\n# æ => ae\n\"\\u00E6\" => \"ae\"\n# ç => c\n\"\\u00E7\" => \"c\"\n# è => e\n\"\\u00E8\" => \"e\"\n# é => e\n\"\\u00E9\" => \"e\"\n# ê => e\n\"\\u00EA\" => \"e\"\n# ë => e\n\"\\u00EB\" => \"e\"\n# ì => i\n\"\\u00EC\" => \"i\"\n# í => i\n\"\\u00ED\" => \"i\"\n# î => i\n\"\\u00EE\" => \"i\"\n# ï => i\n\"\\u00EF\" => \"i\"\n# ĳ => ij\n\"\\u0133\" => \"ij\"\n# ð => d\n\"\\u00F0\" => \"d\"\n# ñ => n\n\"\\u00F1\" => \"n\"\n# ò => o\n\"\\u00F2\" => \"o\"\n# ó => o\n\"\\u00F3\" => \"o\"\n# ô => o\n\"\\u00F4\" => \"o\"\n# õ => o\n\"\\u00F5\" => \"o\"\n# ö => o\n\"\\u00F6\" => \"o\"\n# ø => o\n\"\\u00F8\" => \"o\"\n# œ => oe\n\"\\u0153\" => \"oe\"\n# ß => ss\n\"\\u00DF\" => \"ss\"\n# Ś => S\n\"\\u015a\" => \"S\"\n# þ => th\n\"\\u00FE\" => \"th\"\n# ù => u\n\"\\u00F9\" => \"u\"\n# ú => u\n\"\\u00FA\" => \"u\"\n# û => u\n\"\\u00FB\" => \"u\"\n# ü => u\n\"\\u00FC\" => \"u\"\n# ý => y\n\"\\u00FD\" => \"y\"\n# ÿ => y\n\"\\u00FF\" => \"y\"\n# Ź => Z\n\"\\u0179\" => \"Z\"\n# Ż => Z\n\"\\u017b\" => \"Z\"\n# ﬀ => ff\n\"\\uFB00\" => \"ff\"\n# ﬁ => fi\n\"\\uFB01\" => \"fi\"\n# ﬂ => fl\n\"\\uFB02\" => \"fl\"\n# ﬃ => ffi\n\"\\uFB03\" => \"ffi\"\n# ﬄ => ffl\n\"\\uFB04\" => \"ffl\"\n# ﬅ => st\n\"\\uFB05\" => \"st\"\n# ﬆ => st\n\"\\uFB06\" => \"st\"\n"

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_en_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_en_7_0_0.yml
@@ -1,0 +1,249 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_en_7_0_0
+label: 'English Text Field'
+minimum_solr_version: 7.0.0
+custom_code: ''
+field_type_language_code: en
+domains: {  }
+field_type:
+  name: text_en
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_en.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_en.txt
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_en.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.SnowballPorterFilterFactory
+          language: English
+          protected: protwords_en.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_en.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.SynonymGraphFilterFactory
+          synonyms: synonyms_en.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_en.txt
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 1
+          protected: protwords_en.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.SnowballPorterFilterFactory
+          language: English
+          protected: protwords_en.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type:
+  name: text_unstemmed_en
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_en.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_en.txt
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_en.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_en.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.SynonymGraphFilterFactory
+          synonyms: synonyms_en.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_en.txt
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 1
+          protected: protwords_en.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+spellcheck_field_type: null
+collated_field_type:
+  name: collated_en
+  class: solr.ICUCollationField
+  locale: en
+  strength: primary
+  caseLevel: false
+solr_configs:
+  searchComponents:
+    -
+      name: spellcheck
+      class: solr.SpellCheckComponent
+      lst:
+        -
+          name: spellchecker
+          str:
+            -
+              name: name
+              VALUE: en
+            -
+              name: field
+              VALUE: spellcheck_en
+            -
+              name: classname
+              VALUE: solr.DirectSolrSpellChecker
+            -
+              name: distanceMeasure
+              VALUE: internal
+            -
+              name: accuracy
+              VALUE: '0.5'
+            -
+              name: maxEdits
+              VALUE: '2'
+            -
+              name: minPrefix
+              VALUE: '1'
+            -
+              name: maxInspections
+              VALUE: '5'
+            -
+              name: minQueryLength
+              VALUE: '4'
+            -
+              name: maxQueryFrequency
+              VALUE: '0.01'
+            -
+              name: thresholdTokenFrequency
+              VALUE: '.01'
+            -
+              name: onlyMorePopular
+              VALUE: 'true'
+    -
+      name: suggest
+      class: solr.SuggestComponent
+      lst:
+        -
+          name: suggester
+          str:
+            -
+              name: name
+              VALUE: en
+            -
+              name: lookupImpl
+              VALUE: AnalyzingInfixLookupFactory
+            -
+              name: dictionaryImpl
+              VALUE: DocumentDictionaryFactory
+            -
+              name: field
+              VALUE: twm_suggest
+            -
+              name: suggestAnalyzerFieldType
+              VALUE: text_en
+            -
+              name: contextField
+              VALUE: sm_context_tags
+            -
+              name: buildOnCommit
+              VALUE: 'true'
+            -
+              name: buildOnStartup
+              VALUE: 'false'
+text_files:
+  stopwords: "a\nan\nand\nare\nas\nat\nbe\nbut\nby\nfor\nif\nin\ninto\nis\nit\nno\nnot\nof\non\nor\ns\nsuch\nt\nthat\nthe\ntheir\nthen\nthere\nthese\nthey\nthis\nto\nwas\nwill\nwith\n"
+  synonyms: "drupal, durpal\n"
+  protwords: ''
+  accents: "# À => A\n\"\\u00C0\" => \"A\"\n# Á => A\n\"\\u00C1\" => \"A\"\n# Â => A\n\"\\u00C2\" => \"A\"\n# Ã => A\n\"\\u00C3\" => \"A\"\n# Ä => A\n\"\\u00C4\" => \"A\"\n# Å => A\n\"\\u00C5\" => \"A\"\n# Ą => A\n\"\\u0104\" => \"A\"\n# Æ => AE\n\"\\u00C6\" => \"AE\"\n# Ç => C\n\"\\u00C7\" => \"C\"\n# Ć => C\n\"\\U0106\" => \"C\"\n# È => E\n\"\\u00C8\" => \"E\"\n# É => E\n\"\\u00C9\" => \"E\"\n# Ê => E\n\"\\u00CA\" => \"E\"\n# Ë => E\n\"\\u00CB\" => \"E\"\n# Ę => E\n\"\\u0118\" => \"E\"\n# Ì => I\n\"\\u00CC\" => \"I\"\n# Í => I\n\"\\u00CD\" => \"I\"\n# Î => I\n\"\\u00CE\" => \"I\"\n# Ï => I\n\"\\u00CF\" => \"I\"\n# Ĳ => IJ\n\"\\u0132\" => \"IJ\"\n# Ð => D\n\"\\u00D0\" => \"D\"\n# Ł => L\n\"\\u0141\" => \"L\"\n# Ñ => N\n\"\\u00D1\" => \"N\"\n# Ń => N\n\"\\u0143\" => \"N\"\n# Ò => O\n\"\\u00D2\" => \"O\"\n# Ó => O\n\"\\u00D3\" => \"O\"\n# Ô => O\n\"\\u00D4\" => \"O\"\n# Õ => O\n\"\\u00D5\" => \"O\"\n# Ö => O\n\"\\u00D6\" => \"O\"\n# Ø => O\n\"\\u00D8\" => \"O\"\n# Œ => OE\n\"\\u0152\" => \"OE\"\n# Þ\n\"\\u00DE\" => \"TH\"\n# Ù => U\n\"\\u00D9\" => \"U\"\n# Ú => U\n\"\\u00DA\" => \"U\"\n# Û => U\n\"\\u00DB\" => \"U\"\n# Ü => U\n\"\\u00DC\" => \"U\"\n# Ý => Y\n\"\\u00DD\" => \"Y\"\n# Ÿ => Y\n\"\\u0178\" => \"Y\"\n# à => a\n\"\\u00E0\" => \"a\"\n# á => a\n\"\\u00E1\" => \"a\"\n# â => a\n\"\\u00E2\" => \"a\"\n# ã => a\n\"\\u00E3\" => \"a\"\n# ä => a\n\"\\u00E4\" => \"a\"\n# å => a\n\"\\u00E5\" => \"a\"\n# æ => ae\n\"\\u00E6\" => \"ae\"\n# ç => c\n\"\\u00E7\" => \"c\"\n# è => e\n\"\\u00E8\" => \"e\"\n# é => e\n\"\\u00E9\" => \"e\"\n# ê => e\n\"\\u00EA\" => \"e\"\n# ë => e\n\"\\u00EB\" => \"e\"\n# ì => i\n\"\\u00EC\" => \"i\"\n# í => i\n\"\\u00ED\" => \"i\"\n# î => i\n\"\\u00EE\" => \"i\"\n# ï => i\n\"\\u00EF\" => \"i\"\n# ĳ => ij\n\"\\u0133\" => \"ij\"\n# ð => d\n\"\\u00F0\" => \"d\"\n# ñ => n\n\"\\u00F1\" => \"n\"\n# ò => o\n\"\\u00F2\" => \"o\"\n# ó => o\n\"\\u00F3\" => \"o\"\n# ô => o\n\"\\u00F4\" => \"o\"\n# õ => o\n\"\\u00F5\" => \"o\"\n# ö => o\n\"\\u00F6\" => \"o\"\n# ø => o\n\"\\u00F8\" => \"o\"\n# œ => oe\n\"\\u0153\" => \"oe\"\n# ß => ss\n\"\\u00DF\" => \"ss\"\n# Ś => S\n\"\\u015a\" => \"S\"\n# þ => th\n\"\\u00FE\" => \"th\"\n# ù => u\n\"\\u00F9\" => \"u\"\n# ú => u\n\"\\u00FA\" => \"u\"\n# û => u\n\"\\u00FB\" => \"u\"\n# ü => u\n\"\\u00FC\" => \"u\"\n# ý => y\n\"\\u00FD\" => \"y\"\n# ÿ => y\n\"\\u00FF\" => \"y\"\n# Ź => Z\n\"\\u0179\" => \"Z\"\n# Ż => Z\n\"\\u017b\" => \"Z\"\n# ﬀ => ff\n\"\\uFB00\" => \"ff\"\n# ﬁ => fi\n\"\\uFB01\" => \"fi\"\n# ﬂ => fl\n\"\\uFB02\" => \"fl\"\n# ﬃ => ffi\n\"\\uFB03\" => \"ffi\"\n# ﬄ => ffl\n\"\\uFB04\" => \"ffl\"\n# ﬅ => st\n\"\\uFB05\" => \"st\"\n# ﬆ => st\n\"\\uFB06\" => \"st\"\n"

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_es_6_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_es_6_0_0.yml
@@ -1,0 +1,234 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_es_6_0_0
+label: 'Spanish Text Field'
+minimum_solr_version: 6.0.0
+custom_code: ''
+field_type_language_code: es
+domains: {  }
+field_type:
+  name: text_es
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_es.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_es.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_es.txt
+        -
+          class: solr.SnowballPorterFilterFactory
+          language: Spanish
+          protected: protwords_es.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_es.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 0
+          protected: protwords_es.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.SynonymFilterFactory
+          synonyms: synonyms_es.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_es.txt
+        -
+          class: solr.SnowballPorterFilterFactory
+          language: Spanish
+          protected: protwords_es.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type:
+  name: text_unstemmed_es
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_es.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_es.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_es.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_es.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 0
+          protected: protwords_es.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.SynonymFilterFactory
+          synonyms: synonyms_es.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_es.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+spellcheck_field_type: null
+collated_field_type:
+  name: collated_es
+  class: solr.ICUCollationField
+  locale: es
+  strength: primary
+  caseLevel: false
+solr_configs:
+  searchComponents:
+    -
+      name: spellcheck
+      class: solr.SpellCheckComponent
+      lst:
+        -
+          name: spellchecker
+          str:
+            -
+              name: name
+              VALUE: es
+            -
+              name: field
+              VALUE: spellcheck_es
+            -
+              name: classname
+              VALUE: solr.DirectSolrSpellChecker
+            -
+              name: distanceMeasure
+              VALUE: internal
+            -
+              name: accuracy
+              VALUE: '0.5'
+            -
+              name: maxEdits
+              VALUE: '2'
+            -
+              name: minPrefix
+              VALUE: '1'
+            -
+              name: maxInspections
+              VALUE: '5'
+            -
+              name: minQueryLength
+              VALUE: '4'
+            -
+              name: maxQueryFrequency
+              VALUE: '0.01'
+            -
+              name: thresholdTokenFrequency
+              VALUE: '.01'
+            -
+              name: onlyMorePopular
+              VALUE: 'true'
+    -
+      name: suggest
+      class: solr.SuggestComponent
+      lst:
+        -
+          name: suggester
+          str:
+            -
+              name: name
+              VALUE: es
+            -
+              name: lookupImpl
+              VALUE: AnalyzingInfixLookupFactory
+            -
+              name: dictionaryImpl
+              VALUE: DocumentDictionaryFactory
+            -
+              name: field
+              VALUE: twm_suggest
+            -
+              name: suggestAnalyzerFieldType
+              VALUE: text_es
+            -
+              name: contextField
+              VALUE: sm_context_tags
+            -
+              name: buildOnCommit
+              VALUE: 'true'
+            -
+              name: buildOnStartup
+              VALUE: 'false'
+text_files:
+  stopwords: "de\nla\nque\nel\nen\ny\na\nlos\ndel\nse\nlas\npor\nun\npara\ncon\nno\nuna\nsu\nal\nlo\ncomo\nmás\npero\nsus\nle\nya\no\neste\nsí\nporque\nesta\nentre\ncuando\nmuy\nsin\nsobre\ntambién\nme\nhasta\nhay\ndonde\nquien\ndesde\ntodo\nnos\ndurante\ntodos\nuno\nles\nni\ncontra\notros\nese\neso\nante\nellos\ne\nesto\nmí\nantes\nalgunos\nqué\nunos\nyo\notro\notras\notra\nél\ntanto\nesa\nestos\nmucho\nquienes\nnada\nmuchos\ncual\npoco\nella\nestar\nestas\nalgunas\nalgo\nnosotros\nmi\nmis\ntú\nte\nti\ntu\ntus\nellas\nnosotras\nvosotros\nvosotras\nos\nmío\nmía\nmíos\nmías\ntuyo\ntuya\ntuyos\ntuyas\nsuyo\nsuya\nsuyos\nsuyas\nnuestro\nnuestra\nnuestros\nnuestras\nvuestro\nvuestra\nvuestros\nvuestras\nesos\nesas\nestoy\nestás\nestá\nestamos\nestáis\nestán\nesté\nestés\nestemos\nestéis\nestén\nestaré\nestarás\nestará\nestaremos\nestaréis\nestarán\nestaría\nestarías\nestaríamos\nestaríais\nestarían\nestaba\nestabas\nestábamos\nestabais\nestaban\nestuve\nestuviste\nestuvo\nestuvimos\nestuvisteis\nestuvieron\nestuviera\nestuvieras\nestuviéramos\nestuvierais\nestuvieran\nestuviese\nestuvieses\nestuviésemos\nestuvieseis\nestuviesen\nestando\nestado\nestada\nestados\nestadas\nestad\nhe\nhas\nha\nhemos\nhabéis\nhan\nhaya\nhayas\nhayamos\nhayáis\nhayan\nhabré\nhabrás\nhabrá\nhabremos\nhabréis\nhabrán\nhabría\nhabrías\nhabríamos\nhabríais\nhabrían\nhabía\nhabías\nhabíamos\nhabíais\nhabían\nhube\nhubiste\nhubo\nhubimos\nhubisteis\nhubieron\nhubiera\nhubieras\nhubiéramos\nhubierais\nhubieran\nhubiese\nhubieses\nhubiésemos\nhubieseis\nhubiesen\nhabiendo\nhabido\nhabida\nhabidos\nhabidas\nsoy\neres\nes\nsomos\nsois\nson\nsea\nseas\nseamos\nseáis\nsean\nseré\nserás\nserá\nseremos\nseréis\nserán\nsería\nserías\nseríamos\nseríais\nserían\nera\neras\néramos\nerais\neran\nfui\nfuiste\nfue\nfuimos\nfuisteis\nfueron\nfuera\nfueras\nfuéramos\nfuerais\nfueran\nfuese\nfueses\nfuésemos\nfueseis\nfuesen\nsiendo\nsido\ntengo\ntienes\ntiene\ntenemos\ntenéis\ntienen\ntenga\ntengas\ntengamos\ntengáis\ntengan\ntendré\ntendrás\ntendrá\ntendremos\ntendréis\ntendrán\ntendría\ntendrías\ntendríamos\ntendríais\ntendrían\ntenía\ntenías\nteníamos\nteníais\ntenían\ntuve\ntuviste\ntuvo\ntuvimos\ntuvisteis\ntuvieron\ntuviera\ntuvieras\ntuviéramos\ntuvierais\ntuvieran\ntuviese\ntuvieses\ntuviésemos\ntuvieseis\ntuviesen\nteniendo\ntenido\ntenida\ntenidos\ntenidas\ntened\n"
+  synonyms: "drupal, durpal\n"
+  nouns: ''
+  protwords: ''
+  accents: "# À => A\n\"\\u00C0\" => \"A\"\n# Á => A\n#\"\\u00C1\" => \"A\"\n# Â => A\n\"\\u00C2\" => \"A\"\n# Ã => A\n\"\\u00C3\" => \"A\"\n# Ä => A\n\"\\u00C4\" => \"A\"\n# Å => A\n\"\\u00C5\" => \"A\"\n# Ą => A\n\"\\u0104\" => \"A\"\n# Æ => AE\n\"\\u00C6\" => \"AE\"\n# Ç => C\n\"\\u00C7\" => \"C\"\n# Ć => C\n\"\\U0106\" => \"C\"\n# È => E\n\"\\u00C8\" => \"E\"\n# É => E\n#\"\\u00C9\" => \"E\"\n# Ê => E\n\"\\u00CA\" => \"E\"\n# Ë => E\n\"\\u00CB\" => \"E\"\n# Ę => E\n\"\\u0118\" => \"E\"\n# Ì => I\n\"\\u00CC\" => \"I\"\n# Í => I\n#\"\\u00CD\" => \"I\"\n# Î => I\n\"\\u00CE\" => \"I\"\n# Ï => I\n\"\\u00CF\" => \"I\"\n# Ĳ => IJ\n\"\\u0132\" => \"IJ\"\n# Ð => D\n\"\\u00D0\" => \"D\"\n# Ł => L\n\"\\u0141\" => \"L\"\n# Ñ => N\n#\"\\u00D1\" => \"N\"\n# Ń => N\n\"\\u0143\" => \"N\"\n# Ò => O\n\"\\u00D2\" => \"O\"\n# Ó => O\n#\"\\u00D3\" => \"O\"\n# Ô => O\n\"\\u00D4\" => \"O\"\n# Õ => O\n\"\\u00D5\" => \"O\"\n# Ö => O\n\"\\u00D6\" => \"O\"\n# Ø => O\n\"\\u00D8\" => \"O\"\n# Œ => OE\n\"\\u0152\" => \"OE\"\n# Þ\n\"\\u00DE\" => \"TH\"\n# Ù => U\n\"\\u00D9\" => \"U\"\n# Ú => U\n#\"\\u00DA\" => \"U\"\n# Û => U\n\"\\u00DB\" => \"U\"\n# Ü => U\n\"\\u00DC\" => \"U\"\n# Ý => Y\n\"\\u00DD\" => \"Y\"\n# Ÿ => Y\n\"\\u0178\" => \"Y\"\n# à => a\n\"\\u00E0\" => \"a\"\n# á => a\n#\"\\u00E1\" => \"a\"\n# â => a\n\"\\u00E2\" => \"a\"\n# ã => a\n\"\\u00E3\" => \"a\"\n# ä => a\n\"\\u00E4\" => \"a\"\n# å => a\n\"\\u00E5\" => \"a\"\n# æ => ae\n\"\\u00E6\" => \"ae\"\n# ç => c\n\"\\u00E7\" => \"c\"\n# è => e\n\"\\u00E8\" => \"e\"\n# é => e\n#\"\\u00E9\" => \"e\"\n# ê => e\n\"\\u00EA\" => \"e\"\n# ë => e\n\"\\u00EB\" => \"e\"\n# ì => i\n\"\\u00EC\" => \"i\"\n# í => i\n#\"\\u00ED\" => \"i\"\n# î => i\n\"\\u00EE\" => \"i\"\n# ï => i\n\"\\u00EF\" => \"i\"\n# ĳ => ij\n\"\\u0133\" => \"ij\"\n# ð => d\n\"\\u00F0\" => \"d\"\n# ñ => n\n#\"\\u00F1\" => \"n\"\n# ò => o\n\"\\u00F2\" => \"o\"\n# ó => o\n#\"\\u00F3\" => \"o\"\n# ô => o\n\"\\u00F4\" => \"o\"\n# õ => o\n\"\\u00F5\" => \"o\"\n# ö => o\n\"\\u00F6\" => \"o\"\n# ø => o\n\"\\u00F8\" => \"o\"\n# œ => oe\n\"\\u0153\" => \"oe\"\n# ß => ss\n\"\\u00DF\" => \"ss\"\n# Ś => S\n\"\\u015a\" => \"S\"\n# þ => th\n\"\\u00FE\" => \"th\"\n# ù => u\n\"\\u00F9\" => \"u\"\n# ú => u\n#\"\\u00FA\" => \"u\"\n# û => u\n\"\\u00FB\" => \"u\"\n# ü => u\n\"\\u00FC\" => \"u\"\n# ý => y\n\"\\u00FD\" => \"y\"\n# ÿ => y\n\"\\u00FF\" => \"y\"\n# Ź => Z\n\"\\u0179\" => \"Z\"\n# Ż => Z\n\"\\u017b\" => \"Z\"\n# ﬀ => ff\n\"\\uFB00\" => \"ff\"\n# ﬁ => fi\n\"\\uFB01\" => \"fi\"\n# ﬂ => fl\n\"\\uFB02\" => \"fl\"\n# ﬃ => ffi\n\"\\uFB03\" => \"ffi\"\n# ﬄ => ffl\n\"\\uFB04\" => \"ffl\"\n# ﬅ => st\n\"\\uFB05\" => \"st\"\n# ﬆ => st\n\"\\uFB06\" => \"st\"\n"

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_es_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_es_7_0_0.yml
@@ -1,0 +1,234 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_es_7_0_0
+label: 'Spanish Text Field'
+minimum_solr_version: 7.0.0
+custom_code: ''
+field_type_language_code: es
+domains: {  }
+field_type:
+  name: text_es
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_es.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_es.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_es.txt
+        -
+          class: solr.SnowballPorterFilterFactory
+          language: Spanish
+          protected: protwords_es.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_es.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 0
+          protected: protwords_es.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.SynonymGraphFilterFactory
+          synonyms: synonyms_es.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_es.txt
+        -
+          class: solr.SnowballPorterFilterFactory
+          language: Spanish
+          protected: protwords_es.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type:
+  name: text_unstemmed_es
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_es.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_es.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_es.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_es.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 0
+          protected: protwords_es.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.SynonymGraphFilterFactory
+          synonyms: synonyms_es.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_es.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+spellcheck_field_type: null
+collated_field_type:
+  name: collated_es
+  class: solr.ICUCollationField
+  locale: es
+  strength: primary
+  caseLevel: false
+solr_configs:
+  searchComponents:
+    -
+      name: spellcheck
+      class: solr.SpellCheckComponent
+      lst:
+        -
+          name: spellchecker
+          str:
+            -
+              name: name
+              VALUE: es
+            -
+              name: field
+              VALUE: spellcheck_es
+            -
+              name: classname
+              VALUE: solr.DirectSolrSpellChecker
+            -
+              name: distanceMeasure
+              VALUE: internal
+            -
+              name: accuracy
+              VALUE: '0.5'
+            -
+              name: maxEdits
+              VALUE: '2'
+            -
+              name: minPrefix
+              VALUE: '1'
+            -
+              name: maxInspections
+              VALUE: '5'
+            -
+              name: minQueryLength
+              VALUE: '4'
+            -
+              name: maxQueryFrequency
+              VALUE: '0.01'
+            -
+              name: thresholdTokenFrequency
+              VALUE: '.01'
+            -
+              name: onlyMorePopular
+              VALUE: 'true'
+    -
+      name: suggest
+      class: solr.SuggestComponent
+      lst:
+        -
+          name: suggester
+          str:
+            -
+              name: name
+              VALUE: es
+            -
+              name: lookupImpl
+              VALUE: AnalyzingInfixLookupFactory
+            -
+              name: dictionaryImpl
+              VALUE: DocumentDictionaryFactory
+            -
+              name: field
+              VALUE: twm_suggest
+            -
+              name: suggestAnalyzerFieldType
+              VALUE: text_es
+            -
+              name: contextField
+              VALUE: sm_context_tags
+            -
+              name: buildOnCommit
+              VALUE: 'true'
+            -
+              name: buildOnStartup
+              VALUE: 'false'
+text_files:
+  stopwords: "de\nla\nque\nel\nen\ny\na\nlos\ndel\nse\nlas\npor\nun\npara\ncon\nno\nuna\nsu\nal\nlo\ncomo\nmás\npero\nsus\nle\nya\no\neste\nsí\nporque\nesta\nentre\ncuando\nmuy\nsin\nsobre\ntambién\nme\nhasta\nhay\ndonde\nquien\ndesde\ntodo\nnos\ndurante\ntodos\nuno\nles\nni\ncontra\notros\nese\neso\nante\nellos\ne\nesto\nmí\nantes\nalgunos\nqué\nunos\nyo\notro\notras\notra\nél\ntanto\nesa\nestos\nmucho\nquienes\nnada\nmuchos\ncual\npoco\nella\nestar\nestas\nalgunas\nalgo\nnosotros\nmi\nmis\ntú\nte\nti\ntu\ntus\nellas\nnosotras\nvosotros\nvosotras\nos\nmío\nmía\nmíos\nmías\ntuyo\ntuya\ntuyos\ntuyas\nsuyo\nsuya\nsuyos\nsuyas\nnuestro\nnuestra\nnuestros\nnuestras\nvuestro\nvuestra\nvuestros\nvuestras\nesos\nesas\nestoy\nestás\nestá\nestamos\nestáis\nestán\nesté\nestés\nestemos\nestéis\nestén\nestaré\nestarás\nestará\nestaremos\nestaréis\nestarán\nestaría\nestarías\nestaríamos\nestaríais\nestarían\nestaba\nestabas\nestábamos\nestabais\nestaban\nestuve\nestuviste\nestuvo\nestuvimos\nestuvisteis\nestuvieron\nestuviera\nestuvieras\nestuviéramos\nestuvierais\nestuvieran\nestuviese\nestuvieses\nestuviésemos\nestuvieseis\nestuviesen\nestando\nestado\nestada\nestados\nestadas\nestad\nhe\nhas\nha\nhemos\nhabéis\nhan\nhaya\nhayas\nhayamos\nhayáis\nhayan\nhabré\nhabrás\nhabrá\nhabremos\nhabréis\nhabrán\nhabría\nhabrías\nhabríamos\nhabríais\nhabrían\nhabía\nhabías\nhabíamos\nhabíais\nhabían\nhube\nhubiste\nhubo\nhubimos\nhubisteis\nhubieron\nhubiera\nhubieras\nhubiéramos\nhubierais\nhubieran\nhubiese\nhubieses\nhubiésemos\nhubieseis\nhubiesen\nhabiendo\nhabido\nhabida\nhabidos\nhabidas\nsoy\neres\nes\nsomos\nsois\nson\nsea\nseas\nseamos\nseáis\nsean\nseré\nserás\nserá\nseremos\nseréis\nserán\nsería\nserías\nseríamos\nseríais\nserían\nera\neras\néramos\nerais\neran\nfui\nfuiste\nfue\nfuimos\nfuisteis\nfueron\nfuera\nfueras\nfuéramos\nfuerais\nfueran\nfuese\nfueses\nfuésemos\nfueseis\nfuesen\nsiendo\nsido\ntengo\ntienes\ntiene\ntenemos\ntenéis\ntienen\ntenga\ntengas\ntengamos\ntengáis\ntengan\ntendré\ntendrás\ntendrá\ntendremos\ntendréis\ntendrán\ntendría\ntendrías\ntendríamos\ntendríais\ntendrían\ntenía\ntenías\nteníamos\nteníais\ntenían\ntuve\ntuviste\ntuvo\ntuvimos\ntuvisteis\ntuvieron\ntuviera\ntuvieras\ntuviéramos\ntuvierais\ntuvieran\ntuviese\ntuvieses\ntuviésemos\ntuvieseis\ntuviesen\nteniendo\ntenido\ntenida\ntenidos\ntenidas\ntened\n"
+  synonyms: "drupal, durpal\n"
+  nouns: ''
+  protwords: ''
+  accents: "# À => A\n\"\\u00C0\" => \"A\"\n# Á => A\n#\"\\u00C1\" => \"A\"\n# Â => A\n\"\\u00C2\" => \"A\"\n# Ã => A\n\"\\u00C3\" => \"A\"\n# Ä => A\n\"\\u00C4\" => \"A\"\n# Å => A\n\"\\u00C5\" => \"A\"\n# Ą => A\n\"\\u0104\" => \"A\"\n# Æ => AE\n\"\\u00C6\" => \"AE\"\n# Ç => C\n\"\\u00C7\" => \"C\"\n# Ć => C\n\"\\U0106\" => \"C\"\n# È => E\n\"\\u00C8\" => \"E\"\n# É => E\n#\"\\u00C9\" => \"E\"\n# Ê => E\n\"\\u00CA\" => \"E\"\n# Ë => E\n\"\\u00CB\" => \"E\"\n# Ę => E\n\"\\u0118\" => \"E\"\n# Ì => I\n\"\\u00CC\" => \"I\"\n# Í => I\n#\"\\u00CD\" => \"I\"\n# Î => I\n\"\\u00CE\" => \"I\"\n# Ï => I\n\"\\u00CF\" => \"I\"\n# Ĳ => IJ\n\"\\u0132\" => \"IJ\"\n# Ð => D\n\"\\u00D0\" => \"D\"\n# Ł => L\n\"\\u0141\" => \"L\"\n# Ñ => N\n#\"\\u00D1\" => \"N\"\n# Ń => N\n\"\\u0143\" => \"N\"\n# Ò => O\n\"\\u00D2\" => \"O\"\n# Ó => O\n#\"\\u00D3\" => \"O\"\n# Ô => O\n\"\\u00D4\" => \"O\"\n# Õ => O\n\"\\u00D5\" => \"O\"\n# Ö => O\n\"\\u00D6\" => \"O\"\n# Ø => O\n\"\\u00D8\" => \"O\"\n# Œ => OE\n\"\\u0152\" => \"OE\"\n# Þ\n\"\\u00DE\" => \"TH\"\n# Ù => U\n\"\\u00D9\" => \"U\"\n# Ú => U\n#\"\\u00DA\" => \"U\"\n# Û => U\n\"\\u00DB\" => \"U\"\n# Ü => U\n\"\\u00DC\" => \"U\"\n# Ý => Y\n\"\\u00DD\" => \"Y\"\n# Ÿ => Y\n\"\\u0178\" => \"Y\"\n# à => a\n\"\\u00E0\" => \"a\"\n# á => a\n#\"\\u00E1\" => \"a\"\n# â => a\n\"\\u00E2\" => \"a\"\n# ã => a\n\"\\u00E3\" => \"a\"\n# ä => a\n\"\\u00E4\" => \"a\"\n# å => a\n\"\\u00E5\" => \"a\"\n# æ => ae\n\"\\u00E6\" => \"ae\"\n# ç => c\n\"\\u00E7\" => \"c\"\n# è => e\n\"\\u00E8\" => \"e\"\n# é => e\n#\"\\u00E9\" => \"e\"\n# ê => e\n\"\\u00EA\" => \"e\"\n# ë => e\n\"\\u00EB\" => \"e\"\n# ì => i\n\"\\u00EC\" => \"i\"\n# í => i\n#\"\\u00ED\" => \"i\"\n# î => i\n\"\\u00EE\" => \"i\"\n# ï => i\n\"\\u00EF\" => \"i\"\n# ĳ => ij\n\"\\u0133\" => \"ij\"\n# ð => d\n\"\\u00F0\" => \"d\"\n# ñ => n\n#\"\\u00F1\" => \"n\"\n# ò => o\n\"\\u00F2\" => \"o\"\n# ó => o\n#\"\\u00F3\" => \"o\"\n# ô => o\n\"\\u00F4\" => \"o\"\n# õ => o\n\"\\u00F5\" => \"o\"\n# ö => o\n\"\\u00F6\" => \"o\"\n# ø => o\n\"\\u00F8\" => \"o\"\n# œ => oe\n\"\\u0153\" => \"oe\"\n# ß => ss\n\"\\u00DF\" => \"ss\"\n# Ś => S\n\"\\u015a\" => \"S\"\n# þ => th\n\"\\u00FE\" => \"th\"\n# ù => u\n\"\\u00F9\" => \"u\"\n# ú => u\n#\"\\u00FA\" => \"u\"\n# û => u\n\"\\u00FB\" => \"u\"\n# ü => u\n\"\\u00FC\" => \"u\"\n# ý => y\n\"\\u00FD\" => \"y\"\n# ÿ => y\n\"\\u00FF\" => \"y\"\n# Ź => Z\n\"\\u0179\" => \"Z\"\n# Ż => Z\n\"\\u017b\" => \"Z\"\n# ﬀ => ff\n\"\\uFB00\" => \"ff\"\n# ﬁ => fi\n\"\\uFB01\" => \"fi\"\n# ﬂ => fl\n\"\\uFB02\" => \"fl\"\n# ﬃ => ffi\n\"\\uFB03\" => \"ffi\"\n# ﬄ => ffl\n\"\\uFB04\" => \"ffl\"\n# ﬅ => st\n\"\\uFB05\" => \"st\"\n# ﬆ => st\n\"\\uFB06\" => \"st\"\n"

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_fr_6_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_fr_6_0_0.yml
@@ -1,0 +1,240 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_fr_6_0_0
+label: 'French Text Field'
+minimum_solr_version: 6.0.0
+custom_code: ''
+field_type_language_code: fr
+domains: {  }
+field_type:
+  name: text_fr
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_fr.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.ElisionFilterFactory
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_fr.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_fr.txt
+        -
+          class: solr.SnowballPorterFilterFactory
+          language: French
+          protected: protwords_fr.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_fr.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.ElisionFilterFactory
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 0
+          protected: protwords_fr.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.SynonymFilterFactory
+          synonyms: synonyms_fr.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_fr.txt
+        -
+          class: solr.SnowballPorterFilterFactory
+          language: French
+          protected: protwords_fr.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type:
+  name: text_unstemmed_fr
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_fr.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.ElisionFilterFactory
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_fr.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_fr.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_fr.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 0
+          protected: protwords_fr.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.SynonymFilterFactory
+          synonyms: synonyms_fr.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_fr.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+spellcheck_field_type: null
+collated_field_type:
+  name: collated_fr
+  class: solr.ICUCollationField
+  locale: fr
+  strength: primary
+  caseLevel: false
+solr_configs:
+  searchComponents:
+    -
+      name: spellcheck
+      class: solr.SpellCheckComponent
+      lst:
+        -
+          name: spellchecker
+          str:
+            -
+              name: name
+              VALUE: fr
+            -
+              name: field
+              VALUE: spellcheck_fr
+            -
+              name: classname
+              VALUE: solr.DirectSolrSpellChecker
+            -
+              name: distanceMeasure
+              VALUE: internal
+            -
+              name: accuracy
+              VALUE: '0.5'
+            -
+              name: maxEdits
+              VALUE: '2'
+            -
+              name: minPrefix
+              VALUE: '1'
+            -
+              name: maxInspections
+              VALUE: '5'
+            -
+              name: minQueryLength
+              VALUE: '4'
+            -
+              name: maxQueryFrequency
+              VALUE: '0.01'
+            -
+              name: thresholdTokenFrequency
+              VALUE: '.01'
+            -
+              name: onlyMorePopular
+              VALUE: 'true'
+    -
+      name: suggest
+      class: solr.SuggestComponent
+      lst:
+        -
+          name: suggester
+          str:
+            -
+              name: name
+              VALUE: fr
+            -
+              name: lookupImpl
+              VALUE: AnalyzingInfixLookupFactory
+            -
+              name: dictionaryImpl
+              VALUE: DocumentDictionaryFactory
+            -
+              name: field
+              VALUE: twm_suggest
+            -
+              name: suggestAnalyzerFieldType
+              VALUE: text_fr
+            -
+              name: contextField
+              VALUE: sm_context_tags
+            -
+              name: buildOnCommit
+              VALUE: 'true'
+            -
+              name: buildOnStartup
+              VALUE: 'false'
+text_files:
+  stopwords: "au\naux\navec\nce\nces\ndans\nde\ndes\ndu\nelle\nen\net\neux\nil\nje\nla\nle\nleur\nlui\nma\nmais\nme\nmême\nmes\nmoi\nmon\nne\nnos\nnotre\nnous\non\nou\npar\npas\npour\nqu\nque\nqui\nsa\nse\nses\nson\nsur\nta\nte\ntes\ntoi\nton\ntu\nun\nune\nvos\nvotre\nvous\nc\nd\nj\nl\nà\nm\nn\ns\nt\ny\nété\nétée\nétées\nétés\nétant\nsuis\nes\nest\nsommes\nêtes\nsont\nserai\nseras\nsera\nserons\nserez\nseront\nserais\nserait\nserions\nseriez\nseraient\nétais\nétait\nétions\nétiez\nétaient\nfus\nfut\nfûmes\nfûtes\nfurent\nsois\nsoit\nsoyons\nsoyez\nsoient\nfusse\nfusses\nfût\nfussions\nfussiez\nfussent\nayant\neu\neue\neues\neus\nai\nas\navons\navez\nont\naurai\nauras\naura\naurons\naurez\nauront\naurais\naurait\naurions\nauriez\nauraient\navais\navait\navions\naviez\navaient\neut\neûmes\neûtes\neurent\naie\naies\nait\nayons\nayez\naient\neusse\neusses\neût\neussions\neussiez\neussent\nceci\ncelà\ncet\ncette\nici\nils\nles\nleurs\nquel\nquels\nquelle\nquelles\nsans\nsoi\n"
+  synonyms: "drupal, durpal\n"
+  nouns: ''
+  protwords: ''
+  accents: "# À => A\n\"\\u00C0\" => \"A\"\n# Á => A\n#\"\\u00C1\" => \"A\"\n# Â => A\n\"\\u00C2\" => \"A\"\n# Ã => A\n#\"\\u00C3\" => \"A\"\n# Ä => A\n#\"\\u00C4\" => \"A\"\n# Å => A\n#\"\\u00C5\" => \"A\"\n# Ą => A\n#\"\\u0104\" => \"A\"\n# Æ => AE\n\"\\u00C6\" => \"AE\"\n# Ç => C\n\"\\u00C7\" => \"C\"\n# Ć => C\n#\"\\U0106\" => \"C\"\n# È => E\n\"\\u00C8\" => \"E\"\n# É => E\n\"\\u00C9\" => \"E\"\n# Ê => E\n\"\\u00CA\" => \"E\"\n# Ë => E\n#\"\\u00CB\" => \"E\"\n# Ę => E\n#\"\\u0118\" => \"E\"\n# Ì => I\n#\"\\u00CC\" => \"I\"\n# Í => I\n#\"\\u00CD\" => \"I\"\n# Î => I\n\"\\u00CE\" => \"I\"\n# Ï => I\n#\"\\u00CF\" => \"I\"\n# Ĳ => IJ\n#\"\\u0132\" => \"IJ\"\n# Ð => D\n#\"\\u00D0\" => \"D\"\n# Ł => L\n#\"\\u0141\" => \"L\"\n# Ñ => N\n#\"\\u00D1\" => \"N\"\n# Ń => N\n#\"\\u0143\" => \"N\"\n# Ò => O\n#\"\\u00D2\" => \"O\"\n# Ó => O\n#\"\\u00D3\" => \"O\"\n# Ô => O\n\"\\u00D4\" => \"O\"\n# Õ => O\n#\"\\u00D5\" => \"O\"\n# Ö => O\n#\"\\u00D6\" => \"O\"\n# Ø => O\n#\"\\u00D8\" => \"O\"\n# Œ => OE\n\"\\u0152\" => \"OE\"\n# Þ\n#\"\\u00DE\" => \"TH\"\n# Ù => U\n\"\\u00D9\" => \"U\"\n# Ú => U\n#\"\\u00DA\" => \"U\"\n# Û => U\n\"\\u00DB\" => \"U\"\n# Ü => U\n#\"\\u00DC\" => \"U\"\n# Ý => Y\n#\"\\u00DD\" => \"Y\"\n# Ÿ => Y\n#\"\\u0178\" => \"Y\"\n# à => a\n\"\\u00E0\" => \"a\"\n# á => a\n#\"\\u00E1\" => \"a\"\n# â => a\n\"\\u00E2\" => \"a\"\n# ã => a\n#\"\\u00E3\" => \"a\"\n# ä => a\n#\"\\u00E4\" => \"a\"\n# å => a\n#\"\\u00E5\" => \"a\"\n# æ => ae\n\"\\u00E6\" => \"ae\"\n# ç => c\n\"\\u00E7\" => \"c\"\n# è => e\n\"\\u00E8\" => \"e\"\n# é => e\n\"\\u00E9\" => \"e\"\n# ê => e\n\"\\u00EA\" => \"e\"\n# ë => e\n#\"\\u00EB\" => \"e\"\n# ì => i\n#\"\\u00EC\" => \"i\"\n# í => i\n#\"\\u00ED\" => \"i\"\n# î => i\n\"\\u00EE\" => \"i\"\n# ï => i\n#\"\\u00EF\" => \"i\"\n# ĳ => ij\n#\"\\u0133\" => \"ij\"\n# ð => d\n#\"\\u00F0\" => \"d\"\n# ñ => n\n#\"\\u00F1\" => \"n\"\n# ò => o\n#\"\\u00F2\" => \"o\"\n# ó => o\n#\"\\u00F3\" => \"o\"\n# ô => o\n\"\\u00F4\" => \"o\"\n# õ => o\n#\"\\u00F5\" => \"o\"\n# ö => o\n#\"\\u00F6\" => \"o\"\n# ø => o\n#\"\\u00F8\" => \"o\"\n# œ => oe\n\"\\u0153\" => \"oe\"\n# ß => ss\n#\"\\u00DF\" => \"ss\"\n# Ś => S\n#\"\\u015a\" => \"S\"\n# þ => th\n#\"\\u00FE\" => \"th\"\n# ù => u\n\"\\u00F9\" => \"u\"\n# ú => u\n#\"\\u00FA\" => \"u\"\n# û => u\n\"\\u00FB\" => \"u\"\n# ü => u\n\"\\u00FC\" => \"u\"\n# ý => y\n#\"\\u00FD\" => \"y\"\n# ÿ => y\n#\"\\u00FF\" => \"y\"\n# Ź => Z\n#\"\\u0179\" => \"Z\"\n# Ż => Z\n#\"\\u017b\" => \"Z\"\n# ﬀ => ff\n#\"\\uFB00\" => \"ff\"\n# ﬁ => fi\n#\"\\uFB01\" => \"fi\"\n# ﬂ => fl\n#\"\\uFB02\" => \"fl\"\n# ﬃ => ffi\n#\"\\uFB03\" => \"ffi\"\n# ﬄ => ffl\n#\"\\uFB04\" => \"ffl\"\n# ﬅ => st\n#\"\\uFB05\" => \"st\"\n# ﬆ => st\n#\"\\uFB06\" => \"st\"\n"

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_fr_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_fr_7_0_0.yml
@@ -1,0 +1,240 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_fr_7_0_0
+label: 'French Text Field'
+minimum_solr_version: 7.0.0
+custom_code: ''
+field_type_language_code: fr
+domains: {  }
+field_type:
+  name: text_fr
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_fr.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.ElisionFilterFactory
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_fr.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_fr.txt
+        -
+          class: solr.SnowballPorterFilterFactory
+          language: French
+          protected: protwords_fr.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_fr.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.ElisionFilterFactory
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 0
+          protected: protwords_fr.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.SynonymGraphFilterFactory
+          synonyms: synonyms_fr.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_fr.txt
+        -
+          class: solr.SnowballPorterFilterFactory
+          language: French
+          protected: protwords_fr.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type:
+  name: text_unstemmed_fr
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_fr.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.ElisionFilterFactory
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_fr.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_fr.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_fr.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 0
+          protected: protwords_fr.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.SynonymGraphFilterFactory
+          synonyms: synonyms_fr.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_fr.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+spellcheck_field_type: null
+collated_field_type:
+  name: collated_fr
+  class: solr.ICUCollationField
+  locale: fr
+  strength: primary
+  caseLevel: false
+solr_configs:
+  searchComponents:
+    -
+      name: spellcheck
+      class: solr.SpellCheckComponent
+      lst:
+        -
+          name: spellchecker
+          str:
+            -
+              name: name
+              VALUE: fr
+            -
+              name: field
+              VALUE: spellcheck_fr
+            -
+              name: classname
+              VALUE: solr.DirectSolrSpellChecker
+            -
+              name: distanceMeasure
+              VALUE: internal
+            -
+              name: accuracy
+              VALUE: '0.5'
+            -
+              name: maxEdits
+              VALUE: '2'
+            -
+              name: minPrefix
+              VALUE: '1'
+            -
+              name: maxInspections
+              VALUE: '5'
+            -
+              name: minQueryLength
+              VALUE: '4'
+            -
+              name: maxQueryFrequency
+              VALUE: '0.01'
+            -
+              name: thresholdTokenFrequency
+              VALUE: '.01'
+            -
+              name: onlyMorePopular
+              VALUE: 'true'
+    -
+      name: suggest
+      class: solr.SuggestComponent
+      lst:
+        -
+          name: suggester
+          str:
+            -
+              name: name
+              VALUE: fr
+            -
+              name: lookupImpl
+              VALUE: AnalyzingInfixLookupFactory
+            -
+              name: dictionaryImpl
+              VALUE: DocumentDictionaryFactory
+            -
+              name: field
+              VALUE: twm_suggest
+            -
+              name: suggestAnalyzerFieldType
+              VALUE: text_fr
+            -
+              name: contextField
+              VALUE: sm_context_tags
+            -
+              name: buildOnCommit
+              VALUE: 'true'
+            -
+              name: buildOnStartup
+              VALUE: 'false'
+text_files:
+  stopwords: "au\naux\navec\nce\nces\ndans\nde\ndes\ndu\nelle\nen\net\neux\nil\nje\nla\nle\nleur\nlui\nma\nmais\nme\nmême\nmes\nmoi\nmon\nne\nnos\nnotre\nnous\non\nou\npar\npas\npour\nqu\nque\nqui\nsa\nse\nses\nson\nsur\nta\nte\ntes\ntoi\nton\ntu\nun\nune\nvos\nvotre\nvous\nc\nd\nj\nl\nà\nm\nn\ns\nt\ny\nété\nétée\nétées\nétés\nétant\nsuis\nes\nest\nsommes\nêtes\nsont\nserai\nseras\nsera\nserons\nserez\nseront\nserais\nserait\nserions\nseriez\nseraient\nétais\nétait\nétions\nétiez\nétaient\nfus\nfut\nfûmes\nfûtes\nfurent\nsois\nsoit\nsoyons\nsoyez\nsoient\nfusse\nfusses\nfût\nfussions\nfussiez\nfussent\nayant\neu\neue\neues\neus\nai\nas\navons\navez\nont\naurai\nauras\naura\naurons\naurez\nauront\naurais\naurait\naurions\nauriez\nauraient\navais\navait\navions\naviez\navaient\neut\neûmes\neûtes\neurent\naie\naies\nait\nayons\nayez\naient\neusse\neusses\neût\neussions\neussiez\neussent\nceci\ncelà\ncet\ncette\nici\nils\nles\nleurs\nquel\nquels\nquelle\nquelles\nsans\nsoi\n"
+  synonyms: "drupal, durpal\n"
+  nouns: ''
+  protwords: ''
+  accents: "# À => A\n\"\\u00C0\" => \"A\"\n# Á => A\n#\"\\u00C1\" => \"A\"\n# Â => A\n\"\\u00C2\" => \"A\"\n# Ã => A\n#\"\\u00C3\" => \"A\"\n# Ä => A\n#\"\\u00C4\" => \"A\"\n# Å => A\n#\"\\u00C5\" => \"A\"\n# Ą => A\n#\"\\u0104\" => \"A\"\n# Æ => AE\n\"\\u00C6\" => \"AE\"\n# Ç => C\n\"\\u00C7\" => \"C\"\n# Ć => C\n#\"\\U0106\" => \"C\"\n# È => E\n\"\\u00C8\" => \"E\"\n# É => E\n\"\\u00C9\" => \"E\"\n# Ê => E\n\"\\u00CA\" => \"E\"\n# Ë => E\n#\"\\u00CB\" => \"E\"\n# Ę => E\n#\"\\u0118\" => \"E\"\n# Ì => I\n#\"\\u00CC\" => \"I\"\n# Í => I\n#\"\\u00CD\" => \"I\"\n# Î => I\n\"\\u00CE\" => \"I\"\n# Ï => I\n#\"\\u00CF\" => \"I\"\n# Ĳ => IJ\n#\"\\u0132\" => \"IJ\"\n# Ð => D\n#\"\\u00D0\" => \"D\"\n# Ł => L\n#\"\\u0141\" => \"L\"\n# Ñ => N\n#\"\\u00D1\" => \"N\"\n# Ń => N\n#\"\\u0143\" => \"N\"\n# Ò => O\n#\"\\u00D2\" => \"O\"\n# Ó => O\n#\"\\u00D3\" => \"O\"\n# Ô => O\n\"\\u00D4\" => \"O\"\n# Õ => O\n#\"\\u00D5\" => \"O\"\n# Ö => O\n#\"\\u00D6\" => \"O\"\n# Ø => O\n#\"\\u00D8\" => \"O\"\n# Œ => OE\n\"\\u0152\" => \"OE\"\n# Þ\n#\"\\u00DE\" => \"TH\"\n# Ù => U\n\"\\u00D9\" => \"U\"\n# Ú => U\n#\"\\u00DA\" => \"U\"\n# Û => U\n\"\\u00DB\" => \"U\"\n# Ü => U\n#\"\\u00DC\" => \"U\"\n# Ý => Y\n#\"\\u00DD\" => \"Y\"\n# Ÿ => Y\n#\"\\u0178\" => \"Y\"\n# à => a\n\"\\u00E0\" => \"a\"\n# á => a\n#\"\\u00E1\" => \"a\"\n# â => a\n\"\\u00E2\" => \"a\"\n# ã => a\n#\"\\u00E3\" => \"a\"\n# ä => a\n#\"\\u00E4\" => \"a\"\n# å => a\n#\"\\u00E5\" => \"a\"\n# æ => ae\n\"\\u00E6\" => \"ae\"\n# ç => c\n\"\\u00E7\" => \"c\"\n# è => e\n\"\\u00E8\" => \"e\"\n# é => e\n\"\\u00E9\" => \"e\"\n# ê => e\n\"\\u00EA\" => \"e\"\n# ë => e\n#\"\\u00EB\" => \"e\"\n# ì => i\n#\"\\u00EC\" => \"i\"\n# í => i\n#\"\\u00ED\" => \"i\"\n# î => i\n\"\\u00EE\" => \"i\"\n# ï => i\n#\"\\u00EF\" => \"i\"\n# ĳ => ij\n#\"\\u0133\" => \"ij\"\n# ð => d\n#\"\\u00F0\" => \"d\"\n# ñ => n\n#\"\\u00F1\" => \"n\"\n# ò => o\n#\"\\u00F2\" => \"o\"\n# ó => o\n#\"\\u00F3\" => \"o\"\n# ô => o\n\"\\u00F4\" => \"o\"\n# õ => o\n#\"\\u00F5\" => \"o\"\n# ö => o\n#\"\\u00F6\" => \"o\"\n# ø => o\n#\"\\u00F8\" => \"o\"\n# œ => oe\n\"\\u0153\" => \"oe\"\n# ß => ss\n#\"\\u00DF\" => \"ss\"\n# Ś => S\n#\"\\u015a\" => \"S\"\n# þ => th\n#\"\\u00FE\" => \"th\"\n# ù => u\n\"\\u00F9\" => \"u\"\n# ú => u\n#\"\\u00FA\" => \"u\"\n# û => u\n\"\\u00FB\" => \"u\"\n# ü => u\n\"\\u00FC\" => \"u\"\n# ý => y\n#\"\\u00FD\" => \"y\"\n# ÿ => y\n#\"\\u00FF\" => \"y\"\n# Ź => Z\n#\"\\u0179\" => \"Z\"\n# Ż => Z\n#\"\\u017b\" => \"Z\"\n# ﬀ => ff\n#\"\\uFB00\" => \"ff\"\n# ﬁ => fi\n#\"\\uFB01\" => \"fi\"\n# ﬂ => fl\n#\"\\uFB02\" => \"fl\"\n# ﬃ => ffi\n#\"\\uFB03\" => \"ffi\"\n# ﬄ => ffl\n#\"\\uFB04\" => \"ffl\"\n# ﬅ => st\n#\"\\uFB05\" => \"st\"\n# ﬆ => st\n#\"\\uFB06\" => \"st\"\n"

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_ngram_und_6_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_ngram_und_6_0_0.yml
@@ -1,0 +1,71 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_ngram_und_6_0_0
+label: 'NGram Text Field'
+minimum_solr_version: 6.0.0
+custom_code: ngram
+field_type_language_code: und
+domains: {  }
+field_type:
+  name: text_ngram
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_und.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_und.txt
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_und.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+        -
+          class: solr.NGramFilterFactory
+          minGramSize: 2
+          maxGramSize: 25
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_und.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+solr_configs: {  }
+text_files: {  }

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_ngram_und_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_ngram_und_7_0_0.yml
@@ -1,0 +1,71 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_ngram_und_7_0_0
+label: 'NGram Text Field'
+minimum_solr_version: 7.0.0
+custom_code: ngram
+field_type_language_code: und
+domains: {  }
+field_type:
+  name: text_ngram
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_und.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_und.txt
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_und.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+        -
+          class: solr.NGramFilterFactory
+          minGramSize: 2
+          maxGramSize: 25
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_und.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+solr_configs: {  }
+text_files: {  }

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_ngramstring_und_6_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_ngramstring_und_6_0_0.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_ngramstring_und_6_0_0
+label: 'NGram String Field'
+minimum_solr_version: 6.0.0
+custom_code: ngramstring
+field_type_language_code: und
+domains: {  }
+field_type:
+  name: text_ngramstring
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      tokenizer:
+        class: solr.KeywordTokenizerFactory
+      filters:
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+        -
+          class: solr.NGramFilterFactory
+          minGramSize: 2
+          maxGramSize: 25
+    -
+      type: query
+      tokenizer:
+        class: solr.KeywordTokenizerFactory
+      filters:
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+solr_configs: {  }
+text_files: {  }

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_phonetic_en_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_phonetic_en_7_0_0.yml
@@ -1,0 +1,85 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_phonetic_en_7_0_0
+label: 'Fulltext Phonetic English'
+minimum_solr_version: 7.0.0
+custom_code: phonetic
+field_type_language_code: en
+domains: {  }
+field_type:
+  name: text_phonetic_en
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_en.txt
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_en.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.BeiderMorseFilterFactory
+          languageSet: english
+          nameType: GENERIC
+          ruleType: APPROX
+          concat: true
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_en.txt
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 1
+          protected: protwords_en.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.BeiderMorseFilterFactory
+          languageSet: english
+          nameType: GENERIC
+          ruleType: APPROX
+          concat: true
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+solr_configs: {  }
+text_files: {  }

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_phonetic_es_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_phonetic_es_7_0_0.yml
@@ -1,0 +1,77 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_phonetic_es_7_0_0
+label: 'Fulltext Phonetic Spanish'
+minimum_solr_version: 7.0.0
+custom_code: phonetic
+field_type_language_code: es
+domains: {  }
+field_type:
+  name: text_phonetic_es
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_es.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_es.txt
+        -
+          class: solr.BeiderMorseFilterFactory
+          languageSet: spanish
+          nameType: GENERIC
+          ruleType: APPROX
+          concat: true
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 0
+          protected: protwords_es.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_es.txt
+        -
+          class: solr.BeiderMorseFilterFactory
+          languageSet: spanish
+          nameType: GENERIC
+          ruleType: APPROX
+          concat: true
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+solr_configs: {  }
+text_files: {  }

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_phonetic_fr_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_phonetic_fr_7_0_0.yml
@@ -1,0 +1,79 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_phonetic_fr_7_0_0
+label: 'Fulltext Phonetic French'
+minimum_solr_version: 7.0.0
+custom_code: phonetic
+field_type_language_code: fr
+domains: {  }
+field_type:
+  name: text_phonetic_fr
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.ElisionFilterFactory
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_fr.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_fr.txt
+        -
+          class: solr.BeiderMorseFilterFactory
+          languageSet: french
+          nameType: GENERIC
+          ruleType: APPROX
+          concat: true
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 0
+          protected: protwords_fr.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_fr.txt
+        -
+          class: solr.BeiderMorseFilterFactory
+          languageSet: french
+          nameType: GENERIC
+          ruleType: APPROX
+          concat: true
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+solr_configs: {  }
+text_files: {  }

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_phonetic_und_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_phonetic_und_7_0_0.yml
@@ -1,0 +1,85 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_phonetic_und_7_0_0
+label: 'Fulltext Phonetic'
+minimum_solr_version: 7.0.0
+custom_code: phonetic
+field_type_language_code: und
+domains: {  }
+field_type:
+  name: text_phonetic_und
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_und.txt
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_und.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.BeiderMorseFilterFactory
+          languageSet: auto
+          nameType: GENERIC
+          ruleType: APPROX
+          concat: true
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_und.txt
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 1
+          protected: protwords_und.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.BeiderMorseFilterFactory
+          languageSet: auto
+          nameType: GENERIC
+          ruleType: APPROX
+          concat: true
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+solr_configs: {  }
+text_files: {  }

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_pt-pt_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_pt-pt_7_0_0.yml
@@ -1,0 +1,230 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_pt-pt_7_0_0
+label: 'Portuguese, Portugal Text Field'
+minimum_solr_version: 7.0.0
+custom_code: ''
+field_type_language_code: pt-pt
+domains: {  }
+field_type:
+  name: text_pt_pt
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_pt_pt.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_pt_pt.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_pt_pt.txt
+        -
+          class: solr.PortugueseStemFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_pt_pt.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 0
+          protected: protwords_pt_pt.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_pt_pt.txt
+        -
+          class: solr.SynonymGraphFilterFactory
+          synonyms: synonyms_pt_pt.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.PortugueseStemFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type:
+  name: text_unstemmed_pt_pt
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_pt_pt.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_pt_pt.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_pt_pt.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_pt_pt.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 0
+          protected: protwords_pt_pt.txt
+          splitOnCaseChange: 1
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.SynonymGraphFilterFactory
+          synonyms: synonyms_pt_pt.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_pt_pt.txt
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+spellcheck_field_type: null
+collated_field_type:
+  name: collated_pt_pt
+  class: solr.ICUCollationField
+  locale: pt
+  strength: primary
+  caseLevel: false
+solr_configs:
+  searchComponents:
+    -
+      name: spellcheck
+      class: solr.SpellCheckComponent
+      lst:
+        -
+          name: spellchecker
+          str:
+            -
+              name: name
+              VALUE: pt_pt
+            -
+              name: field
+              VALUE: spellcheck_pt_pt
+            -
+              name: classname
+              VALUE: solr.DirectSolrSpellChecker
+            -
+              name: distanceMeasure
+              VALUE: internal
+            -
+              name: accuracy
+              VALUE: '0.5'
+            -
+              name: maxEdits
+              VALUE: '2'
+            -
+              name: minPrefix
+              VALUE: '1'
+            -
+              name: maxInspections
+              VALUE: '5'
+            -
+              name: minQueryLength
+              VALUE: '4'
+            -
+              name: maxQueryFrequency
+              VALUE: '0.01'
+            -
+              name: thresholdTokenFrequency
+              VALUE: '.01'
+            -
+              name: onlyMorePopular
+              VALUE: 'true'
+    -
+      name: suggest
+      class: solr.SuggestComponent
+      lst:
+        -
+          name: suggester
+          str:
+            -
+              name: name
+              VALUE: pt_pt
+            -
+              name: lookupImpl
+              VALUE: AnalyzingInfixLookupFactory
+            -
+              name: dictionaryImpl
+              VALUE: DocumentDictionaryFactory
+            -
+              name: field
+              VALUE: twm_suggest
+            -
+              name: suggestAnalyzerFieldType
+              VALUE: text_pt_pt
+            -
+              name: contextField
+              VALUE: sm_context_tags
+            -
+              name: buildOnCommit
+              VALUE: 'true'
+            -
+              name: buildOnStartup
+              VALUE: 'false'
+text_files:
+  stopwords: "de\na\no\nque\ne\ndo\nda\nem\num\npara\né\ncom\nnão\numa\nos\nno\nse\nna\npor\nmais\nas\ndos\ncomo\nmas\nfoi\nao\nele\ndas\ntem\nà\nseu\nsua\nou\nser\nquando\nmuito\nhá\nnos\njá\nestá\neu\ntambém\nsó\npelo\npela\naté\nisso\nela\nentre\nera\ndepois\nsem\nmesmo\naos\nter\nseus\nquem\nnas\nme\nesse\neles\nestão\nvocê\ntinha\nforam\nessa\nnum\nnem\nsuas\nmeu\nàs\nminha\ntêm\nnuma\npelos\nelas\nhavia\nseja\nqual\nserá\nnós\ntenho\nlhe\ndeles\nessas\nesses\npelas\neste\nfosse\ndele\ntu\nte\nvocês\nvos\nlhes\nmeus\nminhas\nteu\ntua\nteus\ntuas\nnosso\nnossa\nnossos\nnossas\ndela\ndelas\nesta\nestes\nestas\naquele\naquela\naqueles\naquelas\nisto\naquilo\nestou\nestá\nestamos\nestão\nestive\nesteve\nestivemos\nestiveram\nestava\nestávamos\nestavam\nestivera\nestivéramos\nesteja\nestejamos\nestejam\nestivesse\nestivéssemos\nestivessem\nestiver\nestivermos\nestiverem\nhei\nhá\nhavemos\nhão\nhouve\nhouvemos\nhouveram\nhouvera\nhouvéramos\nhaja\nhajamos\nhajam\nhouvesse\nhouvéssemos\nhouvessem\nhouver\nhouvermos\nhouverem\nhouverei\nhouverá\nhouveremos\nhouverão\nhouveria\nhouveríamos\nhouveriam\nsou\nsomos\nsão\nera\néramos\neram\nfui\nfoi\nfomos\nforam\nfora\nfôramos\nseja\nsejamos\nsejam\nfosse\nfôssemos\nfossem\nfor\nformos\nforem\nserei\nserá\nseremos\nserão\nseria\nseríamos\nseriam\ntenho\ntem\ntemos\ntém\ntinha\ntínhamos\ntinham\ntive\nteve\ntivemos\ntiveram\ntivera\ntivéramos\ntenha\ntenhamos\ntenham\ntivesse\ntivéssemos\ntivessem\ntiver\ntivermos\ntiverem\nterei\nterá\nteremos\nterão\nteria\nteríamos\nteriam\n"
+  synonyms: "drupal, durpal\n"
+  nouns: ''
+  protwords: ''
+  accents: "# À => A\n\"\\u00C0\" => \"A\"\n# Á => A\n#\"\\u00C1\" => \"A\"\n# Â => A\n\"\\u00C2\" => \"A\"\n# Ã => A\n\"\\u00C3\" => \"A\"\n# Ä => A\n\"\\u00C4\" => \"A\"\n# Å => A\n\"\\u00C5\" => \"A\"\n# Ą => A\n\"\\u0104\" => \"A\"\n# Æ => AE\n\"\\u00C6\" => \"AE\"\n# Ç => C\n\"\\u00C7\" => \"C\"\n# Ć => C\n\"\\U0106\" => \"C\"\n# È => E\n\"\\u00C8\" => \"E\"\n# É => E\n#\"\\u00C9\" => \"E\"\n# Ê => E\n\"\\u00CA\" => \"E\"\n# Ë => E\n\"\\u00CB\" => \"E\"\n# Ę => E\n\"\\u0118\" => \"E\"\n# Ì => I\n\"\\u00CC\" => \"I\"\n# Í => I\n#\"\\u00CD\" => \"I\"\n# Î => I\n\"\\u00CE\" => \"I\"\n# Ï => I\n\"\\u00CF\" => \"I\"\n# Ĳ => IJ\n\"\\u0132\" => \"IJ\"\n# Ð => D\n\"\\u00D0\" => \"D\"\n# Ł => L\n\"\\u0141\" => \"L\"\n# Ñ => N\n#\"\\u00D1\" => \"N\"\n# Ń => N\n\"\\u0143\" => \"N\"\n# Ò => O\n\"\\u00D2\" => \"O\"\n# Ó => O\n#\"\\u00D3\" => \"O\"\n# Ô => O\n\"\\u00D4\" => \"O\"\n# Õ => O\n\"\\u00D5\" => \"O\"\n# Ö => O\n\"\\u00D6\" => \"O\"\n# Ø => O\n\"\\u00D8\" => \"O\"\n# Œ => OE\n\"\\u0152\" => \"OE\"\n# Þ\n\"\\u00DE\" => \"TH\"\n# Ù => U\n\"\\u00D9\" => \"U\"\n# Ú => U\n#\"\\u00DA\" => \"U\"\n# Û => U\n\"\\u00DB\" => \"U\"\n# Ü => U\n\"\\u00DC\" => \"U\"\n# Ý => Y\n\"\\u00DD\" => \"Y\"\n# Ÿ => Y\n\"\\u0178\" => \"Y\"\n# à => a\n\"\\u00E0\" => \"a\"\n# á => a\n#\"\\u00E1\" => \"a\"\n# â => a\n\"\\u00E2\" => \"a\"\n# ã => a\n\"\\u00E3\" => \"a\"\n# ä => a\n\"\\u00E4\" => \"a\"\n# å => a\n\"\\u00E5\" => \"a\"\n# æ => ae\n\"\\u00E6\" => \"ae\"\n# ç => c\n\"\\u00E7\" => \"c\"\n# è => e\n\"\\u00E8\" => \"e\"\n# é => e\n#\"\\u00E9\" => \"e\"\n# ê => e\n\"\\u00EA\" => \"e\"\n# ë => e\n\"\\u00EB\" => \"e\"\n# ì => i\n\"\\u00EC\" => \"i\"\n# í => i\n#\"\\u00ED\" => \"i\"\n# î => i\n\"\\u00EE\" => \"i\"\n# ï => i\n\"\\u00EF\" => \"i\"\n# ĳ => ij\n\"\\u0133\" => \"ij\"\n# ð => d\n\"\\u00F0\" => \"d\"\n# ñ => n\n#\"\\u00F1\" => \"n\"\n# ò => o\n\"\\u00F2\" => \"o\"\n# ó => o\n#\"\\u00F3\" => \"o\"\n# ô => o\n\"\\u00F4\" => \"o\"\n# õ => o\n\"\\u00F5\" => \"o\"\n# ö => o\n\"\\u00F6\" => \"o\"\n# ø => o\n\"\\u00F8\" => \"o\"\n# œ => oe\n\"\\u0153\" => \"oe\"\n# ß => ss\n\"\\u00DF\" => \"ss\"\n# Ś => S\n\"\\u015a\" => \"S\"\n# þ => th\n\"\\u00FE\" => \"th\"\n# ù => u\n\"\\u00F9\" => \"u\"\n# ú => u\n#\"\\u00FA\" => \"u\"\n# û => u\n\"\\u00FB\" => \"u\"\n# ü => u\n\"\\u00FC\" => \"u\"\n# ý => y\n\"\\u00FD\" => \"y\"\n# ÿ => y\n\"\\u00FF\" => \"y\"\n# Ź => Z\n\"\\u0179\" => \"Z\"\n# Ż => Z\n\"\\u017b\" => \"Z\"\n# ﬀ => ff\n\"\\uFB00\" => \"ff\"\n# ﬁ => fi\n\"\\uFB01\" => \"fi\"\n# ﬂ => fl\n\"\\uFB02\" => \"fl\"\n# ﬃ => ffi\n\"\\uFB03\" => \"ffi\"\n# ﬄ => ffl\n\"\\uFB04\" => \"ffl\"\n# ﬅ => st\n\"\\uFB05\" => \"st\"\n# ﬆ => st\n\"\\uFB06\" => \"st\"\n"

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_und_6_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_und_6_0_0.yml
@@ -1,0 +1,189 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_und_6_0_0
+label: 'Language Undefined Text Field'
+minimum_solr_version: 6.0.0
+custom_code: ''
+field_type_language_code: und
+domains: {  }
+field_type:
+  name: text_und
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_und.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_und.txt
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_und.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_und.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.SynonymFilterFactory
+          synonyms: synonyms_und.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_und.txt
+        -
+          class: solr.WordDelimiterFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 1
+          protected: protwords_und.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type: null
+spellcheck_field_type:
+  name: text_spell_und
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzer:
+    charFilters:
+      -
+        class: solr.MappingCharFilterFactory
+        mapping: accents_und.txt
+    tokenizer:
+      class: solr.WhitespaceTokenizerFactory
+    filters:
+      -
+        class: solr.LengthFilterFactory
+        min: 2
+        max: 100
+      -
+        class: solr.LowerCaseFilterFactory
+      -
+        class: solr.RemoveDuplicatesTokenFilterFactory
+collated_field_type:
+  name: collated_und
+  class: solr.ICUCollationField
+  locale: en
+  strength: primary
+  caseLevel: false
+solr_configs:
+  searchComponents:
+    -
+      name: spellcheck
+      class: solr.SpellCheckComponent
+      lst:
+        -
+          name: spellchecker
+          str:
+            -
+              name: name
+              VALUE: und
+            -
+              name: field
+              VALUE: spellcheck_und
+            -
+              name: classname
+              VALUE: solr.DirectSolrSpellChecker
+            -
+              name: distanceMeasure
+              VALUE: internal
+            -
+              name: accuracy
+              VALUE: '0.5'
+            -
+              name: maxEdits
+              VALUE: '2'
+            -
+              name: minPrefix
+              VALUE: '1'
+            -
+              name: maxInspections
+              VALUE: '5'
+            -
+              name: minQueryLength
+              VALUE: '4'
+            -
+              name: maxQueryFrequency
+              VALUE: '0.01'
+            -
+              name: thresholdTokenFrequency
+              VALUE: '.01'
+            -
+              name: onlyMorePopular
+              VALUE: 'true'
+    -
+      name: suggest
+      class: solr.SuggestComponent
+      lst:
+        -
+          name: suggester
+          str:
+            -
+              name: name
+              VALUE: und
+            -
+              name: lookupImpl
+              VALUE: AnalyzingInfixLookupFactory
+            -
+              name: dictionaryImpl
+              VALUE: DocumentDictionaryFactory
+            -
+              name: field
+              VALUE: twm_suggest
+            -
+              name: suggestAnalyzerFieldType
+              VALUE: text_und
+            -
+              name: contextField
+              VALUE: sm_context_tags
+            -
+              name: buildOnCommit
+              VALUE: 'true'
+            -
+              name: buildOnStartup
+              VALUE: 'false'
+text_files:
+  stopwords: ''
+  synonyms: "drupal, durpal\n"
+  protwords: ''
+  accents: "# À => A\n\"\\u00C0\" => \"A\"\n# Á => A\n\"\\u00C1\" => \"A\"\n# Â => A\n\"\\u00C2\" => \"A\"\n# Ã => A\n\"\\u00C3\" => \"A\"\n# Ä => A\n\"\\u00C4\" => \"A\"\n# Å => A\n\"\\u00C5\" => \"A\"\n# Æ => AE\n\"\\u00C6\" => \"AE\"\n# Ç => C\n\"\\u00C7\" => \"C\"\n# È => E\n\"\\u00C8\" => \"E\"\n# É => E\n\"\\u00C9\" => \"E\"\n# Ê => E\n\"\\u00CA\" => \"E\"\n# Ë => E\n\"\\u00CB\" => \"E\"\n# Ì => I\n\"\\u00CC\" => \"I\"\n# Í => I\n\"\\u00CD\" => \"I\"\n# Î => I\n\"\\u00CE\" => \"I\"\n# Ï => I\n\"\\u00CF\" => \"I\"\n# Ĳ => IJ\n\"\\u0132\" => \"IJ\"\n# Ð => D\n\"\\u00D0\" => \"D\"\n# Ñ => N\n\"\\u00D1\" => \"N\"\n# Ò => O\n\"\\u00D2\" => \"O\"\n# Ó => O\n\"\\u00D3\" => \"O\"\n# Ô => O\n\"\\u00D4\" => \"O\"\n# Õ => O\n\"\\u00D5\" => \"O\"\n# Ö => O\n\"\\u00D6\" => \"O\"\n# Ø => O\n\"\\u00D8\" => \"O\"\n# Œ => OE\n\"\\u0152\" => \"OE\"\n# Þ\n\"\\u00DE\" => \"TH\"\n# Ù => U\n\"\\u00D9\" => \"U\"\n# Ú => U\n\"\\u00DA\" => \"U\"\n# Û => U\n\"\\u00DB\" => \"U\"\n# Ü => U\n\"\\u00DC\" => \"U\"\n# Ý => Y\n\"\\u00DD\" => \"Y\"\n# Ÿ => Y\n\"\\u0178\" => \"Y\"\n# à => a\n\"\\u00E0\" => \"a\"\n# á => a\n\"\\u00E1\" => \"a\"\n# â => a\n\"\\u00E2\" => \"a\"\n# ã => a\n\"\\u00E3\" => \"a\"\n# ä => a\n\"\\u00E4\" => \"a\"\n# å => a\n\"\\u00E5\" => \"a\"\n# æ => ae\n\"\\u00E6\" => \"ae\"\n# ç => c\n\"\\u00E7\" => \"c\"\n# è => e\n\"\\u00E8\" => \"e\"\n# é => e\n\"\\u00E9\" => \"e\"\n# ê => e\n\"\\u00EA\" => \"e\"\n# ë => e\n\"\\u00EB\" => \"e\"\n# ì => i\n\"\\u00EC\" => \"i\"\n# í => i\n\"\\u00ED\" => \"i\"\n# î => i\n\"\\u00EE\" => \"i\"\n# ï => i\n\"\\u00EF\" => \"i\"\n# ĳ => ij\n\"\\u0133\" => \"ij\"\n# ð => d\n\"\\u00F0\" => \"d\"\n# ñ => n\n\"\\u00F1\" => \"n\"\n# ò => o\n\"\\u00F2\" => \"o\"\n# ó => o\n\"\\u00F3\" => \"o\"\n# ô => o\n\"\\u00F4\" => \"o\"\n# õ => o\n\"\\u00F5\" => \"o\"\n# ö => o\n\"\\u00F6\" => \"o\"\n# ø => o\n\"\\u00F8\" => \"o\"\n# œ => oe\n\"\\u0153\" => \"oe\"\n# ß => ss\n\"\\u00DF\" => \"ss\"\n# þ => th\n\"\\u00FE\" => \"th\"\n# ù => u\n\"\\u00F9\" => \"u\"\n# ú => u\n\"\\u00FA\" => \"u\"\n# û => u\n\"\\u00FB\" => \"u\"\n# ü => u\n\"\\u00FC\" => \"u\"\n# ý => y\n\"\\u00FD\" => \"y\"\n# ÿ => y\n\"\\u00FF\" => \"y\"\n# ﬀ => ff\n\"\\uFB00\" => \"ff\"\n# ﬁ => fi\n\"\\uFB01\" => \"fi\"\n# ﬂ => fl\n\"\\uFB02\" => \"fl\"\n# ﬃ => ffi\n\"\\uFB03\" => \"ffi\"\n# ﬄ => ffl\n\"\\uFB04\" => \"ffl\"\n# ﬅ => st\n\"\\uFB05\" => \"st\"\n# ﬆ => st\n\"\\uFB06\" => \"st\"\n"

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_und_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_und_7_0_0.yml
@@ -1,0 +1,189 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_und_7_0_0
+label: 'Language Undefined Text Field'
+minimum_solr_version: 7.0.0
+custom_code: ''
+field_type_language_code: und
+domains: {  }
+field_type:
+  name: text_und
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_und.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_und.txt
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 1
+          generateNumberParts: 1
+          protected: protwords_und.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 1
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+    -
+      type: query
+      charFilters:
+        -
+          class: solr.MappingCharFilterFactory
+          mapping: accents_und.txt
+      tokenizer:
+        class: solr.WhitespaceTokenizerFactory
+      filters:
+        -
+          class: solr.SynonymGraphFilterFactory
+          synonyms: synonyms_und.txt
+          expand: true
+          ignoreCase: true
+        -
+          class: solr.StopFilterFactory
+          ignoreCase: true
+          words: stopwords_und.txt
+        -
+          class: solr.WordDelimiterGraphFilterFactory
+          catenateNumbers: 0
+          generateNumberParts: 1
+          protected: protwords_und.txt
+          splitOnCaseChange: 0
+          generateWordParts: 1
+          preserveOriginal: 1
+          catenateAll: 0
+          catenateWords: 0
+        -
+          class: solr.LengthFilterFactory
+          min: 2
+          max: 100
+        -
+          class: solr.LowerCaseFilterFactory
+        -
+          class: solr.RemoveDuplicatesTokenFilterFactory
+unstemmed_field_type: null
+spellcheck_field_type:
+  name: text_spell_und
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzer:
+    charFilters:
+      -
+        class: solr.MappingCharFilterFactory
+        mapping: accents_und.txt
+    tokenizer:
+      class: solr.WhitespaceTokenizerFactory
+    filters:
+      -
+        class: solr.LengthFilterFactory
+        min: 2
+        max: 100
+      -
+        class: solr.LowerCaseFilterFactory
+      -
+        class: solr.RemoveDuplicatesTokenFilterFactory
+collated_field_type:
+  name: collated_und
+  class: solr.ICUCollationField
+  locale: en
+  strength: primary
+  caseLevel: false
+solr_configs:
+  searchComponents:
+    -
+      name: spellcheck
+      class: solr.SpellCheckComponent
+      lst:
+        -
+          name: spellchecker
+          str:
+            -
+              name: name
+              VALUE: und
+            -
+              name: field
+              VALUE: spellcheck_und
+            -
+              name: classname
+              VALUE: solr.DirectSolrSpellChecker
+            -
+              name: distanceMeasure
+              VALUE: internal
+            -
+              name: accuracy
+              VALUE: '0.5'
+            -
+              name: maxEdits
+              VALUE: '2'
+            -
+              name: minPrefix
+              VALUE: '1'
+            -
+              name: maxInspections
+              VALUE: '5'
+            -
+              name: minQueryLength
+              VALUE: '4'
+            -
+              name: maxQueryFrequency
+              VALUE: '0.01'
+            -
+              name: thresholdTokenFrequency
+              VALUE: '.01'
+            -
+              name: onlyMorePopular
+              VALUE: 'true'
+    -
+      name: suggest
+      class: solr.SuggestComponent
+      lst:
+        -
+          name: suggester
+          str:
+            -
+              name: name
+              VALUE: und
+            -
+              name: lookupImpl
+              VALUE: AnalyzingInfixLookupFactory
+            -
+              name: dictionaryImpl
+              VALUE: DocumentDictionaryFactory
+            -
+              name: field
+              VALUE: twm_suggest
+            -
+              name: suggestAnalyzerFieldType
+              VALUE: text_und
+            -
+              name: contextField
+              VALUE: sm_context_tags
+            -
+              name: buildOnCommit
+              VALUE: 'true'
+            -
+              name: buildOnStartup
+              VALUE: 'false'
+text_files:
+  stopwords: ''
+  synonyms: "drupal, durpal\n"
+  protwords: ''
+  accents: "# À => A\n\"\\u00C0\" => \"A\"\n# Á => A\n\"\\u00C1\" => \"A\"\n# Â => A\n\"\\u00C2\" => \"A\"\n# Ã => A\n\"\\u00C3\" => \"A\"\n# Ä => A\n\"\\u00C4\" => \"A\"\n# Å => A\n\"\\u00C5\" => \"A\"\n# Æ => AE\n\"\\u00C6\" => \"AE\"\n# Ç => C\n\"\\u00C7\" => \"C\"\n# È => E\n\"\\u00C8\" => \"E\"\n# É => E\n\"\\u00C9\" => \"E\"\n# Ê => E\n\"\\u00CA\" => \"E\"\n# Ë => E\n\"\\u00CB\" => \"E\"\n# Ì => I\n\"\\u00CC\" => \"I\"\n# Í => I\n\"\\u00CD\" => \"I\"\n# Î => I\n\"\\u00CE\" => \"I\"\n# Ï => I\n\"\\u00CF\" => \"I\"\n# Ĳ => IJ\n\"\\u0132\" => \"IJ\"\n# Ð => D\n\"\\u00D0\" => \"D\"\n# Ñ => N\n\"\\u00D1\" => \"N\"\n# Ò => O\n\"\\u00D2\" => \"O\"\n# Ó => O\n\"\\u00D3\" => \"O\"\n# Ô => O\n\"\\u00D4\" => \"O\"\n# Õ => O\n\"\\u00D5\" => \"O\"\n# Ö => O\n\"\\u00D6\" => \"O\"\n# Ø => O\n\"\\u00D8\" => \"O\"\n# Œ => OE\n\"\\u0152\" => \"OE\"\n# Þ\n\"\\u00DE\" => \"TH\"\n# Ù => U\n\"\\u00D9\" => \"U\"\n# Ú => U\n\"\\u00DA\" => \"U\"\n# Û => U\n\"\\u00DB\" => \"U\"\n# Ü => U\n\"\\u00DC\" => \"U\"\n# Ý => Y\n\"\\u00DD\" => \"Y\"\n# Ÿ => Y\n\"\\u0178\" => \"Y\"\n# à => a\n\"\\u00E0\" => \"a\"\n# á => a\n\"\\u00E1\" => \"a\"\n# â => a\n\"\\u00E2\" => \"a\"\n# ã => a\n\"\\u00E3\" => \"a\"\n# ä => a\n\"\\u00E4\" => \"a\"\n# å => a\n\"\\u00E5\" => \"a\"\n# æ => ae\n\"\\u00E6\" => \"ae\"\n# ç => c\n\"\\u00E7\" => \"c\"\n# è => e\n\"\\u00E8\" => \"e\"\n# é => e\n\"\\u00E9\" => \"e\"\n# ê => e\n\"\\u00EA\" => \"e\"\n# ë => e\n\"\\u00EB\" => \"e\"\n# ì => i\n\"\\u00EC\" => \"i\"\n# í => i\n\"\\u00ED\" => \"i\"\n# î => i\n\"\\u00EE\" => \"i\"\n# ï => i\n\"\\u00EF\" => \"i\"\n# ĳ => ij\n\"\\u0133\" => \"ij\"\n# ð => d\n\"\\u00F0\" => \"d\"\n# ñ => n\n\"\\u00F1\" => \"n\"\n# ò => o\n\"\\u00F2\" => \"o\"\n# ó => o\n\"\\u00F3\" => \"o\"\n# ô => o\n\"\\u00F4\" => \"o\"\n# õ => o\n\"\\u00F5\" => \"o\"\n# ö => o\n\"\\u00F6\" => \"o\"\n# ø => o\n\"\\u00F8\" => \"o\"\n# œ => oe\n\"\\u0153\" => \"oe\"\n# ß => ss\n\"\\u00DF\" => \"ss\"\n# þ => th\n\"\\u00FE\" => \"th\"\n# ù => u\n\"\\u00F9\" => \"u\"\n# ú => u\n\"\\u00FA\" => \"u\"\n# û => u\n\"\\u00FB\" => \"u\"\n# ü => u\n\"\\u00FC\" => \"u\"\n# ý => y\n\"\\u00FD\" => \"y\"\n# ÿ => y\n\"\\u00FF\" => \"y\"\n# ﬀ => ff\n\"\\uFB00\" => \"ff\"\n# ﬁ => fi\n\"\\uFB01\" => \"fi\"\n# ﬂ => fl\n\"\\uFB02\" => \"fl\"\n# ﬃ => ffi\n\"\\uFB03\" => \"ffi\"\n# ﬄ => ffl\n\"\\uFB04\" => \"ffl\"\n# ﬅ => st\n\"\\uFB05\" => \"st\"\n# ﬆ => st\n\"\\uFB06\" => \"st\"\n"

--- a/ecms_acquia/config/install/search_api_solr.solr_field_type.text_zh-hans_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_field_type.text_zh-hans_7_0_0.yml
@@ -1,0 +1,132 @@
+langcode: en
+status: true
+dependencies: {  }
+id: text_zh-hans_7_0_0
+label: 'Simplified Chinese Text Field'
+minimum_solr_version: 7.0.0
+custom_code: null
+field_type_language_code: zh-hans
+domains: {  }
+field_type:
+  name: text_zh_hans
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      tokenizer:
+        class: solr.HMMChineseTokenizerFactory
+      filters:
+        -
+          class: solr.CJKWidthFilterFactory
+        -
+          class: solr.StopFilterFactory
+          words: org/apache/lucene/analysis/cn/smart/stopwords.txt
+        -
+          class: solr.PorterStemFilterFactory
+        -
+          class: solr.LowerCaseFilterFactory
+    -
+      type: query
+      tokenizer:
+        class: solr.HMMChineseTokenizerFactory
+      filters:
+        -
+          class: solr.CJKWidthFilterFactory
+        -
+          class: solr.StopFilterFactory
+          words: org/apache/lucene/analysis/cn/smart/stopwords.txt
+        -
+          class: solr.PorterStemFilterFactory
+        -
+          class: solr.LowerCaseFilterFactory
+unstemmed_field_type:
+  name: text_unstemmed_zh_hans
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzers:
+    -
+      type: index
+      tokenizer:
+        class: solr.HMMChineseTokenizerFactory
+      filters:
+        -
+          class: solr.CJKWidthFilterFactory
+        -
+          class: solr.StopFilterFactory
+          words: org/apache/lucene/analysis/cn/smart/stopwords.txt
+        -
+          class: solr.LowerCaseFilterFactory
+    -
+      type: query
+      tokenizer:
+        class: solr.HMMChineseTokenizerFactory
+      filters:
+        -
+          class: solr.CJKWidthFilterFactory
+        -
+          class: solr.StopFilterFactory
+          words: org/apache/lucene/analysis/cn/smart/stopwords.txt
+        -
+          class: solr.LowerCaseFilterFactory
+spellcheck_field_type:
+  name: text_spell_zh_hans
+  class: solr.TextField
+  positionIncrementGap: 100
+  analyzer:
+    tokenizer:
+      class: solr.HMMChineseTokenizerFactory
+    filters:
+      -
+        class: solr.CJKWidthFilterFactory
+      -
+        class: solr.LowerCaseFilterFactory
+collated_field_type:
+  name: collated_zh-hans
+  class: solr.ICUCollationField
+  locale: zh
+  strength: primary
+  caseLevel: false
+solr_configs:
+  searchComponents:
+    -
+      name: spellcheck
+      class: solr.SpellCheckComponent
+      lst:
+        -
+          name: spellchecker
+          str:
+            -
+              name: name
+              VALUE: zh_hans
+            -
+              name: field
+              VALUE: spellcheck_zh_hans
+            -
+              name: classname
+              VALUE: solr.DirectSolrSpellChecker
+            -
+              name: distanceMeasure
+              VALUE: internal
+            -
+              name: accuracy
+              VALUE: '0.5'
+            -
+              name: maxEdits
+              VALUE: '1'
+            -
+              name: minPrefix
+              VALUE: '1'
+            -
+              name: maxInspections
+              VALUE: '5'
+            -
+              name: minQueryLength
+              VALUE: '1'
+            -
+              name: maxQueryFrequency
+              VALUE: '0.01'
+            -
+              name: onlyMorePopular
+              VALUE: 'true'
+text_files: {  }

--- a/ecms_acquia/config/install/search_api_solr.solr_request_dispatcher.request_dispatcher_httpcaching_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_request_dispatcher.request_dispatcher_httpcaching_default_7_0_0.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies: {  }
+id: request_dispatcher_httpcaching_default_7_0_0
+label: 'HTTP Cache'
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: false
+request_dispatcher:
+  name: httpCaching
+  lastModFrom: openTime
+  etagSeed: Solr
+  cacheControl:
+    -
+      VALUE: 'max-age=30, public'

--- a/ecms_acquia/config/install/search_api_solr.solr_request_dispatcher.request_dispatcher_httpcachingnever_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_request_dispatcher.request_dispatcher_httpcachingnever_default_7_0_0.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies: {  }
+id: request_dispatcher_httpcachingnever_default_7_0_0
+label: 'HTTP Cache Never'
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_dispatcher:
+  name: httpCaching
+  never304: true

--- a/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_autocomplete_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_autocomplete_default_7_0_0.yml
@@ -1,0 +1,51 @@
+langcode: en
+status: true
+dependencies: {  }
+id: request_handler_autocomplete_default_7_0_0
+label: Autocomplete
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /autocomplete
+  class: solr.SearchHandler
+  startup: lazy
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: terms
+          VALUE: 'false'
+        -
+          name: distrib
+          VALUE: 'false'
+        -
+          name: spellcheck
+          VALUE: 'false'
+        -
+          name: spellcheck.onlyMorePopular
+          VALUE: 'true'
+        -
+          name: spellcheck.extendedResults
+          VALUE: 'false'
+        -
+          name: spellcheck.count
+          VALUE: '1'
+        -
+          name: suggest
+          VALUE: 'false'
+        -
+          name: suggest.count
+          VALUE: '10'
+  arr:
+    -
+      name: components
+      str:
+        -
+          VALUE: terms
+        -
+          VALUE: spellcheck
+        -
+          VALUE: suggest
+solr_configs: null

--- a/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_elevate_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_elevate_default_7_0_0.yml
@@ -1,0 +1,40 @@
+langcode: en
+status: true
+dependencies: {  }
+id: request_handler_elevate_default_7_0_0
+label: Elevator
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: false
+request_handler:
+  name: /elevate
+  class: solr.SearchHandler
+  startup: lazy
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: echoParams
+          VALUE: explicit
+        -
+          name: df
+          VALUE: id
+  arr:
+    -
+      name: last-components
+      str:
+        -
+          VALUE: elevator
+solr_configs:
+  searchComponents:
+    -
+      name: elevator
+      class: solr.QueryElevationComponent
+      str:
+        -
+          name: queryFieldType
+          VALUE: string
+        -
+          name: config-file
+          VALUE: elevate.xml

--- a/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_extract_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_extract_default_7_0_0.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies: {  }
+id: request_handler_extract_default_7_0_0
+label: Extract
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /update/extract
+  class: solr.extraction.ExtractingRequestHandler
+  startup: lazy
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: lowernames
+          VALUE: 'true'
+        -
+          name: uprefix
+          VALUE: ignored_
+        -
+          name: captureAttr
+          VALUE: 'true'
+        -
+          name: fmap.a
+          VALUE: links
+        -
+          name: fmap.div
+          VALUE: ignored_
+solr_configs: null

--- a/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_mlt_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_mlt_default_7_0_0.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies: {  }
+id: request_handler_mlt_default_7_0_0
+label: 'More Like This'
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /mlt
+  class: solr.MoreLikeThisHandler
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: mlt.mintf
+          VALUE: '1'
+        -
+          name: mlt.mindf
+          VALUE: '1'
+        -
+          name: mlt.match.include
+          VALUE: 'false'
+        -
+          name: timeAllowed
+          VALUE: '${solr.mlt.timeAllowed:2000}'
+solr_configs: null

--- a/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_query_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_query_default_7_0_0.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies: {  }
+id: request_handler_query_default_7_0_0
+label: Query
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /select
+  class: solr.SearchHandler
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: echoParams
+          VALUE: explicit
+        -
+          name: wt
+          VALUE: json
+        -
+          name: indent
+          VALUE: 'true'
+        -
+          name: df
+          VALUE: id
+solr_configs: null

--- a/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_replicationmaster_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_replicationmaster_default_7_0_0.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies: {  }
+id: request_handler_replicationmaster_default_7_0_0
+label: 'Replication Master'
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: false
+request_handler:
+  name: /replication
+  class: solr.ReplicationHandler
+  lst:
+    -
+      name: master
+      str:
+        -
+          name: enable
+          VALUE: '${solr.replication.master:false}'
+        -
+          name: replicateAfter
+          VALUE: commit
+        -
+          name: replicateAfter
+          VALUE: startup
+        -
+          name: confFiles
+          VALUE: '${solr.replication.confFiles:schema.xml,schema_extra_types.xml,schema_extra_fields.xml,elevate.xml}'
+solr_configs: null

--- a/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_replicationslave_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_replicationslave_default_7_0_0.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies: {  }
+id: request_handler_replicationslave_default_7_0_0
+label: 'Replication Slave'
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: false
+request_handler:
+  name: /replication
+  class: solr.ReplicationHandler
+  lst:
+    -
+      name: slave
+      str:
+        -
+          name: enable
+          VALUE: '${solr.replication.slave:false}'
+        -
+          name: masterUrl
+          VALUE: '${solr.replication.masterUrl:http://localhost:8983/solr}/replication'
+        -
+          name: pollInterval
+          VALUE: '${solr.replication.pollInterval:00:00:60}'
+solr_configs: null

--- a/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_select_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_select_default_7_0_0.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies: {  }
+id: request_handler_select_default_7_0_0
+label: Select
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /select
+  class: solr.SearchHandler
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: defType
+          VALUE: lucene
+        -
+          name: df
+          VALUE: id
+        -
+          name: echoParams
+          VALUE: explicit
+        -
+          name: omitHeader
+          VALUE: 'true'
+        -
+          name: timeAllowed
+          VALUE: '${solr.selectSearchHandler.timeAllowed:-1}'
+        -
+          name: spellcheck
+          VALUE: 'false'
+  arr:
+    -
+      name: last-components
+      str:
+        -
+          VALUE: spellcheck
+        -
+          VALUE: elevator
+solr_configs: null

--- a/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_spell_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_spell_default_7_0_0.yml
@@ -1,0 +1,59 @@
+langcode: en
+status: true
+dependencies: {  }
+id: request_handler_spell_default_7_0_0
+label: Spellcheck
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /spell
+  class: solr.SearchHandler
+  startup: lazy
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: df
+          VALUE: id
+        -
+          name: spellcheck.dictionary
+          VALUE: und
+        -
+          name: spellcheck
+          VALUE: 'on'
+        -
+          name: spellcheck.onlyMorePopular
+          VALUE: 'false'
+        -
+          name: spellcheck.extendedResults
+          VALUE: 'false'
+        -
+          name: spellcheck.count
+          VALUE: '1'
+        -
+          name: spellcheck.alternativeTermCount
+          VALUE: '5'
+        -
+          name: spellcheck.maxResultsForSuggest
+          VALUE: '5'
+        -
+          name: spellcheck.collate
+          VALUE: 'true'
+        -
+          name: spellcheck.collateExtendedResults
+          VALUE: 'true'
+        -
+          name: spellcheck.maxCollationTries
+          VALUE: '10'
+        -
+          name: spellcheck.maxCollations
+          VALUE: '5'
+  arr:
+    -
+      name: last-components
+      str:
+        -
+          VALUE: spellcheck
+solr_configs: null

--- a/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_suggest_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_suggest_default_7_0_0.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies: {  }
+id: request_handler_suggest_default_7_0_0
+label: Suggester
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /suggest
+  class: solr.SearchHandler
+  startup: lazy
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: suggest
+          VALUE: 'true'
+        -
+          name: suggest.dictionary
+          VALUE: und
+        -
+          name: suggest.dictionary
+          VALUE: '10'
+  arr:
+    -
+      name: components
+      str:
+        -
+          VALUE: suggest
+solr_configs: null

--- a/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_tvrh_default_7_0_0.yml
+++ b/ecms_acquia/config/install/search_api_solr.solr_request_handler.request_handler_tvrh_default_7_0_0.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: request_handler_tvrh_default_7_0_0
+label: 'Term Vector'
+minimum_solr_version: 7.0.0
+environments: {  }
+recommended: true
+request_handler:
+  name: /tvrh
+  class: solr.SearchHandler
+  startup: lazy
+  lst:
+    -
+      name: defaults
+      str:
+        -
+          name: df
+          VALUE: id
+        -
+          name: tv
+          VALUE: 'true'
+  arr:
+    -
+      name: last-components
+      str:
+        -
+          VALUE: tvComponent
+solr_configs:
+  searchComponents:
+    -
+      name: tvComponent
+      class: solr.TermVectorComponent

--- a/ecms_acquia/config/install/views.view.acquia_search_solr.yml
+++ b/ecms_acquia/config/install/views.view.acquia_search_solr.yml
@@ -496,7 +496,7 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
-      path: site-search
+      path: search
       exposed_block: true
       menu:
         type: normal

--- a/ecms_acquia/config/install/views.view.acquia_search_solr.yml
+++ b/ecms_acquia/config/install/views.view.acquia_search_solr.yml
@@ -299,7 +299,7 @@ display:
           exposed: true
           expose:
             operator_id: search_api_fulltext_op
-            label: Keyword
+            label: ''
             description: ''
             use_operator: false
             operator: search_api_fulltext_op

--- a/ecms_acquia/config/install/views.view.acquia_search_solr.yml
+++ b/ecms_acquia/config/install/views.view.acquia_search_solr.yml
@@ -2,12 +2,10 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.body
     - search_api.index.acquia_search_solr_search_api_solr_index
     - system.menu.main
   module:
     - search_api
-    - text
     - user
 id: acquia_search_solr
 label: 'Acquia Search Solr'
@@ -68,14 +66,11 @@ display:
             last: 'Last »'
           quantity: 9
       style:
-        type: html_list
+        type: default
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          type: ul
-          wrapper_class: item-list
-          class: ''
       row:
         type: fields
         options:
@@ -86,7 +81,7 @@ display:
       fields:
         title:
           id: title
-          table: search_api_index_acquia_search_solr_search_api_solr_index
+          table: search_api_datasource_acquia_search_solr_search_api_solr_index_entity_node
           field: title
           relationship: none
           group_type: group
@@ -135,7 +130,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: false
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -146,82 +141,14 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          field_rendering: false
-          fallback_handler: search_api
-          fallback_options:
-            link_to_item: true
-            use_highlighting: true
-            multi_type: separator
-            multi_separator: ', '
-          plugin_id: search_api_field
-        body:
-          id: body
-          table: search_api_index_acquia_search_solr_search_api_solr_index
-          field: body
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 400
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: true
-            preserve_tags: ''
-            html: true
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: text_default
-          settings: {  }
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          field_rendering: false
+          field_rendering: true
           fallback_handler: search_api
           fallback_options:
             link_to_item: false
-            use_highlighting: true
+            use_highlighting: false
             multi_type: separator
             multi_separator: ', '
+          entity_type: node
           plugin_id: search_api_field
         search_api_excerpt:
           id: search_api_excerpt
@@ -276,14 +203,14 @@ display:
           multi_type: separator
           multi_separator: ', '
           plugin_id: search_api
-        type:
-          id: type
-          table: search_api_index_acquia_search_solr_search_api_solr_index
-          field: type
+        nid:
+          id: nid
+          table: search_api_datasource_acquia_search_solr_search_api_solr_index_entity_node
+          field: nid
           relationship: none
           group_type: group
           admin_label: ''
-          label: Type
+          label: ''
           exclude: false
           alter:
             alter_text: false
@@ -312,11 +239,11 @@ display:
             trim: false
             preserve_tags: ''
             html: false
-          element_type: em
+          element_type: ''
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: true
+          element_label_colon: false
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -324,11 +251,12 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_label
+          click_sort_column: value
+          type: number_integer
           settings:
-            link: true
-          group_column: target_id
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -338,16 +266,25 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          field_rendering: false
-          fallback_handler: search_api_entity
+          field_rendering: true
+          fallback_handler: search_api_numeric
           fallback_options:
+            set_precision: false
+            precision: 0
+            decimal: .
+            separator: ','
+            format_plural: false
+            format_plural_string: !!binary MQNAY291bnQ=
+            prefix: ''
+            suffix: ''
             link_to_item: false
             use_highlighting: false
             multi_type: separator
             multi_separator: ', '
-            display_methods:
-              node_type:
-                display_method: label
+            format_plural_values:
+              - '1'
+              - '@count'
+          entity_type: node
           plugin_id: search_api_field
       filters:
         search_api_fulltext:
@@ -487,7 +424,6 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
-        - 'config:field.storage.node.body'
         - 'config:search_api.index.acquia_search_solr_search_api_solr_index'
   page:
     display_plugin: page
@@ -518,5 +454,4 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
-        - 'config:field.storage.node.body'
         - 'config:search_api.index.acquia_search_solr_search_api_solr_index'

--- a/ecms_acquia/config/install/views.view.acquia_search_solr.yml
+++ b/ecms_acquia/config/install/views.view.acquia_search_solr.yml
@@ -1,0 +1,522 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - search_api.index.acquia_search_solr_search_api_solr_index
+    - system.menu.main
+  module:
+    - search_api
+    - text
+    - user
+id: acquia_search_solr
+label: 'Acquia Search Solr'
+module: views
+description: ''
+tag: ''
+base_table: search_api_index_acquia_search_solr_search_api_solr_index
+base_field: search_api_id
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: none
+        options: {  }
+      query:
+        type: views_query
+        options:
+          bypass_access: false
+          skip_access: false
+          parse_mode: terms
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Search
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: '‹ Previous'
+            next: 'Next ›'
+            first: '« First'
+            last: 'Last »'
+          quantity: 9
+      style:
+        type: html_list
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          type: ul
+          wrapper_class: item-list
+          class: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      fields:
+        title:
+          id: title
+          table: search_api_index_acquia_search_solr_search_api_solr_index
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: false
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: true
+            use_highlighting: true
+            multi_type: separator
+            multi_separator: ', '
+          plugin_id: search_api_field
+        body:
+          id: body
+          table: search_api_index_acquia_search_solr_search_api_solr_index
+          field: body
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 400
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: true
+            preserve_tags: ''
+            html: true
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: false
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: true
+            multi_type: separator
+            multi_separator: ', '
+          plugin_id: search_api_field
+        search_api_excerpt:
+          id: search_api_excerpt
+          table: search_api_index_acquia_search_solr_search_api_solr_index
+          field: search_api_excerpt
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: '{{body}}'
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          link_to_item: false
+          use_highlighting: false
+          multi_type: separator
+          multi_separator: ', '
+          plugin_id: search_api
+        type:
+          id: type
+          table: search_api_index_acquia_search_solr_search_api_solr_index
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Type
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: em
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: false
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            display_methods:
+              node_type:
+                display_method: label
+          plugin_id: search_api_field
+      filters:
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_acquia_search_solr_search_api_solr_index
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: and
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_op
+            label: Keyword
+            description: ''
+            use_operator: false
+            operator: search_api_fulltext_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: search
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              drupal_admin: '0'
+              content_author: '0'
+              embed_author: '0'
+              form_author: '0'
+              content_publisher: '0'
+              site_admin: '0'
+              ecms_api_recipient: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: direct
+          min_length: null
+          fields: {  }
+          plugin_id: search_api_fulltext
+        search_api_language:
+          id: search_api_language
+          table: search_api_index_acquia_search_solr_search_api_solr_index
+          field: search_api_language
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: search_api_language
+      sorts:
+        search_api_relevance:
+          id: search_api_relevance
+          table: search_api_index_acquia_search_solr_search_api_solr_index
+          field: search_api_relevance
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: search_api
+      title: ''
+      header: {  }
+      footer: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'No results found.'
+            format: basic_html
+          plugin_id: text
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'
+        - 'config:search_api.index.acquia_search_solr_search_api_solr_index'
+  page:
+    display_plugin: page
+    id: page
+    display_title: 'Acquia Search Solr Page'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: site-search
+      exposed_block: true
+      menu:
+        type: normal
+        title: Search
+        description: ''
+        expanded: false
+        parent: ''
+        weight: 0
+        context: '0'
+        menu_name: main
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'
+        - 'config:search_api.index.acquia_search_solr_search_api_solr_index'

--- a/ecms_acquia/config/install/views.view.acquia_search_solr.yml
+++ b/ecms_acquia/config/install/views.view.acquia_search_solr.yml
@@ -38,7 +38,7 @@ display:
         type: basic
         options:
           submit_button: Search
-          reset_button: true
+          reset_button: false
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
           expose_sort_order: true
@@ -81,7 +81,7 @@ display:
       fields:
         title:
           id: title
-          table: search_api_datasource_acquia_search_solr_search_api_solr_index_entity_node
+          table: search_api_index_acquia_search_solr_search_api_solr_index
           field: title
           relationship: none
           group_type: group
@@ -130,7 +130,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: true
+            link_to_entity: false
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -141,14 +141,13 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          field_rendering: true
+          field_rendering: false
           fallback_handler: search_api
           fallback_options:
-            link_to_item: false
-            use_highlighting: false
+            link_to_item: true
+            use_highlighting: true
             multi_type: separator
             multi_separator: ', '
-          entity_type: node
           plugin_id: search_api_field
         search_api_excerpt:
           id: search_api_excerpt
@@ -255,7 +254,7 @@ display:
           type: number_integer
           settings:
             thousand_separator: ''
-            prefix_suffix: false
+            prefix_suffix: true
           group_column: value
           group_columns: {  }
           group_rows: true

--- a/ecms_acquia/config/install/views.view.acquia_search_solr.yml
+++ b/ecms_acquia/config/install/views.view.acquia_search_solr.yml
@@ -305,7 +305,7 @@ display:
             operator: search_api_fulltext_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: search
+            identifier: search_api_fulltext
             required: false
             remember: false
             multiple: false
@@ -318,8 +318,9 @@ display:
               form_author: '0'
               content_publisher: '0'
               site_admin: '0'
-              ecms_api_recipient: '0'
             placeholder: ''
+            expose_fields: false
+            searched_fields_id: ''
           is_grouped: false
           group_info:
             label: ''

--- a/ecms_acquia/ecms_acquia.info.yml
+++ b/ecms_acquia/ecms_acquia.info.yml
@@ -7,7 +7,9 @@ core_version_requirement: ^9
 # Module dependencies for the distribution.
 dependencies:
   - acsf
+  - acquia_connector
   - acquia_purge
+  - acquia_search_solr
   - purge
   - purge_drush
   - purge_processor_cron

--- a/ecms_base/config/install/filter.format.minimal.yml
+++ b/ecms_base/config/install/filter.format.minimal.yml
@@ -1,4 +1,3 @@
-uuid: e9c2d2d0-e46c-4cb8-9db0-88e9ce51bc1a
 langcode: en
 status: true
 dependencies:

--- a/ecms_base/config/install/views.view.site_search.yml
+++ b/ecms_base/config/install/views.view.site_search.yml
@@ -402,7 +402,7 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
-      path: search
+      path: search-backup
       exposed_block: true
     cache_metadata:
       max-age: -1

--- a/ecms_base/themes/custom/ecms/config/optional/block.block.exposedformacquia_search_solrpage.yml
+++ b/ecms_base/themes/custom/ecms/config/optional/block.block.exposedformacquia_search_solrpage.yml
@@ -24,5 +24,5 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: /site-search
+    pages: /search
     negate: false

--- a/ecms_base/themes/custom/ecms/config/optional/block.block.exposedformacquia_search_solrpage.yml
+++ b/ecms_base/themes/custom/ecms/config/optional/block.block.exposedformacquia_search_solrpage.yml
@@ -1,0 +1,28 @@
+uuid: cb7b7df2-4a47-407f-aea8-22e90a1d1413
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.acquia_search_solr
+  module:
+    - system
+    - views
+  theme:
+    - ecms
+id: exposedformacquia_search_solrpage
+theme: ecms
+region: content
+weight: -5
+provider: null
+plugin: 'views_exposed_filter_block:acquia_search_solr-page'
+settings:
+  id: 'views_exposed_filter_block:acquia_search_solr-page'
+  label: ''
+  provider: views
+  label_display: '0'
+  views_label: ''
+visibility:
+  request_path:
+    id: request_path
+    pages: /site-search
+    negate: false

--- a/ecms_base/themes/custom/ecms/config/optional/block.block.exposedformacquia_search_solrpage.yml
+++ b/ecms_base/themes/custom/ecms/config/optional/block.block.exposedformacquia_search_solrpage.yml
@@ -1,4 +1,3 @@
-uuid: cb7b7df2-4a47-407f-aea8-22e90a1d1413
 langcode: en
 status: true
 dependencies:

--- a/ecms_base/themes/custom/ecms/config/optional/block.block.exposedformsite_searchpage_1.yml
+++ b/ecms_base/themes/custom/ecms/config/optional/block.block.exposedformsite_searchpage_1.yml
@@ -23,5 +23,5 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: /search
+    pages: /search-backup
     negate: false

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -286,7 +286,10 @@ function ecms_theme_suggestions_input_alter(array &$suggestions, array $variable
  * Implements hook_form_alter().
  */
 function ecms_form_alter(&$form, FormStateInterface $form_state, string $form_id): void {
-  if ($form_id === 'ecms_search_block_form' || $form['#id'] === "views-exposed-form-site-search-page-1") {
+  if ($form_id === 'ecms_search_block_form'
+    || $form['#id'] === "views-exposed-form-site-search-page-1"
+    || $form['#id'] === "views-exposed-form-acquia-search-solr-page"
+  ) {
 
     // Input provided by search view exposed form.
     if (isset($form['search_api_fulltext'])) {

--- a/ecms_base/themes/custom/ecms/templates/views/views-exposed-form--acquia-search-solr-page.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/views/views-exposed-form--acquia-search-solr-page.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Theme override of a views exposed form.
+ *
+ * Available variables:
+ * - form: A render element representing the form.
+ *
+ * @see template_preprocess_views_exposed_form()
+ */
+#}
+{% if q is not empty %}
+  {#
+    This ensures that, if clean URLs are off, the 'q' is added first,
+    as a hidden form element, so that it shows up first in the POST URL.
+  #}
+{{ q }}
+{% endif %}
+
+{% include '@molecules/site-search/site-search--inner.twig' with {
+    form: form
+  }
+%}
+

--- a/ecms_base/themes/custom/ecms/templates/views/views-exposed-form--acquia-search-solr.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/views/views-exposed-form--acquia-search-solr.html.twig
@@ -17,16 +17,6 @@
 {{ q }}
 {% endif %}
 
-{#
-  Make sure input field ('form.search') is passed as "search_api_fulltext"
-  to pattern lab template.
-#}
-{% for key in form|keys %}
-  <li>{{ key }}</li>
-{% endfor %}
-
-{% set form = form|merge({ 'search_api_fulltext': form.search }) %}
-
 {% include '@molecules/site-search/site-search--inner.twig' with {
     form: form
   }

--- a/ecms_base/themes/custom/ecms/templates/views/views-exposed-form--acquia-search-solr.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/views/views-exposed-form--acquia-search-solr.html.twig
@@ -17,6 +17,12 @@
 {{ q }}
 {% endif %}
 
+{#
+  Make sure input field ('form.search') is passed as "search_api_fulltext"
+  to pattern lab template.
+#}
+{% set form = form|merge({ 'search_api_fulltext': form.search }) %}
+
 {% include '@molecules/site-search/site-search--inner.twig' with {
     form: form
   }

--- a/ecms_base/themes/custom/ecms/templates/views/views-exposed-form--acquia-search-solr.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/views/views-exposed-form--acquia-search-solr.html.twig
@@ -21,6 +21,10 @@
   Make sure input field ('form.search') is passed as "search_api_fulltext"
   to pattern lab template.
 #}
+{% for key in form|keys %}
+  <li>{{ key }}</li>
+{% endfor %}
+
 {% set form = form|merge({ 'search_api_fulltext': form.search }) %}
 
 {% include '@molecules/site-search/site-search--inner.twig' with {

--- a/ecms_base/themes/custom/ecms/templates/views/views-view-fields--acquia-search-solr.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/views/views-view-fields--acquia-search-solr.html.twig
@@ -1,0 +1,48 @@
+{#
+/**
+ * @file
+ * Theme override to display all the fields of site search view.
+ *
+ * Available variables:
+ * - view: The view in use.
+ * - fields: A list of fields, each one contains:
+ *   - content: The output of the field.
+ *   - raw: The raw data for the field, if it exists. This is NOT output safe.
+ *   - class: The safe class ID to use.
+ *   - handler: The Views field handler controlling this field.
+ *   - inline: Whether or not the field should be inline.
+ *   - wrapper_element: An HTML element for a wrapper.
+ *   - wrapper_attributes: List of attributes for wrapper element.
+ *   - separator: An optional separator that may appear before a field.
+ *   - label: The field's label text.
+ *   - label_element: An HTML element for a label wrapper.
+ *   - label_attributes: List of attributes for label wrapper.
+ *   - label_suffix: Colon after the label.
+ *   - element_type: An HTML element for the field content.
+ *   - element_attributes: List of attributes for HTML element for field content.
+ *   - has_label_colon: A boolean indicating whether to display a colon after
+ *     the label.
+ *   - element_type: An HTML element for the field content.
+ *   - element_attributes: List of attributes for HTML element for field content.
+ * - row: The raw result from the query, with all data it fetched.
+ *
+ * @see template_preprocess_views_view_fields()
+ */
+#}
+
+{% set path = '#' %}
+{% if fields.nid.content %}
+  {% set path = path('entity.node.canonical', {'node': fields.nid.content|striptags|trim|number_format(0,'','')}) %}
+{% endif %}
+
+{% if fields %}
+
+  {% include '@molecules/teaser-article/teaser-article.twig' with {
+    title: fields.title.content,
+    excerpt: fields.search_api_excerpt.content,
+    url: path,
+    alt_read_text: 'View page'
+  } %}
+
+{% endif %}
+

--- a/ecms_base/themes/custom/ecms/templates/views/views-view-unformatted--acquia-search-solr.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/views/views-view-unformatted--acquia-search-solr.html.twig
@@ -1,0 +1,68 @@
+{#
+/**
+ * @file
+ * Theme override for a main view template.
+ *
+ * Available variables:
+ * - attributes: Remaining HTML attributes for the element.
+ * - css_name: A CSS-safe version of the view name.
+ * - css_class: The user-specified classes names, if any.
+ * - header: The optional header.
+ * - footer: The optional footer.
+ * - rows: The results of the view query, if any.
+ * - empty: The content to display if there are no rows.
+ * - pager: The optional pager next/prev links to display.
+ * - exposed: Exposed widget form/info to display.
+ * - feed_icons: Optional feed icons to display.
+ * - more: An optional link to the next page of results.
+ * - title: Title of the view, only used when displaying in the admin preview.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the view title.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the view title.
+ * - attachment_before: An optional attachment view to be displayed before the
+ *   view content.
+ * - attachment_after: An optional attachment view to be displayed after the
+ *   view content.
+ * - dom_id: Unique id for every view being printed to give unique class for
+ *   Javascript.
+ *
+ * @see template_preprocess_views_view()
+ */
+#}
+{%
+  set classes = [
+    'view',
+    'view-' ~ id|clean_class,
+    'view-id-' ~ id,
+    'view-display-id-' ~ display_id,
+    dom_id ? 'js-view-dom-id-' ~ dom_id,
+  ]
+%}
+  {% if exposed %}
+    <div class="view-filters">
+      {{ exposed }}
+    </div>
+  {% endif %}
+
+  {% if rows %}
+
+    {% include '@organisms/articles-list/articles-list.twig' with {
+      title: title,
+      rows: rows,
+      rows_loop: TRUE
+    } %}
+
+  {% elseif empty %}
+      {{ empty }}
+  {% endif %}
+
+  {% if pager %}
+    {{ pager }}
+  {% endif %}
+
+  {% if feed_icons %}
+    <div class="feed-icons">
+      {{ feed_icons }}
+    </div>
+  {% endif %}

--- a/scripts/clean-config.sh
+++ b/scripts/clean-config.sh
@@ -11,6 +11,7 @@ echo -e "*   Cleanup Config   *"
 echo -e "**********************"
 echo -e "Cleaning up configuration in: ${BASE_DIR}/*/config/install/\n"
 echo -e "Cleaning up configuration in: ${BASE_DIR}/*/modules/custom/*/config/install/\n"
+echo -e "Cleaning up configuration in: ${BASE_DIR}/*/themes/custom/*/config/*\n"
 echo -e "Cleaning up configuration in: ${BASE_DIR}/*/features/custom/*/config/install/\n"
 
 # sed is different for Macs, detect that here.
@@ -22,6 +23,10 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   find ${BASE_DIR}/*/modules/custom -path "*/config/*.yml" -exec sed -i '' '/^uuid: /d' {} \;
   find ${BASE_DIR}/*/modules/custom -path "*/config/*.yml" -exec sed -i '' '/_core:/{N;d;}' {} \;
 
+  # Traverse the custom themes too.
+  find ${BASE_DIR}/*/themes/custom -path "*/config/*.yml" -exec sed -i '' '/^uuid: /d' {} \;
+  find ${BASE_DIR}/*/themes/custom -path "*/config/*.yml" -exec sed -i '' '/_core:/{N;d;}' {} \;
+
   # Traverse the features too.
   find ${BASE_DIR}/*/features/custom -path "*/config/*.yml" -exec sed -i '' '/^uuid: /d' {} \;
   find ${BASE_DIR}/*/features/custom -path "*/config/*.yml" -exec sed -i '' '/_core:/{N;d;}' {} \;
@@ -32,6 +37,10 @@ else
   # Traverse the custom modules too.
   find ${BASE_DIR}/*/modules/custom -path "*/config/*.yml" -exec sed -i '/^uuid: /d' {} \;
   find ${BASE_DIR}/*/modules/custom -path "*/config/*.yml" -exec sed -i '/_core:/,+1d' {} \;
+
+  # Traverse the custom themes too.
+  find ${BASE_DIR}/*/themes/custom -path "*/config/*.yml" -exec sed -i '/^uuid: /d' {} \;
+  find ${BASE_DIR}/*/themes/custom -path "*/config/*.yml" -exec sed -i '/_core:/,+1d' {} \;
 
   # Traverse the features too.
   find ${BASE_DIR}/*/features/custom -path "*/config/*.yml" -exec sed -i '/^uuid: /d' {} \;


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
<!-- Include a summary of your changes that expands upon the title. -->
Adds Acquia Solr search and associated config. Much of the config is boilerplate SOLR output.
Adds new Acquia Solr Search view and exposed filter. Adds twig files  to mimic how the current DB site search is setup.
Moves the current site search and associated block to temp page (/search-backup).
Updates clean script to address theme config as well.

UPDATE HOOKS: Left these out intentionally, there is too much here in my opinion to try and script, will be quicker and safer to manually set this up. I am outlining steps needed in the ticket.

Database search, config, templates can be removed in a future PR.


## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes/no
| Did you perform a self review first? | yes/no
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Medium
| Relevant links | https://thinkoomph.jira.com/browse/RIG-222