### PR TITLE
Add Search State CTA to acquia search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-162: Added State Search CTA to acquia search results.
 
 ### Changed
 - RIGA-6: Update oomphinc/drupal-scaffold to 1.2.x branch.

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -285,6 +285,17 @@ function ecms_preprocess_views_view(array &$variables): void {
 }
 
 /**
+ * Implements hook_preprocess_view().
+ */
+function ecms_preprocess_views_view_unformatted(array &$variables): void {
+  $view = $variables['view'];
+
+  if ($variables['view']->id() === "acquia_search") {
+    $variables['search_link'] = "https://rigov.ecms.ri.gov/search/index.php?q=" . \Drupal::request()->query->get('search_api_fulltext');
+  }
+}
+
+/**
  * Implements hook_preprocess_menu().
  */
 function ecms_preprocess_menu__minor(array &$variables): void {

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -291,7 +291,7 @@ function ecms_preprocess_views_view_unformatted(array &$variables): void {
   $view = $variables['view'];
 
   if ($variables['view']->id() === "acquia_search") {
-    $variables['search_link'] = "https://rigov.ecms.ri.gov/search/index.php?q=" . \Drupal::request()->query->get('search_api_fulltext');
+    $variables['search_link'] = "https://www.ri.gov/search/result.php?q=" . \Drupal::request()->query->get('search_api_fulltext');
   }
 }
 

--- a/ecms_base/themes/custom/ecms/templates/views/views-view-unformatted--acquia-search.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/views/views-view-unformatted--acquia-search.html.twig
@@ -61,6 +61,10 @@
     {{ pager }}
   {% endif %}
 
+  {% include '@molecules/search-state-cta/search-state-cta.twig' with {
+    search_link: search_link,
+  } %}
+
   {% if feed_icons %}
     <div class="feed-icons">
       {{ feed_icons }}


### PR DESCRIPTION
## Summary
This PR references a new Pattern Lab component for a search state CTA. The component will redirect users to the ri.gov site search.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| `CHANGELOG` reflects changes? | yes
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIGA-162