### PR TITLE
Restore press to workflow, provide option to exclude on a site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-223: Added eCMS Workflow config to allow sites to exclude content types from default workflow.
 
 ### Changed
 - RIGA-222: Update core to 9.3.8.
 - RIGA-222: Update core patch for issue 1356276 (profiles can define base/parent).
 - RIGA-222: Update Simple OAuth from 4.6 to 5.2.
+- RIGA-223: Restored press_release to the default workflow.
 
 ### Deprecated
 

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -1456,4 +1456,20 @@ function ecms_base_update_9085(array &$sandbox): void {
   $workflowBundleCreate = \Drupal::service('ecms_workflow.bundle_create');
   $workflowBundleCreate->addContentTypeToWorkflow('press_release');
 
+  // Import new ecms_workflow.settings config
+  $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
+
+  $workflow_source = new FileStorage($path . "/modules/custom/ecms_workflow/config/install/");
+
+  /** @var \Drupal\Core\Config\StorageInterface $active_storage */
+  $active_storage = \Drupal::service('config.storage');
+
+  $newConfig = [
+    'ecms_workflow.settings',
+  ];
+
+  foreach ($newConfig as $config) {
+    $active_storage->write("{$config}", $workflow_source->read("{$config}"));
+  }
+
 }

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -1446,3 +1446,14 @@ function ecms_base_update_9084(array &$sandbox): void {
   }
 
 }
+
+/**
+ * Add press_release back to workflow.
+ */
+function ecms_base_update_9085(array &$sandbox): void {
+
+  /** @var \Drupal\ecms_workflow\EcmsWorkflowBundleCreate $workflowBundleCreate */
+  $workflowBundleCreate = \Drupal::service('ecms_workflow.bundle_create');
+  $workflowBundleCreate->addContentTypeToWorkflow('press_release');
+
+}

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -1456,7 +1456,7 @@ function ecms_base_update_9085(array &$sandbox): void {
   $workflowBundleCreate = \Drupal::service('ecms_workflow.bundle_create');
   $workflowBundleCreate->addContentTypeToWorkflow('press_release');
 
-  // Import new ecms_workflow.settings config
+  // Import new ecms_workflow.settings config.
   $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
 
   $workflow_source = new FileStorage($path . "/modules/custom/ecms_workflow/config/install/");

--- a/ecms_base/modules/custom/ecms_feeds/src/Feeds/Parser/EcmsIcalParser.php
+++ b/ecms_base/modules/custom/ecms_feeds/src/Feeds/Parser/EcmsIcalParser.php
@@ -148,4 +148,11 @@ class EcmsIcalParser extends PluginBase implements ParserInterface {
     ];
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getSupportedCustomSourcePlugins(): array {
+    return [];
+  }
+
 }

--- a/ecms_base/modules/custom/ecms_workflow/config/install/ecms_workflow.settings.yml
+++ b/ecms_base/modules/custom/ecms_workflow/config/install/ecms_workflow.settings.yml
@@ -1,0 +1,1 @@
+excluded_content_types: { }

--- a/ecms_base/modules/custom/ecms_workflow/ecms_workflow.links.menu.yml
+++ b/ecms_base/modules/custom/ecms_workflow/ecms_workflow.links.menu.yml
@@ -1,0 +1,6 @@
+ecms_workflow.settings_form:
+  title: 'eCMS Workflow Configuration'
+  description: 'Configure the excluded content types for the default workflow.'
+  route_name: ecms_worksflow.settings_form
+  parent: entity.workflow.collection
+  weight: 10

