### PR TITLE
Remove languages from dropdown with form hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
+- RIGA-344: Add form alter hook to remove langcodes from publications selector.
 
 ### Deprecated
 

--- a/ecms_base/modules/custom/ecms_languages/README.md
+++ b/ecms_base/modules/custom/ecms_languages/README.md
@@ -1,6 +1,11 @@
 # ECMS Languages
 
-Provides configuration and logic to customize the language switcher.
+Provides :
+
+- Configuration and logic to customize the language switcher.
+  - i.e. to pick the language the whole site is translated into.
+- Form alter function to remove unwanted langcodes from search filter selector.
+  - i.e. the language of content to appear in search results.
 
 ## Configuration
 

--- a/ecms_base/modules/custom/ecms_languages/ecms_languages.module
+++ b/ecms_base/modules/custom/ecms_languages/ecms_languages.module
@@ -87,7 +87,21 @@ function ecms_languages_menu_local_tasks_alter(array &$data, ?string $route_name
 
 /**
  * Implements hook_form_alter().
+ *   Removes unwanted langcodes from dropdown selector.
  */
 function ecms_languages_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
-  \Drupal::messenger()->addMessage(print_r($form_id, TRUE), 'info');
+  // Check we're only acting on 'langcode' views exposed filter.
+  if ($form_id === 'views_exposed_form' && isset($form['langcode'])) {
+    // Langcodes included by default, but should not be available to users.
+    $langcodes_to_remove = [
+      '***LANGUAGE_site_default***',
+      '***LANGUAGE_language_interface***',
+      '***LANGUAGE_language_content***',
+      'und',
+      'zxx',
+    ];
+    foreach ($langcodes_to_remove as $key => $lang) {
+      unset($form['langcode']['#options'][$lang]);
+    }
+  }
 }

--- a/ecms_base/modules/custom/ecms_languages/ecms_languages.module
+++ b/ecms_base/modules/custom/ecms_languages/ecms_languages.module
@@ -84,3 +84,10 @@ function ecms_languages_menu_local_tasks_alter(array &$data, ?string $route_name
     }
   }
 }
+
+/**
+ * Implements hook_form_alter().
+ */
+function ecms_languages_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  \Drupal::messenger()->addMessage(print_r($form_id, TRUE), 'info');
+}

--- a/ecms_base/modules/custom/ecms_languages/ecms_languages.module
+++ b/ecms_base/modules/custom/ecms_languages/ecms_languages.module
@@ -9,6 +9,7 @@ declare(strict_types = 1);
 
 use Drupal\Core\Language\Language;
 use Drupal\Core\Url;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Implements hook_module_implements_alter().
@@ -87,9 +88,10 @@ function ecms_languages_menu_local_tasks_alter(array &$data, ?string $route_name
 
 /**
  * Implements hook_form_alter().
+ *
  *   Removes unwanted langcodes from dropdown selector.
  */
-function ecms_languages_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+function ecms_languages_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Check we're only acting on 'langcode' views exposed filter.
   if ($form_id === 'views_exposed_form' && isset($form['langcode'])) {
     // Langcodes included by default, but should not be available to users.


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
Adds hook_form_alter to remove langcodes from views exposed filter dropdown selector, which are included by default but not wanted.
- Removing only these standard values allows different sites to maintain their own different languages

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
This is in use on the Covid site, on the Publications search page `/publications`
Visit page and make sure these are no longer present:
- Site's Default language
- Interface text language selected for page
- Content language selected for page
- Not Applicable
- Not Specified

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->
<img width="833" alt="Screen Shot 2023-05-09 at 3 57 33 AM" src="https://user-images.githubusercontent.com/25329856/237032323-859cf1f9-cf3c-4a07-8a9a-e7b2ecc5cd1d.png">

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |Y
| Documentation reflects changes? |Y
| `CHANGELOG` reflects changes? |Y
| Unit/Functional tests cover changes? |N
| Did you perform browser testing? |Y
| Did you provide detail in the summary on how and where to test this branch? |Y
| Risk level |L
| Relevant links | [RIGA-344](https://thinkoomph.jira.com/browse/RIGA-344)
