### PR TITLE
Several small event updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,22 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ## [Unreleased]
 ### Added
 - RIGA-57: Allow table tags within basic_html format.
+- RIGA-62: Support events that span multiple months in teaser view.
+- RIGA-62: Added patch for smart_date to fix issue with all day dates.
 
 ### Changed
 - RIGA-24: Update Drupal core from 9.0.x to 9.1.x.
 - RIGA-24: Update Views Ajax Get module to 1.x-dev.
 - RIGA-24: Restored functional tests for Github actions.
+- RIGA-61: Changed events view to use end date rather than start date for filter.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- RIGA-63: Fixed frontend output for all day events.
+- RIGA-77: Fixed events not showing restration url.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Fixed
 - RIGA-63: Fixed frontend output for all day events.
-- RIGA-77: Fixed events not showing restration url.
+- RIGA-77: Fixed events not showing registration url.
 
 ### Security
 

--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,9 @@
       "drupal/redirect": {
         "3082364 - Fix the migration of the status_code redirect property: status code of NULL or 0 causes exception": "https://www.drupal.org/files/issues/2020-07-28/redirect-fix_status_code_property_migration-3082364-13.patch"
       },
+      "drupal/smart_date": {
+        "Hide the end date unless different hides the end date on all day": "https://www.drupal.org/files/issues/2021-05-08/smart_date-dont_hide_all_day_end-3212990-2.patch"
+      },
       "drupal/paragraphs": {
         "2901390 - Integrity constraint violation: 1048 Column 'langcode' cannot be null": "https://www.drupal.org/files/issues/2020-06-25/paragraphs-2901390-51.patch",
         "3090200 - Paragraphs do not render: access check for 'view' fail when using layout builder": "https://www.drupal.org/files/issues/2020-07-08/access-controll-issue-3090200-22.patch",

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "3082364 - Fix the migration of the status_code redirect property: status code of NULL or 0 causes exception": "https://www.drupal.org/files/issues/2020-07-28/redirect-fix_status_code_property_migration-3082364-13.patch"
       },
       "drupal/smart_date": {
-        "Hide the end date unless different hides the end date on all day": "https://www.drupal.org/files/issues/2021-05-08/smart_date-dont_hide_all_day_end-3212990-2.patch"
+        "3212990 - Hide the end date unless different hides the end date on all day": "https://www.drupal.org/files/issues/2021-05-08/smart_date-dont_hide_all_day_end-3212990-2.patch"
       },
       "drupal/paragraphs": {
         "2901390 - Integrity constraint violation: 1048 Column 'langcode' cannot be null": "https://www.drupal.org/files/issues/2020-06-25/paragraphs-2901390-51.patch",

--- a/ecms_base/features/custom/ecms_event/config/install/views.view.events.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/views.view.events.yml
@@ -214,10 +214,10 @@ display:
           entity_type: node
           entity_field: default_langcode
           plugin_id: boolean
-        field_event_date_value:
-          id: field_event_date_value
+        field_event_date_end_value:
+          id: field_event_date_end_value
           table: node__field_event_date
-          field: field_event_date_value
+          field: field_event_date_end_value
           relationship: none
           group_type: group
           admin_label: ''

--- a/ecms_base/features/custom/ecms_event/ecms_event.info.yml
+++ b/ecms_base/features/custom/ecms_event/ecms_event.info.yml
@@ -1,34 +1,34 @@
 name: Event
 description: 'Provides Event content type and related configuration.'
 type: module
-core_version_requirement: ^9
+core_version_requirement: '^8.9 || ^9'
 dependencies:
-  - content_moderation
-  - content_translation
-  - ecms_feeds
-  - ecms_promotions
-  - ecms_workflow
-  - feeds
-  - field
-  - file
-  - image
-  - language
-  - link
-  - media
-  - media_library
-  - menu_ui
-  - metatag
-  - node
-  - path
-  - pathauto
-  - rabbit_hole
-  - scheduled_transitions
-  - simple_sitemap
-  - smart_date
-  - svg_image
-  - taxonomy
-  - text
-  - user
-  - views
+  - 'drupal:content_moderation'
+  - 'drupal:content_translation'
+  - 'drupal:field'
+  - 'drupal:file'
+  - 'drupal:image'
+  - 'drupal:language'
+  - 'drupal:link'
+  - 'drupal:media'
+  - 'drupal:media_library'
+  - 'drupal:menu_ui'
+  - 'drupal:node'
+  - 'drupal:path'
+  - 'drupal:taxonomy'
+  - 'drupal:text'
+  - 'drupal:user'
+  - 'drupal:views'
+  - 'ecms_feeds:ecms_feeds'
+  - 'ecms_promotions:ecms_promotions'
+  - 'ecms_workflow:ecms_workflow'
+  - 'feeds:feeds'
+  - 'metatag:metatag'
+  - 'pathauto:pathauto'
+  - 'rabbit_hole:rabbit_hole'
+  - 'scheduled_transitions:scheduled_transitions'
+  - 'simple_sitemap:simple_sitemap'
+  - 'smart_date:smart_date'
+  - 'svg_image:svg_image'
 package: eCMS
 version: 9.x-1.0

--- a/ecms_base/themes/custom/ecms/templates/content/node--event--full.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/content/node--event--full.html.twig
@@ -123,10 +123,10 @@
 {% endif %}
 
 {# Get registration link url #}
-{% if node.field_event_virtual_meeting_url.0.url.external %}
-  {% set registration_link_url = content.field_event_virtual_meeting_url.0['#url'].getUri() %}
+{% if node.field_event_registration_url.0.url.external %}
+  {% set registration_link_url = content.field_event_registration_url.0['#url'].getUri() %}
 {% else %}
-  {% set registration_link_url = content.field_event_virtual_meeting_url.0['#url'] %}
+  {% set registration_link_url = content.field_event_registration_url.0['#url'] %}
 {% endif %}
 
 {% include '@templates/01-content/node--event--full.twig' with {

--- a/ecms_base/themes/custom/ecms/templates/content/node--event--teaser.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/content/node--event--teaser.html.twig
@@ -73,9 +73,12 @@
 
 {{ attach_library('ecms/rrule-js') }}
 
-{# Month variables #}
-{% set month = node.field_event_date.value|date('F') %}
-{% set datetime_month_format = node.field_event_date.value|date('Y-m') %}
+{# Month variable #}
+{% if node.field_event_date.start_value|date('M') == node.field_event_date.end_value|date('M')  %}
+  {% set month = node.field_event_date.start_value|date('M') %}
+{% else %}
+  {% set month = node.field_event_date.start_value|date('M') ~ ' - ' ~ node.field_event_date.end_value|date('M') %}
+{% endif %}
 
 {# Start date variables #}
 {% set start_date = node.field_event_date.value|date('j') %}
@@ -90,12 +93,6 @@
 {% set datetime_starttime_format = node.field_event_date.value|date('H:i:s') %}
 {% set end_time = node.field_event_date.end_value|date('g:ia') %}
 {% set datetime_endtime_format = node.field_event_date.end_value|date('H:i:s') %}
-
-{% if start_time != end_time %}
-  {% set time = start_time ~ ' - ' ~ end_time %}
-{% else %}
-  {% set time = start_time %}
-{% endif %}
 
 {% include '@molecules/teaser-event/teaser-event.twig' with {
   title: node.label,


### PR DESCRIPTION
## Summary
This PR handles several small changes to the event functionality site that span multiple tickets.

- RIGA-62: Support events that span multiple months in teaser view.
- RIGA-62: Added patch for smart_date to fix issue with all day dates.
- RIGA-61: Changed events view to use end date rather than start date for filter.
- RIGA-63: Fixed frontend output for all day events.
- RIGA-77: Fixed events not showing registration url.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | ye
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIGA-62, https://thinkoomph.jira.com/browse/RIGA-61, https://thinkoomph.jira.com/browse/RIGA-63, https://thinkoomph.jira.com/browse/RIGA-77