### PR TITLE
Move palette class to HTML tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIGA-52: Fixed IE11 not displaying color themes correctly.
 - RIGA-56: Embed paragraph preview mode was breaking in admin.
 
 ### Security

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -68,7 +68,7 @@ function ecms_preprocess_html(array &$variables): void {
 
   // Add paletteClass from theme settings form.
   $paletteClass = 'qh__t__' . theme_get_setting('color_palette');
-  $variables['attributes']['class'][] = $paletteClass;
+  $variables['palette'] = $paletteClass;
 }
 
 /**

--- a/ecms_base/themes/custom/ecms/templates/layout/html.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/layout/html.html.twig
@@ -47,6 +47,7 @@
   skip_link: skip_link,
   page_top: page_top,
   page: page,
-  page_bottom: page_bottom
+  page_bottom: page_bottom,
+  palette: palette
 }
 %}


### PR DESCRIPTION
## Summary
This PR moves the palette class to the HTML tag rather than the body.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIGA-52