### PR TITLE
Fixed issue with events displaying incorrect month.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIGA-85: Fixed issue with events displaying incorrect month.
 
 ### Security
 

--- a/ecms_base/themes/custom/ecms/templates/content/node--event--teaser.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/content/node--event--teaser.html.twig
@@ -74,15 +74,15 @@
 {{ attach_library('ecms/rrule-js') }}
 
 {# Month variable #}
-{% if node.field_event_date.start_value|date('M') == node.field_event_date.end_value|date('M')  %}
-  {% set month = node.field_event_date.start_value|date('M') %}
+{% if node.field_event_date.value|date('M') == node.field_event_date.end_value|date('M')  %}
+  {% set month = node.field_event_date.value|date('M') %}
 {% else %}
-  {% set month = node.field_event_date.start_value|date('M') ~ ' - ' ~ node.field_event_date.end_value|date('M') %}
+  {% set month = node.field_event_date.value|date('M') ~ ' - ' ~ node.field_event_date.end_value|date('M') %}
 {% endif %}
 
 {# Start date variables #}
 {% set start_date = node.field_event_date.value|date('j') %}
-{% set datetime_startdate_format = node.field_event_date.start_value|date('Y-m-d') %}
+{% set datetime_startdate_format = node.field_event_date.value|date('Y-m-d') %}
 
 {# End date variables #}
 {% set end_date = node.field_event_date.end_value|date('j') %}


### PR DESCRIPTION
## Summary
Fixed issue with events displaying incorrect month. Start value was always returning the value of the current month rather than pulling from field.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIGA-85