### PR TITLE
Alphabetize 'Use' statements to fix codesniffer errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Changed
 - RIGA-390: Update drupal/simple_sitemap requirement to ^4.1.
+- RIGA-388: Alphabetize 'Use' statements to fix codesniffer errors.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- RIGA-390: Update drupal/simple_sitemap requirement to ^4.1.
 - RIGA-388: Alphabetize 'Use' statements to fix codesniffer errors.
+- RIGA-390: Update drupal/simple_sitemap requirement to ^4.1.
 
 ### Deprecated
 

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -12,12 +12,12 @@ declare(strict_types = 1);
  * Install, update and uninstall functions for the ecms_base profile.
  */
 
-use Drupal\user\Entity\User;
-use Drupal\shortcut\Entity\Shortcut;
-use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Config\FileStorage;
-use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\File\Exception\FileException;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\shortcut\Entity\Shortcut;
+use Drupal\user\Entity\User;
 
 /**
  * Implements hook_install().

--- a/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSiteAccessControlHandler.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiSiteAccessControlHandler.php
@@ -4,10 +4,10 @@ declare(strict_types = 1);
 
 namespace Drupal\ecms_api_publisher;
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Access\AccessResult;
 
 /**
  * Access controller for the eCMS API Site entity.

--- a/ecms_base/modules/custom/ecms_api_publisher/src/Entity/EcmsApiSite.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/Entity/EcmsApiSite.php
@@ -4,12 +4,12 @@ declare(strict_types = 1);
 
 namespace Drupal\ecms_api_publisher\Entity;
 
-use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityStorageInterface;
-use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityChangedTrait;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\link\LinkItemInterface;
 use Drupal\link\Plugin\Field\FieldType\LinkItem;
 use Drupal\user\EntityOwnerInterface;

--- a/ecms_base/modules/custom/ecms_api_publisher/src/Form/EcmsApiBatchSendUpdatesForm.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/Form/EcmsApiBatchSendUpdatesForm.php
@@ -4,13 +4,13 @@ declare(strict_types = 1);
 
 namespace Drupal\ecms_api_publisher\Form;
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\ecms_api_publisher\Entity\EcmsApiSiteInterface;
-use Drupal\Core\Entity\EntityInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/ecms_base/modules/custom/ecms_api_recipient/src/EcmsApiRecipientInstall.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/src/EcmsApiRecipientInstall.php
@@ -4,12 +4,12 @@ declare(strict_types = 1);
 
 namespace Drupal\ecms_api_recipient;
 
+use Drupal\Component\Utility\Crypt;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\Component\Utility\Crypt;
 
 /**
  * Installation tasks for the ecms_api_recipient module.

--- a/ecms_base/modules/custom/ecms_api_recipient/src/Form/EcmsApiRecipientConfigForm.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/src/Form/EcmsApiRecipientConfigForm.php
@@ -6,10 +6,10 @@ namespace Drupal\ecms_api_recipient\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityStorageException;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\user\RoleInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/ecms_base/modules/custom/ecms_blocks/src/Form/SearchStateBlockForm.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Form/SearchStateBlockForm.php
@@ -6,8 +6,8 @@ namespace Drupal\ecms_blocks\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Url;
 use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\Core\Url;
 
 /**
  * Provides a custom site search form.

--- a/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/HotelListingBlock.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/HotelListingBlock.php
@@ -6,12 +6,12 @@ namespace Drupal\ecms_blocks\Plugin\Block;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Language\LanguageManagerInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfo;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a listing of hotels.

--- a/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/PromotionsGlobalBlock.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/PromotionsGlobalBlock.php
@@ -6,12 +6,12 @@ namespace Drupal\ecms_blocks\Plugin\Block;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Language\LanguageManagerInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a listing of global promos.

--- a/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/PromotionsNodeSpecificBlock.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/PromotionsNodeSpecificBlock.php
@@ -6,12 +6,12 @@ namespace Drupal\ecms_blocks\Plugin\Block;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a listing of promos referenced by the node.

--- a/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SearchBlock.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SearchBlock.php
@@ -5,9 +5,9 @@ declare(strict_types = 1);
 namespace Drupal\ecms_blocks\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Form\FormBuilderInterface;
 
 /**
  * Provides a custom block for the site search form.

--- a/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SearchStateBlock.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SearchStateBlock.php
@@ -5,9 +5,9 @@ declare(strict_types = 1);
 namespace Drupal\ecms_blocks\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Form\FormBuilderInterface;
 
 /**
  * Provides a custom block for the site search form.

--- a/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SidebarContentBlock.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SidebarContentBlock.php
@@ -6,12 +6,12 @@ namespace Drupal\ecms_blocks\Plugin\Block;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides sidebar content view mode for any node type.

--- a/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SiteNotificationsBlock.php
+++ b/ecms_base/modules/custom/ecms_blocks/src/Plugin/Block/SiteNotificationsBlock.php
@@ -6,14 +6,14 @@ namespace Drupal\ecms_blocks\Plugin\Block;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Language\LanguageManagerInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Datetime\DrupalDateTime;
-use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a listing of promos referenced by the node.

--- a/ecms_base/modules/custom/ecms_feeds/src/Feeds/Parser/EcmsIcalParser.php
+++ b/ecms_base/modules/custom/ecms_feeds/src/Feeds/Parser/EcmsIcalParser.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\ecms_feeds\Feeds\Parser;
 
+use Drupal\ecms_feeds\Feeds\Item\EcmsIcalItem;
 use Drupal\feeds\Component\XmlParserTrait;
 use Drupal\feeds\Exception\EmptyFeedException;
 use Drupal\feeds\FeedInterface;
@@ -12,7 +13,6 @@ use Drupal\feeds\Plugin\Type\PluginBase;
 use Drupal\feeds\Result\FetcherResultInterface;
 use Drupal\feeds\Result\ParserResult;
 use Drupal\feeds\StateInterface;
-use Drupal\ecms_feeds\Feeds\Item\EcmsIcalItem;
 use ICal\ICal;
 
 /**

--- a/ecms_base/modules/custom/ecms_icon_library/src/Plugin/Field/FieldFormatter/EcmsIconLibraryFormatter.php
+++ b/ecms_base/modules/custom/ecms_icon_library/src/Plugin/Field/FieldFormatter/EcmsIconLibraryFormatter.php
@@ -5,10 +5,10 @@ declare(strict_types = 1);
 namespace Drupal\ecms_icon_library\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\media\Entity\Media;
-use Drupal\file\Entity\File;
-use Drupal\Core\Render\Markup;
 use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Render\Markup;
+use Drupal\file\Entity\File;
+use Drupal\media\Entity\Media;
 
 /**
  * Plugin implementation of the 'image' formatter.

--- a/ecms_base/modules/custom/ecms_icon_library/src/Plugin/Field/FieldWidget/EcmsIconLibraryWidget.php
+++ b/ecms_base/modules/custom/ecms_icon_library/src/Plugin/Field/FieldWidget/EcmsIconLibraryWidget.php
@@ -4,11 +4,11 @@ declare(strict_types = 1);
 
 namespace Drupal\ecms_icon_library\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\WidgetBase;
-use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\HtmlCommand;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Plugin implementation of the 'field_example_text' widget.

--- a/ecms_base/modules/custom/ecms_languages/ecms_languages.module
+++ b/ecms_base/modules/custom/ecms_languages/ecms_languages.module
@@ -7,9 +7,9 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\Language;
 use Drupal\Core\Url;
-use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Implements hook_module_implements_alter().

--- a/ecms_base/modules/custom/ecms_layout/ecms_layout.module
+++ b/ecms_base/modules/custom/ecms_layout/ecms_layout.module
@@ -7,8 +7,8 @@
 
 declare(strict_types = 1);
 
-use Drupal\Core\Url;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_plugin_filter_TYPE__CONSUMER_alter().

--- a/ecms_base/modules/custom/ecms_layout/src/Plugin/Layout/LayoutBase.php
+++ b/ecms_base/modules/custom/ecms_layout/src/Plugin/Layout/LayoutBase.php
@@ -4,9 +4,9 @@ declare(strict_types = 1);
 
 namespace Drupal\ecms_layout\Plugin\Layout;
 
-use Drupal\ecms_layout\EcmsLayout;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Layout\LayoutDefault;
+use Drupal\ecms_layout\EcmsLayout;
 
 /**
  * Provides a layout base for custom layouts.

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -4,10 +4,10 @@ declare(strict_types = 1);
 
 namespace Drupal\ecms_workflow;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\Core\Config\ConfigFactoryInterface;
 
 /**
  * Add node bundles to the editorial workflow.

--- a/ecms_base/modules/custom/ecms_workflow/src/Form/EcmsWorkflowConfigForm.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/Form/EcmsWorkflowConfigForm.php
@@ -5,12 +5,12 @@ declare(strict_types =1);
 namespace Drupal\ecms_workflow\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\ecms_workflow\EcmsWorkflowBundleCreate;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Setup the configuration form for the ecms_workflow module.

--- a/ecms_base/modules/custom/ecms_workflow/tests/src/ExistingSite/InstallationTest.php
+++ b/ecms_base/modules/custom/ecms_workflow/tests/src/ExistingSite/InstallationTest.php
@@ -7,10 +7,10 @@ namespace Drupal\Tests\ecms_workflow\ExistingSite;
 // Require the all profiles abstract class since autoloading doesn't work.
 require_once dirname(__FILE__) . '/../../../../../../../tests/src/ExistingSite/AllProfileInstallationTestsAbstract.php';
 
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\node\Entity\NodeType;
 use Drupal\Tests\ecms_profile\ExistingSite\AllProfileInstallationTestsAbstract;
 use Drupal\user\Entity\Role;
-use Drupal\node\Entity\NodeType;
-use Drupal\Core\Entity\EntityStorageException;
 
 /**
  * ExistingSite tests for the ecms_workflow module.

--- a/ecms_base/modules/custom/ecms_workflow/tests/src/Unit/EcmsWorkflowBundleCreateTest.php
+++ b/ecms_base/modules/custom/ecms_workflow/tests/src/Unit/EcmsWorkflowBundleCreateTest.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\ecms_workflow\Unit;
 
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -12,8 +14,6 @@ use Drupal\Tests\UnitTestCase;
 use Drupal\user\RoleInterface;
 use Drupal\workflows\WorkflowInterface;
 use Drupal\workflows\WorkflowTypeInterface;
-use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Config\Config;
 
 /**
  * Unit tests for the EcmsWorkflowBundleCreate class.

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -9,9 +9,9 @@ declare(strict_types = 1);
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\node\NodeInterface;
 use Drupal\file\Entity\File;
 use Drupal\media\Entity\Media;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_theme_suggestions_HOOK_alter().


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
While testing https://thinkoomph.jira.com/browse/RIGA-388, existing files began failing tests.

This is presumably because of a recent change in linting requirements.

This fixes those style/linting errors by alphabetizing all "Use" statements.

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
Make sure all tests pass during guthub actions

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |Y
| Documentation reflects changes? |N
| `CHANGELOG` reflects changes? |Y
| Unit/Functional tests cover changes? |N
| Did you perform browser testing? |Y
| Did you provide detail in the summary on how and where to test this branch? |Y
| Risk level |L
| Relevant links | [RIGA-388](https://thinkoomph.jira.com/browse/RIGA-388)
