### PR TITLE
Add aria-label to search block input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Fixed
 - RIGA-192: File revert button on file not showing for all users.
+- RIGA-191: Fixed aria-label missing from search block input.
 
 ### Security
 

--- a/ecms_base/modules/custom/ecms_blocks/src/Form/SearchBlockForm.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Form/SearchBlockForm.php
@@ -33,7 +33,7 @@ class SearchBlockForm extends FormBase {
       '#required' => TRUE,
       "#attributes" => [
         'type' => "search",
-        'aria-label' => $this->t("Search")
+        'aria-label' => $this->t("Search"),
       ],
       '#theme_wrappers' => [],
     ];

--- a/ecms_base/modules/custom/ecms_blocks/src/Form/SearchBlockForm.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Form/SearchBlockForm.php
@@ -33,6 +33,7 @@ class SearchBlockForm extends FormBase {
       '#required' => TRUE,
       "#attributes" => [
         'type' => "search",
+        'aria-label' => $this->t("Search")
       ],
       '#theme_wrappers' => [],
     ];

--- a/ecms_base/modules/custom/ecms_blocks/src/Form/SearchStateBlockForm.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Form/SearchStateBlockForm.php
@@ -34,7 +34,7 @@ class SearchStateBlockForm extends FormBase {
       '#required' => TRUE,
       "#attributes" => [
         'type' => "search",
-        'aria-label' => $this->t("Search")
+        'aria-label' => $this->t("Search"),
       ],
       '#theme_wrappers' => [],
     ];

--- a/ecms_base/modules/custom/ecms_blocks/src/Form/SearchStateBlockForm.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Form/SearchStateBlockForm.php
@@ -34,6 +34,7 @@ class SearchStateBlockForm extends FormBase {
       '#required' => TRUE,
       "#attributes" => [
         'type' => "search",
+        'aria-label' => $this->t("Search")
       ],
       '#theme_wrappers' => [],
     ];


### PR DESCRIPTION
## Summary / Approach
This PR fixes an accessibility issue with the aria-label missing from search block input.

## Testing Instruction(s)
Test the search block in the header to see if it has an aria-label.

## Screenshots

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? | y
| Documentation reflects changes? |
| `CHANGELOG` reflects changes? | y
| Unit/Functional tests cover changes? |
| Did you perform browser testing? |
| Did you provide detail in the summary on how and where to test this branch? |
| Risk level | l 
| Relevant links | https://thinkoomph.jira.com/browse/RIGA-191