### PR TITLE
Add search state block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ## [Unreleased]
 ### Added
 - RIGA-162: Added State Search CTA to acquia search results.
+- RIGA-163: Added search state block.
 
 ### Changed
 - RIGA-6: Update oomphinc/drupal-scaffold to 1.2.x branch.

--- a/ecms_base/modules/custom/ecms_blocks/src/Form/SearchStateBlockForm.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Form/SearchStateBlockForm.php
@@ -57,7 +57,7 @@ class SearchStateBlockForm extends FormBase {
       'q' => $input,
     ];
 
-    $response = new TrustedRedirectResponse(Url::fromUri("https://rigov.ecms.ri.gov/search/index.php", $params)->toString());
+    $response = new TrustedRedirectResponse(Url::fromUri("https://www.ri.gov/search/result.php", $params)->toString());
 
     $metadata = $response->getCacheableMetadata();
     $metadata->setCacheMaxAge(0);

--- a/ecms_base/modules/custom/ecms_blocks/src/Form/SearchStateBlockForm.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Form/SearchStateBlockForm.php
@@ -30,7 +30,7 @@ class SearchStateBlockForm extends FormBase {
 
     $form['search_input'] = [
       '#type' => 'textfield',
-      "#placeholder" => $this->t('Search the site'),
+      "#placeholder" => $this->t('Search all RI.gov sites'),
       '#required' => TRUE,
       "#attributes" => [
         'type' => "search",

--- a/ecms_base/modules/custom/ecms_blocks/src/Form/SearchStateBlockForm.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Form/SearchStateBlockForm.php
@@ -30,7 +30,7 @@ class SearchStateBlockForm extends FormBase {
 
     $form['search_input'] = [
       '#type' => 'textfield',
-      "#placeholder" => $this->t('Search all RI.gov sites'),
+      "#placeholder" => $this->t('Search RI Government'),
       '#required' => TRUE,
       "#attributes" => [
         'type' => "search",

--- a/ecms_base/modules/custom/ecms_blocks/src/Form/SearchStateBlockForm.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Form/SearchStateBlockForm.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\ecms_blocks\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+
+/**
+ * Provides a custom site search form.
+ *
+ * @package Drupal\ecms_blocks\Form
+ */
+class SearchStateBlockForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'ecms_search_state_block_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+
+    $form['search_input'] = [
+      '#type' => 'textfield',
+      "#placeholder" => $this->t('Search the site'),
+      '#required' => TRUE,
+      "#attributes" => [
+        'type' => "search",
+      ],
+      '#theme_wrappers' => [],
+    ];
+
+    $form['actions']['#type'] = 'actions';
+
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Search'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $input = $form_state->getValue('search_input');
+    $params['query'] = [
+      'q' => $input,
+    ];
+
+    $response = new TrustedRedirectResponse(Url::fromUri("https://rigov.ecms.ri.gov/search/index.php", $params)->toString());
+
+    $metadata = $response->getCacheableMetadata();
+    $metadata->setCacheMaxAge(0);
+
+    $form_state->setResponse($response);
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SearchStateBlock.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SearchStateBlock.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\ecms_blocks\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Form\FormBuilderInterface;
+
+/**
+ * Provides a custom block for the site search form.
+ *
+ * @Block(
+ *   id = "ecms_search_state_block",
+ *   admin_label = @Translation("Search State Block"),
+ * )
+ */
+class SearchStateBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Form builder service.
+   *
+   * @var \Drupal\Core\Form\FormBuilderInterface
+   */
+  protected $formBuilder;
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('form_builder')
+    );
+  }
+
+  /**
+   * SearchBlock constructor.
+   *
+   * @param array $configuration
+   *   Configuration array for the block.
+   * @param string $plugin_id
+   *   The plugin id.
+   * @param mixed $plugin_definition
+   *   The plugin definition.
+   * @param \Drupal\Core\Form\FormBuilderInterface $form_builder
+   *   The Form builder service.
+   */
+  public function __construct(array $configuration, string $plugin_id, $plugin_definition, FormBuilderInterface $form_builder) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->formBuilder = $form_builder;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(): array {
+
+    $output['form'] = $this->formBuilder->getForm('Drupal\ecms_blocks\Form\SearchStateBlockForm');
+    return $output;
+
+  }
+
+}

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -334,6 +334,7 @@ function ecms_theme_suggestions_input_alter(array &$suggestions, array $variable
  */
 function ecms_form_alter(&$form, FormStateInterface $form_state, string $form_id): void {
   if ($form_id === 'ecms_search_block_form'
+    || $form_id === 'ecms_search_state_block_form'
     || $form['#id'] === "views-exposed-form-site-search-page-1"
     || $form['#id'] === "views-exposed-form-acquia-search-page"
     || $form['#id'] === "views-exposed-form-acquia-search-page-1"

--- a/ecms_base/themes/custom/ecms/templates/blocks/block--ecms-search-state-block.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/blocks/block--ecms-search-state-block.html.twig
@@ -1,0 +1,11 @@
+{#
+/**
+ * @file
+ * Theme override for the ecms search block.
+#}
+
+{% include '@molecules/site-search/site-search.twig' with {
+    content: content,
+    js_id: TRUE
+  }
+%}


### PR DESCRIPTION
## Summary
This PR adds a search state block that can be used instead of the existing search block. The search link is hardcoded as discussed previously. This will be a manual process of switching blocks for the sites that would like to use it.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIGA-163