--- a/ecms_base/modules/custom/ecms_workflow/ecms_workflow.routing.yml
+++ b/ecms_base/modules/custom/ecms_workflow/ecms_workflow.routing.yml
@@ -1,0 +1,7 @@
+ecms_worksflow.settings_form:
+  path: 'admin/config/workflow/workflows/ecms_workflow/settings'
+  defaults:
+    _form: '\Drupal\ecms_workflow\Form\EcmsWorkflowConfigForm'
+    _title: 'eCMS Workflow Configuration'
+  requirements:
+    _permission: 'administer site configuration'

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -176,13 +176,21 @@ class EcmsWorkflowBundleCreate {
    *
    * @param string $contentType
    *   The machine name of the new content type.
+   * @param bool $ignoreExclude
+   *   Flag to skip the exclude check and force adding.
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  public function addContentTypeToWorkflow(string $contentType): void {
+  public function addContentTypeToWorkflow(string $contentType, bool $ignoreExclude = FALSE): void {
 
-    // Guard against any excluded content types.
+    // Guard against any globally excluded content types.
     if (in_array($contentType, self::EXCLUDED_TYPES)) {
+      return;
+    }
+
+    // Check per site exclusion in config.
+    $ecmsWorkflowConfig = $this->configFactory->get('ecms_workflow.settings');
+    if (!$ignoreExclude && in_array($contentType, $ecmsWorkflowConfig->get('excluded_content_types'))) {
       return;
     }
 
@@ -256,11 +264,6 @@ class EcmsWorkflowBundleCreate {
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function removeContentTypeFromWorkflow(string $contentType): void {
-
-    // Ensure content type is included in the exclude list.
-    if (!in_array($contentType, self::EXCLUDED_TYPES)) {
-      return;
-    }
 
     // Remove the new content type from the editorial workflow.
     $workflowEntities = $this->entityTypeManager

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -43,7 +43,7 @@ class EcmsWorkflowBundleCreate {
   /**
    * Array of content types to exclude.
    */
-  const EXCLUDED_TYPES = ['notification', 'press_release'];
+  const EXCLUDED_TYPES = ['notification'];
 
   /**
    * The entity_type.manager service.

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -189,8 +189,14 @@ class EcmsWorkflowBundleCreate {
     }
 
     // Check per site exclusion in config.
-    $ecmsWorkflowConfig = $this->configFactory->get('ecms_workflow.settings');
-    if (!$ignoreExclude && in_array($contentType, $ecmsWorkflowConfig->get('excluded_content_types'))) {
+    $ecmsWorkflowConfigExcluded = [];
+    if ($this->configFactory->get('ecms_workflow.settings')) {
+      $ecmsWorkflowConfigExcluded = $this->configFactory
+        ->get('ecms_workflow.settings')
+        ->get('excluded_content_types');
+    }
+
+    if (!$ignoreExclude && in_array($contentType, $ecmsWorkflowConfigExcluded)) {
       return;
     }
 

--- a/ecms_base/modules/custom/ecms_workflow/src/Form/EcmsWorkflowConfigForm.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/Form/EcmsWorkflowConfigForm.php
@@ -117,7 +117,7 @@ class EcmsWorkflowConfigForm extends ConfigFormBase {
 
     parent::submitForm($form, $form_state);
 
-    // Save the permissions of the selected content types to the api role.
+    // Remove the selected content types from the workflow.
     $this->removeTypesFromWorkflow($contentTypes);
   }
 
@@ -131,7 +131,6 @@ class EcmsWorkflowConfigForm extends ConfigFormBase {
    */
   private function removeTypesFromWorkflow(array $contentTypes): void {
 
-    // Grant create and edit own permissions for the selected content types.
     foreach ($contentTypes as $key => $type) {
       $this->ecmsWorkflowBundleCreate->removeContentTypeFromWorkflow($key);
     }

--- a/ecms_base/modules/custom/ecms_workflow/src/Form/EcmsWorkflowConfigForm.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/Form/EcmsWorkflowConfigForm.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types =1);
+
+namespace Drupal\ecms_workflow\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\user\RoleInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Setup the configuration form for the ecms_workflow module.
+ *
+ * @package Drupal\ecms_workflow\Form
+ */
+class EcmsWorkflowConfigForm extends ConfigFormBase {
+
+  /**
+   * The entity_type.manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private $entityTypeManager;
+
+  /**
+   * The entity_type.bundle.info service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  private $entityTypeBundleInfo;
+
+  /**
+   * The ecms_workflow.bundle_create service.
+   *
+   * @var \Drupal\ecms_workflow\EcmsWorkflowBundleCreate
+   */
+  private $ecmsWorkflowBundleCreate;
+
+  /**
+   * EcmsWorkflowConfigForm constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config.factory service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity_type.manager service.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entityTypeBundleInfo
+   *   The entity_type.bundle.info service.
+   * @param \Drupal\Core\Entity\EcmsWorkflowBundleCreate $ecmsWorkflowBundleCreateService
+   *   The ecms_workflow.bundle_create service.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entityTypeManager, EntityTypeBundleInfoInterface $entityTypeBundleInfo, EcmsWorkflowBundleCreate $ecmsWorkflowBundleCreateService) {
+    parent::__construct($config_factory);
+
+    $this->entityTypeManager = $entityTypeManager;
+    $this->entityTypeBundleInfo = $entityTypeBundleInfo;
+    $this->ecmsWorkflowBundleCreate = $ecmsWorkflowBundleCreateService;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('entity_type.manager'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('ecms_workflow.bundle_create')
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getEditableConfigNames(): array {
+    return [
+      'ecms_workflow.settings',
+    ];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getFormId(): string {
+    return 'ecms_workflow_settings_form';
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildForm($form, $form_state);
+
+    // Load the available nodes and build list of types.
+    $nodes = $this->entityTypeBundleInfo->getBundleInfo('node');
+    $nodes = array_map(function ($bundle_info) {
+      return $bundle_info['label'];
+    }, $nodes);
+
+    // List of all available content types as checkboxes.
+    $form['excluded_content_types'] = [
+      '#title' => $this->t('Excluded Content types'),
+      '#description' => $this->t('Select the content types to exclude from the default workflow.'),
+      '#type' => 'checkboxes',
+      '#options' => $nodes,
+      '#default_value' => $this->config('ecms_workflow.settings')->get('excluded_content_types'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    // Get the allowed content types from the user.
+    $contentTypes = $form_state->getValue('excluded_content_types');
+
+    // Filter the array.
+    $contentTypes = array_filter($contentTypes);
+
+    // Save the allowed content types to the configuration object.
+    $this->config('ecms_workflow.settings')
+      ->set('excluded_content_types', $contentTypes)
+      ->save();
+
+    parent::submitForm($form, $form_state);
+
+    // Save the permissions of the selected content types to the api role.
+    $this->removeTypesFromWorkflow($contentTypes);
+  }
+
+  /**
+   * Removes the selected types from the default workflow.
+   *
+   * @param array $contentTypes
+   *   Array of content types selected on the configuration form.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  private function removeTypesFromWorkflow(array $contentTypes): void {
+
+    // Grant create and edit own permissions for the selected content types.
+    foreach ($contentTypes as $key => $type) {
+      $this->ecmsWorkflowBundleCreate->removeContentTypeFromWorkflow($key);
+    }
+
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_workflow/src/Form/EcmsWorkflowConfigForm.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/Form/EcmsWorkflowConfigForm.php
@@ -5,13 +5,11 @@ declare(strict_types =1);
 namespace Drupal\ecms_workflow\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
-use Drupal\user\RoleInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\ecms_workflow\EcmsWorkflowBundleCreate;
 
 /**
  * Setup the configuration form for the ecms_workflow module.
@@ -19,13 +17,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @package Drupal\ecms_workflow\Form
  */
 class EcmsWorkflowConfigForm extends ConfigFormBase {
-
-  /**
-   * The entity_type.manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  private $entityTypeManager;
 
   /**
    * The entity_type.bundle.info service.
@@ -46,17 +37,14 @@ class EcmsWorkflowConfigForm extends ConfigFormBase {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config.factory service.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity_type.manager service.
    * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entityTypeBundleInfo
    *   The entity_type.bundle.info service.
-   * @param \Drupal\Core\Entity\EcmsWorkflowBundleCreate $ecmsWorkflowBundleCreateService
+   * @param \Drupal\ecms_workflow\EcmsWorkflowBundleCreate $ecmsWorkflowBundleCreateService
    *   The ecms_workflow.bundle_create service.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entityTypeManager, EntityTypeBundleInfoInterface $entityTypeBundleInfo, EcmsWorkflowBundleCreate $ecmsWorkflowBundleCreateService) {
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeBundleInfoInterface $entityTypeBundleInfo, EcmsWorkflowBundleCreate $ecmsWorkflowBundleCreateService) {
     parent::__construct($config_factory);
 
-    $this->entityTypeManager = $entityTypeManager;
     $this->entityTypeBundleInfo = $entityTypeBundleInfo;
     $this->ecmsWorkflowBundleCreate = $ecmsWorkflowBundleCreateService;
   }
@@ -67,7 +55,6 @@ class EcmsWorkflowConfigForm extends ConfigFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
-      $container->get('entity_type.manager'),
       $container->get('entity_type.bundle.info'),
       $container->get('ecms_workflow.bundle_create')
     );

--- a/ecms_base/modules/custom/ecms_workflow/src/Form/EcmsWorkflowConfigForm.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/Form/EcmsWorkflowConfigForm.php
@@ -113,7 +113,7 @@ class EcmsWorkflowConfigForm extends ConfigFormBase {
    * {@inheritDoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state): void {
-    // Get the allowed content types from the user.
+    // Get the excluded content types from the user.
     $contentTypes = $form_state->getValue('excluded_content_types');
 
     // Filter the array.


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
Restore press release to default workflow (remove from class CONST exclude variable, add update hook).
Added config to ecms_workflow to allow sites to exclude content types from workflow.
Fixed PHP fatal error coming from Feeds custom parser.

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |
| Documentation reflects changes? |
| `CHANGELOG` reflects changes? |
| Unit/Functional tests cover changes? |
| Did you perform browser testing? |
| Did you provide detail in the summary on how and where to test this branch? |
| Risk level |
| Relevant links | JIRA issue, bug reports, security alerts, etc.
