### PR TITLE
Install feeds ex module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-380: Install drupal/feeds_ex ^1.0@beta.
 
 ### Changed
 - RIGA-380: Replace querypath/querypath with gravitypdf/querypath.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
+- RIGA-380: Replace querypath/querypath with gravitypdf/querypath.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ## [Unreleased]
 ### Added
 - RIGA-380: Install drupal/feeds_ex ^1.0@beta.
+- RIGA-380: Install softcreatr/jsonpath, a sub-module for feeds_ex.
 
 ### Changed
 - RIGA-380: Replace querypath/querypath with gravitypdf/querypath.

--- a/composer.json
+++ b/composer.json
@@ -200,9 +200,9 @@
       "geocoder-php/arcgis-online-provider": "^4.3",
       "geocoder-php/google-maps-provider": "^4.6",
       "geocoder-php/ipstack-provider": "^0.3.0",
+      "gravitypdf/querypath": "^3.2",
       "johngrogg/ics-parser": "^2",
-      "oomphinc/composer-installers-extender": "^2.0",
-      "querypath/querypath": "^3.0"
+      "oomphinc/composer-installers-extender": "^2.0"
     },
     "require-dev": {
       "behat/mink-goutte-driver": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -203,7 +203,8 @@
       "geocoder-php/ipstack-provider": "^0.3.0",
       "gravitypdf/querypath": "^3.2",
       "johngrogg/ics-parser": "^2",
-      "oomphinc/composer-installers-extender": "^2.0"
+      "oomphinc/composer-installers-extender": "^2.0",
+      "softcreatr/jsonpath": "^0.5 || ^0.7 || ^0.8"
     },
     "require-dev": {
       "behat/mink-goutte-driver": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -136,6 +136,7 @@
       "drupal/extlink": "^1.5",
       "drupal/features": "^3.11",
       "drupal/feeds": "^3.0@alpha",
+      "drupal/feeds_ex": "^1.0@beta",
       "drupal/file_delete": "^2.0",
       "drupal/geocoder": "^3.15",
       "drupal/geofield": "^1.20",


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
- Installs `drupal/feeds_ex` ^1.0@beta.
- Installs `softcreatr/jsonpath`, a sub-module for feeds_ex.
- Replaces `querypath/querypath` with `gravitypdf/querypath`.
  - The old package is no longer maintained, the new is an actively maintained fork of the original
  - New version contains a composer "replace" section; should resolve composer errors for anything that previously relied on querypath.

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
Go to edit the configuration of a Feed
e.g. `/admin/structure/feeds/manage/olis_delivery_weekly_schedule_20`
In the dropdown selector for Basic Settings -> Parser, verify that JSON options are now available

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->
<img width="525" alt="Screen Shot 2023-04-26 at 4 30 36 PM" src="https://user-images.githubusercontent.com/25329856/234698586-71c72d30-54c2-4f30-953e-fa02ee9ad3ee.png">


## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |Y
| Documentation reflects changes? |N
| `CHANGELOG` reflects changes? |Y
| Unit/Functional tests cover changes? |N
| Did you perform browser testing? |Y
| Did you provide detail in the summary on how and where to test this branch? |Y
| Risk level |M
| Relevant links | [RIGA-380](https://thinkoomph.jira.com/browse/RIGA-380)
