### PR TITLE
Setup profile to handle illustrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIGA-70: Added person additional fields taxonomy, field to person content type.
 - RIGA-70: Added photo support to person teaser and additional preprocessing to person and person_list.
 - RIGA-69: Add geolocation support for locations.
+- RIGA-78: Add pathauto pattern for Webform content type.
+- RIGA-74: Add theme setting for illustration and pass value to patternlab.
 
 ### Changed
 - RIGA-21: Remove Admin Tabs Showing for "Unpublish This Translation".

--- a/ecms_base/themes/custom/ecms/ecms.info.yml
+++ b/ecms_base/themes/custom/ecms/ecms.info.yml
@@ -30,6 +30,9 @@ component-libraries:
   icons:
     paths:
       - ecms_patternlab/source/images/icons
+  illustrations:
+    paths:
+      - ecms_patternlab/source/images/illustrations
   generic:
     paths:
       - templates/generic

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -34,6 +34,7 @@ function ecms_preprocess_page(array &$variables): void {
   $variables['header_preprocess_values']['top_line'] = ['#plain_text' => theme_get_setting('header_top_line')];
   $variables['header_preprocess_values']['main_line'] = ['#plain_text' => theme_get_setting('header_main_line')];
   $variables['header_preprocess_values']['bottom_line'] = ['#plain_text' => theme_get_setting('header_bottom_line')];
+  $variables['illustration'] = theme_get_setting('illustration_option');
 
   // Attach footer variables.
   $variables['footer_preprocess_values']['footer_left'] = [

--- a/ecms_base/themes/custom/ecms/templates/layout/page--landing-page.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/layout/page--landing-page.html.twig
@@ -53,6 +53,7 @@
   node: node,
   header_preprocess_values: header_preprocess_values,
   footer_preprocess_values: footer_preprocess_values,
+  illustration: illustration
 }
 %}
 

--- a/ecms_base/themes/custom/ecms/templates/layout/page.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/layout/page.html.twig
@@ -53,6 +53,7 @@
   node: node,
   header_preprocess_values: header_preprocess_values,
   footer_preprocess_values: footer_preprocess_values,
+  illustration: illustration
 }
 %}
 

--- a/ecms_base/themes/custom/ecms/theme-settings.php
+++ b/ecms_base/themes/custom/ecms/theme-settings.php
@@ -80,7 +80,7 @@ function ecms_form_system_theme_settings_alter(&$form, FormStateInterface $form_
     // Set up hardcoded options.
     $illustrationOptions = [
       'none' => t("No illustration"),
-      $randomKeyString => t("Random illustration")
+      $randomKeyString => t("Random illustration"),
     ];
 
     // Add compilied list to hardcoded options.

--- a/ecms_base/themes/custom/ecms/theme-settings.php
+++ b/ecms_base/themes/custom/ecms/theme-settings.php
@@ -24,6 +24,8 @@ function ecms_form_system_theme_settings_alter(&$form, FormStateInterface $form_
   ];
 
   $theme = \Drupal::theme()->getActiveTheme();
+
+  // Pallete options.
   $color_config_json_string = file_get_contents("{$theme->getPath()}/ecms_patternlab/source/_data/color-config.json");
   if ($color_config_json_string) {
 
@@ -49,6 +51,47 @@ function ecms_form_system_theme_settings_alter(&$form, FormStateInterface $form_
       "#default_value" => theme_get_setting('color_palette'),
       "#options" => $paletteOptions,
       "#description" => t("Select which color palette the site will use."),
+    ];
+  }
+
+  // Illustration options.
+  $illustration_json_string = file_get_contents("{$theme->getPath()}/ecms_patternlab/source/_data/illustrations.json");
+  if ($illustration_json_string) {
+
+    $json_decoded = json_decode($illustration_json_string, TRUE);
+    if ($json_decoded === NULL) {
+      return;
+    }
+
+    $illustrations = [];
+    $allFilenames = [];
+
+    // Loop over illustrations and build out arrays.
+    foreach ($json_decoded['illustrations'] as $key => $object) {
+      $illustrations[$object['filename']] = $key;
+      $allFilenames[] = $object['filename'];
+    }
+
+    // Comma separate all filenames to pass as the key for the random selection.
+    // Twig will parse this string and select a filename at random.
+    $allFilenames = implode(', ', $allFilenames);
+    $randomKeyString = 'random:' . $allFilenames;
+
+    // Set up hardcoded options.
+    $illustrationOptions = [
+      'none' => t("No illustration"),
+      $randomKeyString => t("Random illustration")
+    ];
+
+    // Add compilied list to hardcoded options.
+    $illustrationOptions = $illustrationOptions + $illustrations;
+
+    $form['ecms_theme_options']['illustration_option'] = [
+      "#type" => "select",
+      "#title" => t("Illustration"),
+      "#default_value" => theme_get_setting('illustration_option'),
+      "#options" => $illustrationOptions,
+      "#description" => t("Select your configuration for page illustrations."),
     ];
   }
 

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -114,11 +114,11 @@ echo " Initialize lando for local usage "
 echo "----------------------------------"
 cd ${DEST_DIR}
 
-#echo "Lock Drupal core to 9.0 branch."
-#$COMPOSER require "drupal/core-composer-scaffold:~9.0.9" --no-update
-#$COMPOSER require "drupal/core-project-message:~9.0.9" --no-update
-#$COMPOSER require "drupal/core-recommended:~9.0.9" --no-update
-#$COMPOSER require "drupal/core-vendor-hardening:~9.0.9" --no-update
+echo "Lock Drupal core to 9.1.9 branch."
+$COMPOSER require "drupal/core-composer-scaffold:9.1.9" --no-update
+$COMPOSER require "drupal/core-project-message:9.1.9" --no-update
+$COMPOSER require "drupal/core-recommended:9.1.9" --no-update
+$COMPOSER require "drupal/core-vendor-hardening:9.1.9" --no-update
 
 
 echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} $LANDO init --name $APP_NAME --recipe drupal9 --webroot $DOCROOT --source cwd\n\n"


### PR DESCRIPTION
## Summary
This PR adds a theme setting to pick an illustration and pass it to patternlab.

Also included is the necessary change to lock Drupal core.

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIGA-74