### PR TITLE
Fix missing moderation workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIGA-395: Add 'ecms_base_update_9099' to re-import empty workflow config.
 
 ### Changed
+- RIGA-395: Update 'ecms_workflow.bundle_create' to show/hide moderation field.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-395: Add 'ecms_base_update_9099' to re-import empty workflow config.
 
 ### Changed
 

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -1839,9 +1839,9 @@ function ecms_base_update_9099(array &$sandbox): void {
 
   // If active config has no data, load it from install file.
   if (!$active_workflow_config) {
-      $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
-      /** @var \Drupal\Core\Config\FileStorage $install_source */
-      $workflow_source = new FileStorage($path . "/modules/custom/ecms_workflow/config/install/");
-      $active_storage->write('workflows.workflow.editorial', $workflow_source->read('workflows.workflow.editorial'));
+    $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
+    /** @var \Drupal\Core\Config\FileStorage $install_source */
+    $workflow_source = new FileStorage($path . "/modules/custom/ecms_workflow/config/install/");
+    $active_storage->write('workflows.workflow.editorial', $workflow_source->read('workflows.workflow.editorial'));
   }
 }

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -1826,3 +1826,22 @@ function ecms_base_update_9098(array &$sandbox): void {
     $active_storage->write("{$config}", $install_source->read("{$config}"));
   }
 }
+
+/**
+ * Updates to run for the 0.9.30 tag; re-save Editorial Workflow config.
+ */
+function ecms_base_update_9099(array &$sandbox): void {
+
+  // Get current value of default workflow config.
+  /** @var \Drupal\Core\Config\StorageInterface $active_storage */
+  $active_storage = \Drupal::service('config.storage');
+  $active_workflow_config = $active_storage->read('workflows.workflow.editorial');
+
+  // If active config has no data, load it from install file.
+  if (!$active_workflow_config) {
+      $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
+      /** @var \Drupal\Core\Config\FileStorage $install_source */
+      $workflow_source = new FileStorage($path . "/modules/custom/ecms_workflow/config/install/");
+      $active_storage->write('workflows.workflow.editorial', $workflow_source->read('workflows.workflow.editorial'));
+  }
+}

--- a/ecms_base/modules/custom/ecms_workflow/ecms_workflow.services.yml
+++ b/ecms_base/modules/custom/ecms_workflow/ecms_workflow.services.yml
@@ -1,4 +1,4 @@
 services:
   ecms_workflow.bundle_create:
     class: Drupal\ecms_workflow\EcmsWorkflowBundleCreate
