### PR TITLE
Update drupal/simple_sitemap requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
+- RIGA-390: Update drupal/simple_sitemap requirement to ^4.1.
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -184,7 +184,7 @@
       "drupal/search_api_solr": "^4.2",
       "drupal/simple_menu_permissions": "^1.4",
       "drupal/simple_oauth": "^5.2",
-      "drupal/simple_sitemap": "^3.8",
+      "drupal/simple_sitemap": "^4.1",
       "drupal/smart_date": "^4.0@alpha",
       "drupal/svg_image": "^1.14",
       "drupal/token": "^1.7",


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
In conjunction with June contrib module updates (distribution PR https://github.com/State-of-Rhode-Island-eCMS/ecms_distribution/pull/238)
This updates the composer version constraint for simple_sitemap to use the 4.x branch now.

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |Y
| Documentation reflects changes? |N
| `CHANGELOG` reflects changes? |Y
| Unit/Functional tests cover changes? |N
| Did you perform browser testing? |Y
| Did you provide detail in the summary on how and where to test this branch? |Y
| Risk level |L
| Relevant links | [RIGA-390](https://thinkoomph.jira.com/browse/RIGA-390)
