### PR TITLE
Fixed missing module dependency media_library_form_element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIG-254: Fixed missing module dependency media_library_form_element.
 
 ### Security
 

--- a/composer.json
+++ b/composer.json
@@ -149,6 +149,7 @@
     "drupal/language_neutral_aliases": "^3.0",
     "drupal/layout_builder_modal": "^1.1",
     "drupal/layout_builder_restrictions": "^2.7",
+    "drupal/media_library_form_element": "^2.0",
     "drupal/media_library_theme_reset": "^1.0",
     "drupal/memcache": "^2.2",
     "drupal/menu_block": "1.x-dev",

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -48,6 +48,7 @@ dependencies:
   - locale
   - media
   - media_library
+  - media_library_form_element
   - media_library_theme_reset
   - menu_block
   - menu_link_content

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -799,3 +799,15 @@ function ecms_base_update_9048(array &$sandbox): void {
     $active_storage->write("{$config}", $profile_install_source->read("{$config}"));
   }
 }
+
+/**
+ * Updates to run for the 0.4.9 tag.
+ */
+function ecms_base_update_9049(array &$sandbox): void {
+  // Install new required modules.
+  $modules_to_install = [
+    'media_library_form_element',
+  ];
+
+  \Drupal::service('module_installer')->install($modules_to_install);
+}


### PR DESCRIPTION
## Summary
This PR fixes a missing module dependency from 0.4.8 release.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | no
| Risk level | Low
| Relevant links | JIRA issue, bug reports, security alerts, etc.