-    arguments: ['@entity_type.manager', '@config.factory']
+    arguments: ['@entity_type.manager', '@config.factory', '@entity_display.repository']

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -74,6 +74,8 @@ class EcmsWorkflowBundleCreate {
    *   The entity_type.manager service.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   The config.factory service.
+   * @param \Drupal\Core\Entity\EntityDisplayRepositoryInterface $entityDisplayRepository
+   *   The entity_display.repository service.
    */
   public function __construct(EntityTypeManagerInterface $entityTypeManager, ConfigFactoryInterface $configFactory, EntityDisplayRepositoryInterface $entityDisplayRepository) {
     $this->entityTypeManager = $entityTypeManager;

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -248,7 +248,7 @@ class EcmsWorkflowBundleCreate {
     if (isset($entityFormDisplay)) {
       try {
         $entityFormDisplay->setComponent('moderation_state', [
-          'type' => 'select',
+          'type' => 'options_select',
         ])->save();
       }
       catch (ConfigException $e) {

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\ecms_workflow;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -60,6 +61,13 @@ class EcmsWorkflowBundleCreate {
   private $configFactory;
 
   /**
+   * The entity_display.repository service.
+   *
+   * @var \Drupal\Core\Entity\EntityDisplayRepositoryInterface
+   */
+  private $entityDisplayRepository;
+
+  /**
    * EcmsWorkflowBundleCreate constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
@@ -67,9 +75,10 @@ class EcmsWorkflowBundleCreate {
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   The config.factory service.
    */
-  public function __construct(EntityTypeManagerInterface $entityTypeManager, ConfigFactoryInterface $configFactory) {
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, ConfigFactoryInterface $configFactory, EntityDisplayRepositoryInterface $entityDisplayRepository) {
     $this->entityTypeManager = $entityTypeManager;
     $this->configFactory = $configFactory;
+    $this->entityDisplayRepository = $entityDisplayRepository;
   }
 
   /**
@@ -229,7 +238,8 @@ class EcmsWorkflowBundleCreate {
       return;
     }
 
-    \Drupal::service('entity_display.repository')
+    // Show moderation field in Entity From Display.
+    $this->entityDisplayRepository
       ->getFormDisplay('node', $contentType, 'default')
       ->setComponent('moderation_state')
       ->save();
@@ -317,7 +327,8 @@ class EcmsWorkflowBundleCreate {
       return;
     }
 
-    \Drupal::service('entity_display.repository')
+    // Hide moderation field from Entity From Display.
+    $this->entityDisplayRepository
       ->getFormDisplay('node', $contentType, 'default')
       ->removeComponent('moderation_state')
       ->save();

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -229,6 +229,11 @@ class EcmsWorkflowBundleCreate {
       return;
     }
 
+    \Drupal::service('entity_display.repository')
+      ->getFormDisplay('node', $contentType, 'default')
+      ->setComponent('moderation_state')
+      ->save();
+
   }
 
   /**

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -245,12 +245,15 @@ class EcmsWorkflowBundleCreate {
     $entityFormDisplay = $this->entityDisplayRepository
       ->getFormDisplay('node', $contentType, 'default');
 
-    try {
-      $entityFormDisplay->setComponent('moderation_state')
-        ->save();
-    }
-    catch (ConfigException $e) {
-      return;
+    if (isset($entityFormDisplay)) {
+      try {
+        $entityFormDisplay->setComponent('moderation_state', [
+          'type' => 'select',
+        ])->save();
+      }
+      catch (ConfigException $e) {
+        return;
+      }
     }
   }
 
@@ -339,14 +342,15 @@ class EcmsWorkflowBundleCreate {
     $entityFormDisplay = $this->entityDisplayRepository
       ->getFormDisplay('node', $contentType, 'default');
 
-    try {
-      $entityFormDisplay->removeComponent('moderation_state')
-        ->save();
+    if (isset($entityFormDisplay)) {
+      try {
+        $entityFormDisplay->removeComponent('moderation_state')
+          ->save();
+      }
+      catch (ConfigException $e) {
+        return;
+      }
     }
-    catch (ConfigException $e) {
-      return;
-    }
-
   }
 
   /**

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\ecms_workflow;
 
+use Drupal\Core\Config\ConfigException;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
 use Drupal\Core\Entity\EntityStorageException;
@@ -241,11 +242,16 @@ class EcmsWorkflowBundleCreate {
     }
 
     // Show moderation field in Entity From Display.
-    $this->entityDisplayRepository
-      ->getFormDisplay('node', $contentType, 'default')
-      ->setComponent('moderation_state')
-      ->save();
+    $entityFormDisplay = $this->entityDisplayRepository
+      ->getFormDisplay('node', $contentType, 'default');
 
+    try {
+      $entityFormDisplay->setComponent('moderation_state')
+        ->save();
+    }
+    catch (ConfigException $e) {
+      return;
+    }
   }
 
   /**
@@ -330,10 +336,16 @@ class EcmsWorkflowBundleCreate {
     }
 
     // Hide moderation field from Entity From Display.
-    $this->entityDisplayRepository
-      ->getFormDisplay('node', $contentType, 'default')
-      ->removeComponent('moderation_state')
-      ->save();
+    $entityFormDisplay = $this->entityDisplayRepository
+      ->getFormDisplay('node', $contentType, 'default');
+
+    try {
+      $entityFormDisplay->removeComponent('moderation_state')
+        ->save();
+    }
+    catch (ConfigException $e) {
+      return;
+    }
 
   }
 

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -317,6 +317,11 @@ class EcmsWorkflowBundleCreate {
       return;
     }
 
+    \Drupal::service('entity_display.repository')
+      ->getFormDisplay('node', $contentType, 'default')
+      ->removeComponent('moderation_state')
+      ->save();
+
   }
 
   /**

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -241,10 +241,9 @@ class EcmsWorkflowBundleCreate {
       return;
     }
 
-    // Show moderation field in Entity From Display.
+    // Show Moderation State and hide Status checkbox in Entity Form Display.
     $entityFormDisplay = $this->entityDisplayRepository
       ->getFormDisplay('node', $contentType, 'default');
-
     if (isset($entityFormDisplay)) {
       try {
         $entityFormDisplay->setComponent('moderation_state', [
@@ -256,7 +255,15 @@ class EcmsWorkflowBundleCreate {
       catch (ConfigException $e) {
         return;
       }
+      try {
+        $entityFormDisplay->removeComponent('status')
+          ->save();
+      }
+      catch (ConfigException $e) {
+        return;
+      }
     }
+
   }
 
   /**
@@ -340,11 +347,23 @@ class EcmsWorkflowBundleCreate {
       return;
     }
 
-    // Hide moderation field from Entity From Display.
+    // Show Status checkbox and hide Moderation State from Entity Form Display.
     $entityFormDisplay = $this->entityDisplayRepository
       ->getFormDisplay('node', $contentType, 'default');
-
     if (isset($entityFormDisplay)) {
+      try {
+        $entityFormDisplay->setComponent('status', [
+          'type' => 'boolean_checkbox',
+          'weight' => 19,
+          'region' => 'content',
+          'settings' => [
+            'display_label' => TRUE,
+          ],
+        ])->save();
+      }
+      catch (ConfigException $e) {
+        return;
+      }
       try {
         $entityFormDisplay->removeComponent('moderation_state')
           ->save();
@@ -353,6 +372,7 @@ class EcmsWorkflowBundleCreate {
         return;
       }
     }
+
   }
 
   /**

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -248,7 +248,9 @@ class EcmsWorkflowBundleCreate {
     if (isset($entityFormDisplay)) {
       try {
         $entityFormDisplay->setComponent('moderation_state', [
-          'type' => 'options_select',
+          'type' => 'moderation_state_default',
+          'weight' => 29,
+          'region' => 'content',
         ])->save();
       }
       catch (ConfigException $e) {

--- a/ecms_base/modules/custom/ecms_workflow/tests/src/Unit/EcmsWorkflowBundleCreateTest.php
+++ b/ecms_base/modules/custom/ecms_workflow/tests/src/Unit/EcmsWorkflowBundleCreateTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\ecms_workflow\Unit;
 use Drupal\Core\Config\Config;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
+use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\ecms_workflow\EcmsWorkflowBundleCreate;
@@ -66,6 +67,13 @@ class EcmsWorkflowBundleCreateTest extends UnitTestCase {
   private $configFactory;
 
   /**
+   * Mock of the EntityDisplayRepositoryInterface.
+   *
+   * @var \Drupal\Core\Entity\EntityDisplayRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $entityDisplayRepository;
+
+  /**
    * Mock of a mutable Config object.
    *
    * @var \Drupal\Core\Config\Config|\PHPUnit\Framework\MockObject\MockObject
@@ -81,6 +89,7 @@ class EcmsWorkflowBundleCreateTest extends UnitTestCase {
     $this->entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
     $this->entityStorage = $this->createMock(EntityStorageInterface::class);
     $this->configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $this->entityDisplayRepository = $this->createMock(EntityDisplayRepositoryInterface::class);
     $this->config = $this->createMock(Config::class);
 
   }
@@ -132,6 +141,7 @@ class EcmsWorkflowBundleCreateTest extends UnitTestCase {
     $testClass = new EcmsWorkflowBundleCreate(
       $this->entityTypeManager,
       $this->configFactory,
+      $this->entityDisplayRepository,
     );
 
     $testClass->addTaxonomyTypePermissions($bundle);
@@ -262,6 +272,7 @@ class EcmsWorkflowBundleCreateTest extends UnitTestCase {
     $testClass = new EcmsWorkflowBundleCreate(
       $this->entityTypeManager,
       $this->configFactory,
+      $this->entityDisplayRepository,
     );
 
     $testClass->addContentTypeToWorkflow($contentType);
@@ -304,6 +315,7 @@ class EcmsWorkflowBundleCreateTest extends UnitTestCase {
         [
           $this->entityTypeManager,
           $this->configFactory,
+          $this->entityDisplayRepository,
         ]
       )
       ->getMock();


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
- The OLIS site lost the Content Moderation field from its Node edit forms.
- It looks like there were 2 issues: 
  - deleted workflow config, 
  - and a submit form which adds/removes Node types from the workflow, but which didn't actively do anything to update the node edit forms
- This adds a db update hook to check whether the workflow config exists, and to install it from files if not.
- It also adds to the PHP service related to the form submission, so now the Moderation field is added/removed from form display as appropriate
```
 ----------- ----------- --------------- ------------------------------------------------------------------------------
  Module      Update ID   Type            Description
 ----------- ----------- --------------- ------------------------------------------------------------------------------
  ecms_base   9099        hook_update_n   9099 - Updates to run for the 0.9.30 tag; re-save Editorial Workflow config.
 ----------- ----------- --------------- ------------------------------------------------------------------------------
```
## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
Make sure you are able to use the moderation switcher when using the node edit page.
Verify that the content type you are testing has not been removed from the workflow at `/admin/config/workflow/workflows/ecms_workflow/settings`
You can test adding/removing content types to the workflow, and then checking a node edit page of that content type and verifying that the moderation switcher becomes availanle/unavailable.

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |Y
| Documentation reflects changes? |N
| `CHANGELOG` reflects changes? |Y
| Unit/Functional tests cover changes? |N
| Did you perform browser testing? |Y
| Did you provide detail in the summary on how and where to test this branch? |Y
| Risk level |L
| Relevant links | [RIGA-395](https://thinkoomph.jira.com/browse/RIGA-395)
