### PR TITLE
Remove unpublish and publish tabs from node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
+- RIGA-21: Remove Admin Tabs Showing for "Unpublish This Translation".
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -76,9 +76,6 @@
       "drupal/openid_connect_windows_aad": {
         "3169996 - Incorrect configuration schema file": "https://www.drupal.org/files/issues/2020-09-09/openid_connect_windows_aad-schema-update-3169996-3.patch"
       },
-      "drupal/publishcontent": {
-        "3170248 - Configuration Schema Errors": "https://www.drupal.org/files/issues/2020-09-10/publishcontent-schema-3170248-2.patch"
-      },
       "drupal/redirect": {
         "3082364 - Fix the migration of the status_code redirect property: status code of NULL or 0 causes exception": "https://www.drupal.org/files/issues/2020-07-28/redirect-fix_status_code_property_migration-3082364-13.patch"
       },
@@ -164,7 +161,7 @@
     "drupal/openid_connect_windows_aad": "^1.3",
     "drupal/paragraphs": "^1.12",
     "drupal/pathauto": "^1.8",
-    "drupal/publishcontent": "^1.2",
+    "drupal/publishcontent": "^1.3",
     "drupal/rabbit_hole": "^1.0",
     "drupal/real_aes": "^2.3",
     "drupal/redirect": "^1.6",

--- a/ecms_base/modules/custom/ecms_languages/ecms_languages.module
+++ b/ecms_base/modules/custom/ecms_languages/ecms_languages.module
@@ -63,11 +63,11 @@ function ecms_languages_pathauto_alias_alter(&$alias, array &$context): void {
 }
 
 /**
- * Implementation of hook_menu_local_tasks_alter().
+ * Implements hook_menu_local_tasks_alter().
  */
 function ecms_languages_menu_local_tasks_alter(array &$data, string $route_name): void {
   // Remove the toggle publish tabs for node view and edit routes.
-  if($route_name === 'entity.node.canonical'
+  if ($route_name === 'entity.node.canonical'
     || $route_name === 'entity.node.edit_form') {
 
     // Hide the "Publish" / "Unpublish" tabs since they do not work

--- a/ecms_base/modules/custom/ecms_languages/ecms_languages.module
+++ b/ecms_base/modules/custom/ecms_languages/ecms_languages.module
@@ -61,3 +61,22 @@ function ecms_languages_pathauto_alias_alter(&$alias, array &$context): void {
   // Force all aliases to be saved as language neutral.
   $context['language'] = Language::LANGCODE_NOT_SPECIFIED;
 }
+
+/**
+ * Implementation of hook_menu_local_tasks_alter().
+ */
+function ecms_languages_menu_local_tasks_alter(array &$data, string $route_name): void {
+  // Remove the toggle publish tabs for node view and edit routes.
+  if($route_name === 'entity.node.canonical'
+    || $route_name === 'entity.node.edit_form') {
+
+    // Hide the "Publish" / "Unpublish" tabs since they do not work
+    // with content moderation.
+    if (!empty($data['tabs'][0]['entity.node.publish'])) {
+      unset($data['tabs'][0]['entity.node.publish']);
+    }
+    if (!empty($data['tabs'][0]['entity.node.publish_translation'])) {
+      unset($data['tabs'][0]['entity.node.publish_translation']);
+    }
+  }
+}


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
<!-- Include a summary of your changes that expands upon the title. -->
This updates the publishcontent module which provides the publishing toggle tabs we want to target and remove.
It removes a patch that was committed to the recent release (yay @pfrilling !).
The logic is provided via the menu_local_tasks_alter hook

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIGA-21