### PR TITLE
September module updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
+- RIGA-308: Update drupal/acsf 2.72 => 2.73.
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,7 @@
     "drupal/acquia_connector": "^3.0",
     "drupal/acquia_purge": "^1.1",
     "drupal/acquia_search": "^3.0",
-    "drupal/acsf": "2.72",
+    "drupal/acsf": "2.73",
     "drupal/address": "^1.8",
     "drupal/admin_toolbar": "^3.1.0",
     "drupal/allowed_formats": "^1.3",

--- a/ecms_base/modules/custom/ecms_distribution/ecms_distribution.module
+++ b/ecms_base/modules/custom/ecms_distribution/ecms_distribution.module
@@ -17,7 +17,7 @@ use Drupal\Core\Form\FormStateInterface;
  * @return array|null
  *   The available social navigation options, or null if an error.
  */
-function get_patternlab_social_source(): ?array {
+function ecms_distribution_get_patternlab_social_source(): ?array {
   $return = [];
   /** @var \Drupal\Core\Extension\ThemeHandler $themeHandler */
   $themeHandler = \Drupal::service('theme_handler');
@@ -50,7 +50,7 @@ function get_patternlab_social_source(): ?array {
  * Implements hook_form_FORM_ID_alter() for menu_link_content_menu_link_content_form.
  */
 function ecms_distribution_form_menu_link_content_menu_link_content_form_alter(&$form, FormStateInterface $form_state): void {
-  $options = get_patternlab_social_source();
+  $options = ecms_distribution_get_patternlab_social_source();
 
   if (empty($options)) {
     return;
@@ -177,7 +177,7 @@ function _ecms_distribution_menu_form_submit(array $form, FormStateInterface $fo
   $menuParentValue = $form_state->getValue('menu_parent');
 
   if (str_starts_with($menuParentValue, 'social-navigation:')) {
-    $options = get_patternlab_social_source();
+    $options = ecms_distribution_get_patternlab_social_source();
 
     // The title will be the class name.
     $class = $form_state->getValue('title');


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
- Updates drupal/acsf 2.72 => 2.73
- Fixes a new PHPCS linting error by prepending module name to function.
  - `get_patternlab_social_source` => `ecms_distribution_get_patternlab_social_source`

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
See RIGA-308

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |Y
| Documentation reflects changes? |N
| `CHANGELOG` reflects changes? |Y
| Unit/Functional tests cover changes? |N
| Did you perform browser testing? |Y
| Did you provide detail in the summary on how and where to test this branch? |Y
| Risk level |M
| Relevant links | [RIGA-308](https://thinkoomph.jira.com/browse/RIGA-308) , [Related distribution PR](https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/pull/182)