### PR TITLE
Prepare CHANGELOG for 0.9.21 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,21 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- RIGA-336: Updated allowed formats to 2.x.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
-- RIGA-336: Added patch for allowed formats issue 2950548.
 
 ### Security
+
+## [0.9.21] - 2022-12-15
+### Changed
+- RIGA-336: Updated allowed formats to 2.x.
+
+### Fixed
+- RIGA-336: Added patch for allowed formats issue 2950548.
 
 ## [0.9.20] - 2022-12-15
 ### Changed
@@ -1014,7 +1019,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-37: Fixed the develop script to properly pull in the pattern lab repo.
 - RIG-89: Fixed the Ecms API to work with syndicating translations.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.9.20...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.9.21...HEAD
+[0.9.21]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.9.20...0.9.21
 [0.9.20]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.9.19...0.9.20
 [0.9.19]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.9.18...0.9.19
 [0.9.18]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.9.17...0.9.18


### PR DESCRIPTION
## [0.9.21] - 2022-12-15
### Changed
- RIGA-336: Updated allowed formats to 2.x.

### Fixed
- RIGA-336: Added patch for allowed formats issue 2950548.