### PR TITLE
Riga 185/remove press from workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,28 +1,21 @@
-<!-- INSTRUCTIONS
-- Please use a meaningful pull request title which does not include the issue
-  key or branch name.
-- Please apply meaningful GitHub Labels to your pull request such as: PHP,
-  Twig, SCSS, JS, etc.
-- Please make sure you've reviewed the "Files changed" tab before opening this
-  PR to ensure it includes what you expect (and nothing more) and adheres to
-  our coding standards.
-- Browser requirements can be found in docs/browser-requirements.md from the
-  root of the project.
--->
-
-## Summary
+## Summary / Approach
 <!-- Include a summary of your changes that expands upon the title. -->
+
+## Testing Instruction(s)
+<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
+
+## Screenshots
+<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->
 
 ## Metadata
 <!-- Please fill out ALL metadata. Use N/A when necessary. -->
 | Question | Answer |
 |----------|--------|
-| Did you use a meaningful pull request title? | yes/no
-| Did you apply meaningful labels to the pull request? | yes/no
-| Did you perform a self review first? | yes/no
-| Documentation reflects changes? | yes/no
-| `CHANGELOG` reflects changes? | yes/no
-| Unit/Functional tests reflect changes? | yes/no
-| Did you perform browser testing? | yes/no
-| Risk level | Low, Medium, High
+| Did you apply meaningful labels to the pull request? |
+| Documentation reflects changes? |
+| `CHANGELOG` reflects changes? |
+| Unit/Functional tests cover changes? |
+| Did you perform browser testing? |
+| Did you provide detail in the summary on how and where to test this branch? |
+| Risk level |
 | Relevant links | JIRA issue, bug reports, security alerts, etc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
+- RIGA-185: Remove press releases from editorial workflow.
 
 ### Deprecated
 

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -1386,3 +1386,12 @@ function ecms_base_update_9081(array &$sandbox): void {
   }
 
 }
+
+/**
+ * Remove press releases from workflow.
+ */
+function ecms_base_update_9082(array &$sandbox): void {
+  /** @var \Drupal\ecms_workflow\EcmsWorkflowBundleCreate $workflowBundleCreate */
+  $workflowBundleCreate = \Drupal::service('ecms_workflow.bundle_create');
+  $workflowBundleCreate->removeContentTypeFromWorkflow('press_release');
+}

--- a/ecms_base/modules/custom/ecms_workflow/README.md
+++ b/ecms_base/modules/custom/ecms_workflow/README.md
@@ -1,0 +1,12 @@
+# ECMS Workflow
+
+The ecms_workflow custom module provides functionality to help manage
+the editorial workflow settings for content types. It provides the
+default workflow configuration, and implements `hook_entity_bundle_create()`
+to automate the application of the preferred workflow to all new content types.
+
+## Exclusion
+
+Not all content types are managed by the default workflow. The current
+exceptions are press release and notifications.
+

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -278,7 +278,7 @@ class EcmsWorkflowBundleCreate {
     $config = $workflow->getTypePlugin()->getConfiguration();
     $currentNodes = $config["entity_types"]["node"];
 
-    // Make sure we remove any duplicates
+    // Make sure we remove any duplicates.
     $currentNodes = array_unique($currentNodes);
     $newNodesList = [];
     foreach ($currentNodes as $type) {

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -276,8 +276,22 @@ class EcmsWorkflowBundleCreate {
     $workflow = array_shift($workflowEntities);
 
     $config = $workflow->getTypePlugin()->getConfiguration();
-    unset($config["entity_types"]["node"][$contentType]);
-    unset($config["dependencies"]["config"]["node.type." . $contentType]);
+    $currentNodes = $config["entity_types"]["node"];
+
+    // Make sure we remove any duplicates
+    $currentNodes = array_unique($currentNodes);
+    $newNodesList = [];
+    foreach ($currentNodes as $type) {
+
+      // Maintain all other node types.
+      if ($type !== $contentType) {
+        $newNodesList[] = $type;
+      }
+    }
+
+    // Reset the node list to the maintained.
+    $config["entity_types"]["node"] = $newNodesList;
+
     $workflow->getTypePlugin()->setConfiguration($config);
 
     try {

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -43,7 +43,7 @@ class EcmsWorkflowBundleCreate {
   /**
    * Array of content types to exclude.
    */
-  const EXCLUDED_TYPES = ['notification'];
+  const EXCLUDED_TYPES = ['notification', 'press_release'];
 
   /**
    * The entity_type.manager service.

--- a/scripts/ci-develop.sh
+++ b/scripts/ci-develop.sh
@@ -31,7 +31,7 @@ cd $APP_NAME;
 $COMPOSER config minimum-stability "dev"
 
 # Add the development requirements for testing.
-$COMPOSER require "behat/mink-goutte-driver" --dev --no-update
+$COMPOSER require "behat/mink-goutte-driver:~1.2" --dev --no-update
 $COMPOSER require "php-mock/php-mock" --dev --no-update
 $COMPOSER require "php-mock/php-mock-phpunit" --dev --no-update
 $COMPOSER require "weitzman/drupal-test-traits" --dev --no-update


### PR DESCRIPTION
<!-- INSTRUCTIONS
- Please use a meaningful pull request title which does not include the issue
  key or branch name.
- Please apply meaningful GitHub Labels to your pull request such as: PHP,
  Twig, SCSS, JS, etc.
- Please make sure you've reviewed the "Files changed" tab before opening this
  PR to ensure it includes what you expect (and nothing more) and adheres to
  our coding standards.
- Browser requirements can be found in docs/browser-requirements.md from the
  root of the project.
-->

## Summary
<!-- Include a summary of your changes that expands upon the title. -->
Add a "removefromworkflow" method to the ecmsWorkflow class so there is a way to programmatically remove a content type from the existing workflow. Add press release to the exclude list so it's not added to future sites.
Write update hook to call the new remove method.
Update PR template per our new specs.
Added a ecms_workflow readme file.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|

| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | no
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | https://thinkoomph.jira.com/browse/RIGA-185