### PR TITLE
Add translation link to inline blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-182: Added inline block translation links for admins.
 
 ### Changed
 - RIGA-103: Use EcmsApiPublisher service to syndicate Press Releases.

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -607,6 +607,15 @@ function ecms_preprocess_block(array &$variables): void {
       $variables['label'] = $variables['content']['#block_content']->label();
     }
   }
+
+  // Send node translation status to blocks.
+  $variables['current_node_has_translation'] = FALSE;
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if ($node instanceof EntityInterface) {
+    // Get translated languages excluding default.
+    $translations = $node->getTranslationLanguages(FALSE);
+    $variables['current_node_has_translation'] = (bool) count($translations);
+  }
 }
 
 /**

--- a/ecms_base/themes/custom/ecms/templates/blocks/block--inline-block--content-components.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/blocks/block--inline-block--content-components.html.twig
@@ -23,6 +23,8 @@
  *   displayed in front of the main title tag that appears in the template.
  * - title_suffix: Additional output populated by modules, intended to be
  *   displayed after the main title tag that appears in the template.
+ * - current_node_has_translation: Boolean value indicating if the current
+ *   node (if applicable) has any translations. @see ecms_preprocess_block().
  *
  * @see template_preprocess_block()
  *
@@ -40,7 +42,7 @@
 {# Add block translate link manually for now until core contextual links issue is resolved.
    @see: https://www.drupal.org/node/3020876
 #}
-{% if logged_in %}
+{% if logged_in and current_node_has_translation %}
   <a href="/block/{{ elements.content['#block_content'].id() }}/translations">{{ 'Translate Block'|t }}</a>
 {% endif %}
 

--- a/ecms_base/themes/custom/ecms/templates/blocks/block--inline-block--content-components.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/blocks/block--inline-block--content-components.html.twig
@@ -37,6 +37,13 @@
   {% set bg_color_class = 'qh__tc__' ~ content['#block_content'].get('field_components_bg_color').value|clean_class %}
 {% endif %}
 
+{# Add block translate link manually for now until core contextual links issue is resolved.
+   @see: https://www.drupal.org/node/3020876
+#}
+{% if logged_in %}
+  <a href="/block/{{ elements.content['#block_content'].id() }}/translations">{{ 'Translate Block'|t }}</a>
+{% endif %}
+
 {% include '@organisms/content-components-block/content-components-block.twig' with {
   label: label,
   title_prefix: title_prefix,


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
Add block translate links for each inline block component. Only adds them to translated nodes. This temporarily resolves the issue in RIGA-182 where admins no longer get the contextual links on inline block for layout builder enabled pages.

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
Checkout branch and review locally, ensure links are shown for authenticated users but not for anonymous.
Add a new landing page with no translation, add a block. Should not see translate link.

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

Logged in, translated node:
![image](https://user-images.githubusercontent.com/53975352/149196547-4049bba5-2138-4014-a679-5511cdb36ba3.png)

Logged out, translated node:
![image](https://user-images.githubusercontent.com/53975352/149196612-36932937-78c2-4655-9467-6dd2a0c93e83.png)

Logged in, untranslated node:
![image](https://user-images.githubusercontent.com/53975352/149197438-9c061996-9a66-47fe-b651-160292f59be7.png)



## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? | y
| Documentation reflects changes? | y - comments should be helpful when we remove this.
| `CHANGELOG` reflects changes? | y
| Unit/Functional tests cover changes? | n
| Did you perform browser testing? | y
| Did you provide detail in the summary on how and where to test this branch? | y
| Risk level | low
| Relevant links | https://thinkoomph.jira.com/browse/RIGA-182
