### PR TITLE
Add taxonomy for media files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-104: Added File Tags taxonomy for media files.
 
 ### Changed
 

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.media.file.field_file_description
     - field.field.media.file.field_file_link_behavior
     - field.field.media.file.field_file_size
+    - field.field.media.file.field_file_tags
     - field.field.media.file.field_file_type
     - media.type.file
   module:
@@ -43,6 +44,12 @@ content:
     third_party_settings: {  }
     type: options_select
     region: content
+  field_file_tags:
+    weight: 28
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   langcode:
     type: language_select
     weight: 2
@@ -73,9 +80,9 @@ content:
     third_party_settings: {  }
   translation:
     weight: 10
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 2

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.media_library.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.media.file.media_library.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.media.file.field_file_description
     - field.field.media.file.field_file_link_behavior
     - field.field.media.file.field_file_size
+    - field.field.media.file.field_file_tags
     - field.field.media.file.field_file_type
     - media.type.file
 id: media.file.media_library
@@ -40,6 +41,7 @@ hidden:
   field_file_description: true
   field_file_link_behavior: true
   field_file_size: true
+  field_file_tags: true
   field_file_type: true
   path: true
   status: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.taxonomy_term.file_tags.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_form_display.taxonomy_term.file_tags.default.yml
@@ -1,0 +1,43 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.file_tags
+  module:
+    - text
+id: taxonomy_term.file_tags.default
+targetEntityType: taxonomy_term
+bundle: file_tags
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      placeholder: ''
+      rows: 5
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  path: true
+  status: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.file.default.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.file.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.media.file.field_file_description
     - field.field.media.file.field_file_link_behavior
     - field.field.media.file.field_file_size
+    - field.field.media.file.field_file_tags
     - field.field.media.file.field_file_type
     - media.type.file
   module:
@@ -42,6 +43,7 @@ hidden:
   created: true
   field_file: true
   field_file_size: true
+  field_file_tags: true
   field_file_type: true
   langcode: true
   search_api_excerpt: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.file.media_library.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/core.entity_view_display.media.file.media_library.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.media.file.field_file_description
     - field.field.media.file.field_file_link_behavior
     - field.field.media.file.field_file_size
+    - field.field.media.file.field_file_tags
     - field.field.media.file.field_file_type
     - image.style.media_library
     - media.type.file
@@ -44,6 +45,7 @@ hidden:
   field_file_description: true
   field_file_link_behavior: true
   field_file_size: true
+  field_file_tags: true
   field_file_type: true
   langcode: true
   search_api_excerpt: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.file.field_file_tags.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.file.field_file_tags.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_file_tags
+    - media.type.file
+    - taxonomy.vocabulary.file_tags
+id: media.file.field_file_tags
+field_name: field_file_tags
+entity_type: media
+bundle: file
+label: 'File Tags'
+description: 'Select a tag to group this file within a list of files output by the file list component'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      file_tags: file_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.storage.media.field_file_tags.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.storage.media.field_file_tags.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - taxonomy
+id: media.field_file_tags
+field_name: field_file_tags
+entity_type: media
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.taxonomy_term.file_tags.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/language.content_settings.taxonomy_term.file_tags.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.file_tags
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: taxonomy_term.file_tags
+target_entity_type_id: taxonomy_term
+target_bundle: file_tags
+default_langcode: site_default
+language_alterable: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/rabbit_hole.behavior_settings.taxonomy_vocabulary_file_tags.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/rabbit_hole.behavior_settings.taxonomy_vocabulary_file_tags.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.file_tags
+id: taxonomy_vocabulary_file_tags
+entity_type_id: taxonomy_vocabulary
+entity_id: file_tags
+action: page_redirect
+allow_override: 1
+redirect: /
+redirect_code: 301
+redirect_fallback_action: access_denied

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/taxonomy.vocabulary.file_tags.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/taxonomy.vocabulary.file_tags.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'File Tags'
+vid: file_tags
+description: 'Provides optional tags for file grouping'
+weight: 0

--- a/ecms_base/features/custom/ecms_paragraphs/ecms_paragraphs.features.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/ecms_paragraphs.features.yml
@@ -1,1 +1,8 @@
 bundle: ecms
+required:
+  - language.content_settings.taxonomy_term.file_tags
+  - core.entity_form_display.taxonomy_term.file_tags.default
+  - field.field.media.file.field_file_tags
+  - field.storage.media.field_file_tags
+  - rabbit_hole.behavior_settings.taxonomy_vocabulary_file_tags
+  - taxonomy.vocabulary.file_tags

--- a/ecms_base/features/custom/ecms_paragraphs/ecms_paragraphs.info.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/ecms_paragraphs.info.yml
@@ -18,6 +18,7 @@ dependencies:
   - 'drupal:media_library'
   - 'drupal:options'
   - 'drupal:path'
+  - 'drupal:taxonomy'
   - 'drupal:text'
   - 'drupal:user'
   - 'ecms_icon_library:ecms_icon_library'
@@ -25,6 +26,7 @@ dependencies:
   - 'metatag:metatag'
   - 'paragraphs:paragraphs'
   - 'paragraphs:paragraphs_translation_sync'
+  - 'rabbit_hole:rabbit_hole'
   - 'svg_image:svg_image'
 version: 9.x-1.0
 package: eCMS


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
<!-- Include a summary of your changes that expands upon the title. -->
Adds a new vocabulary "File Tags" and associated term reference field to the media file bundle.
Optional field, single term only.
Terms are translatable.
Added to the ecms_paragraphs feature which contains the media file bundle.

This is the next step in the larger file list by taxonomy component. This will allow client to begin file tagging on development sites while we work to finish the actual paragraph component that will be used to output files by a given term.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIGA-104