### PR TITLE
Fix text format permission for Embed Author role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-384: Add post update, fix text format permissions for embed_author.
 
 ### Changed
 

--- a/ecms_base/config/install/autologout.role.ecms_api_recipient.yml
+++ b/ecms_base/config/install/autologout.role.ecms_api_recipient.yml
@@ -1,3 +1,0 @@
-enabled: false
-timeout: null
-url: ''

--- a/ecms_base/config/install/autologout.role.embed_author.yml
+++ b/ecms_base/config/install/autologout.role.embed_author.yml
@@ -1,3 +1,0 @@
-enabled: false
-timeout: null
-url: ''

--- a/ecms_base/config/install/autologout.role.form_author.yml
+++ b/ecms_base/config/install/autologout.role.form_author.yml
@@ -1,3 +1,0 @@
-enabled: false
-timeout: null
-url: ''

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -1826,3 +1826,28 @@ function ecms_base_update_9098(array &$sandbox): void {
     $active_storage->write("{$config}", $install_source->read("{$config}"));
   }
 }
+
+/**
+ * Updates to run for the 0.9.26 tag; update autologout config.
+ */
+function ecms_base_update_9099(array &$sandbox): void {
+
+  // Import user permissions and Automated Logout config settings.
+  $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
+
+  /** @var \Drupal\Core\Config\FileStorage $install_source */
+  $install_source = new FileStorage($path . "/config/install/");
+
+  /** @var \Drupal\Core\Config\StorageInterface $active_storage */
+  $active_storage = \Drupal::service('config.storage');
+
+  $newConfig = [
+    'autologout.role.ecms_api_recipient',
+    'autologout.role.embed_author',
+    'autologout.role.form_author',
+  ];
+
+  foreach ($newConfig as $config) {
+    $active_storage->write("{$config}", $install_source->read("{$config}"));
+  }
+}

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -1826,28 +1826,3 @@ function ecms_base_update_9098(array &$sandbox): void {
     $active_storage->write("{$config}", $install_source->read("{$config}"));
   }
 }
-
-/**
- * Updates to run for the 0.9.26 tag; update autologout config.
- */
-function ecms_base_update_9099(array &$sandbox): void {
-
-  // Import user permissions and Automated Logout config settings.
-  $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
-
-  /** @var \Drupal\Core\Config\FileStorage $install_source */
-  $install_source = new FileStorage($path . "/config/install/");
-
-  /** @var \Drupal\Core\Config\StorageInterface $active_storage */
-  $active_storage = \Drupal::service('config.storage');
-
-  $newConfig = [
-    'autologout.role.ecms_api_recipient',
-    'autologout.role.embed_author',
-    'autologout.role.form_author',
-  ];
-
-  foreach ($newConfig as $config) {
-    $active_storage->write("{$config}", $install_source->read("{$config}"));
-  }
-}

--- a/ecms_base/ecms_base.post_update.php
+++ b/ecms_base/ecms_base.post_update.php
@@ -223,3 +223,30 @@ function ecms_base_post_update_019_update_role_permissions(&$sandbox): void {
     }
   }
 }
+
+/**
+ * Grant 'use embed text format' permission to embed_author role.
+ */
+function ecms_base_post_update_020_fix_embed_author_permissions(&$sandbox): void {
+
+  /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entityManager */
+  $entityManager = \Drupal::service('entity_type.manager');
+
+  /** @var \Drupal\Core\Entity\EntityStorageInterface $roleStorage */
+  $roleStorage = $entityManager->getStorage('user_role');
+
+  /** @var \Drupal\user\RoleInterface $role */
+  $role = $roleStorage->load('embed_author');
+
+  if (!empty($role)) {
+
+    $role->grantPermission('use text format embed');
+
+    try {
+      $role->save();
+    }
+    catch (EntityStorageException $e) {
+      // Trap any storage errors.
+    }
+  }
+}


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
The `embed_author` role had the necessary permissions to edit paragraphs, but was missing the permission to use the text format.

This adds a post update hook to grant the permission 'use text format embed' to the embed_author role

Also deletes some unneeded config files introduced recently while installing autologout module.

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
- Visit permissions UI `/admin/people/permissions`
- Search for "Use the Embed text format"
- Verify that the checkbox corresponding to `embed_author` is now checked

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |Y
| Documentation reflects changes? |N
| `CHANGELOG` reflects changes? |Y
| Unit/Functional tests cover changes? |N
| Did you perform browser testing? |Y
| Did you provide detail in the summary on how and where to test this branch? |Y
| Risk level |L
| Relevant links | [RIGA-384](https://thinkoomph.jira.com/browse/RIGA-384)
