### PR TITLE
Update "Event list type" field config to non-required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-401: Add drupal/focal_point ^2.0 to composer.json.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIGA-401: Add drupal/focal_point ^2.0.1 to composer.json.
 - RIGA-401: Add drupal/iek (Image effect kit) ^1.3 to composer.json.
 - RIGA-401: Add drupal/entity_usage ^2.0@beta to composer.json.
-- RIGA-401: Add ecms_base_update_9100 update hook to enable new modules.
+- RIGA-401: Add ecms_base_update_9100 hook to enable modules and update config.
 
 ### Changed
 - RIGA-383: Update the Event List Type field config to be non-required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIGA-401: Add drupal/focal_point ^2.0.1 to composer.json.
 - RIGA-401: Add drupal/iek (Image effect kit) ^1.3 to composer.json.
 - RIGA-401: Add drupal/entity_usage ^2.0@beta to composer.json.
+- RIGA-401: Add ecms_base_update_9100 update hook to enable new modules.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
-- RIGA-401: Add drupal/focal_point ^2.0.1 to composer.json.
-- RIGA-401: Add drupal/iek (Image effect kit) ^1.3 to composer.json.
-- RIGA-401: Add drupal/entity_usage ^2.0@beta to composer.json.
-- RIGA-401: Add ecms_base_update_9100 hook to enable modules and update config.
+- RIGA-383: Add ecms_base_update_9100 hook to import updated config.
 
 ### Changed
 - RIGA-383: Update the Event List Type field config to be non-required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ## [Unreleased]
 ### Added
 - RIGA-401: Add drupal/focal_point ^2.0.1 to composer.json.
+- RIGA-401: Add drupal/iek (Image effect kit) ^1.3 to composer.json.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIGA-401: Add ecms_base_update_9100 update hook to enable new modules.
 
 ### Changed
+- RIGA-383: Update the Event List Type field config to be non-required.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
-- RIGA-401: Add drupal/focal_point ^2.0 to composer.json.
+- RIGA-401: Add drupal/focal_point ^2.0.1 to composer.json.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 - RIGA-401: Add drupal/focal_point ^2.0.1 to composer.json.
 - RIGA-401: Add drupal/iek (Image effect kit) ^1.3 to composer.json.
+- RIGA-401: Add drupal/entity_usage ^2.0@beta to composer.json.
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -98,8 +98,7 @@
         "drupal/core-composer-scaffold": true,
         "drupal/core-project-message": true,
         "drupal/core-vendor-hardening": true,
-        "dealerdirect/phpcodesniffer-composer-installer": true,
-        "php-http/discovery": true
+        "dealerdirect/phpcodesniffer-composer-installer": true
       }
     },
     "scripts": {
@@ -134,14 +133,11 @@
       "drupal/core-recommended": "~9.5.9",
       "drupal/easy_breadcrumb": "^2.0",
       "drupal/entity_print": "^2.5",
-      "drupal/entity_usage": "^2.0@beta",
       "drupal/extlink": "^1.5",
       "drupal/features": "^3.11",
       "drupal/feeds": "^3.0@alpha",
       "drupal/feeds_ex": "^1.0@beta",
       "drupal/file_delete": "^2.0",
-      "drupal/focal_point": "^2.0.1",
-      "drupal/iek": "^1.3",
       "drupal/geocoder": "^3.15",
       "drupal/geofield": "^1.20",
       "drupal/geolocation": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,8 @@
         "drupal/core-composer-scaffold": true,
         "drupal/core-project-message": true,
         "drupal/core-vendor-hardening": true,
-        "dealerdirect/phpcodesniffer-composer-installer": true
+        "dealerdirect/phpcodesniffer-composer-installer": true,
+        "php-http/discovery": true
       }
     },
     "scripts": {
@@ -138,7 +139,7 @@
       "drupal/feeds": "^3.0@alpha",
       "drupal/feeds_ex": "^1.0@beta",
       "drupal/file_delete": "^2.0",
-      "drupal/focal_point": "^2.0",
+      "drupal/focal_point": "^2.0.1",
       "drupal/geocoder": "^3.15",
       "drupal/geofield": "^1.20",
       "drupal/geolocation": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -138,6 +138,7 @@
       "drupal/feeds": "^3.0@alpha",
       "drupal/feeds_ex": "^1.0@beta",
       "drupal/file_delete": "^2.0",
+      "drupal/focal_point": "^2.0",
       "drupal/geocoder": "^3.15",
       "drupal/geofield": "^1.20",
       "drupal/geolocation": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -140,6 +140,7 @@
       "drupal/feeds_ex": "^1.0@beta",
       "drupal/file_delete": "^2.0",
       "drupal/focal_point": "^2.0.1",
+      "drupal/iek": "^1.3",
       "drupal/geocoder": "^3.15",
       "drupal/geofield": "^1.20",
       "drupal/geolocation": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -134,6 +134,7 @@
       "drupal/core-recommended": "~9.5.9",
       "drupal/easy_breadcrumb": "^2.0",
       "drupal/entity_print": "^2.5",
+      "drupal/entity_usage": "^2.0@beta",
       "drupal/extlink": "^1.5",
       "drupal/features": "^3.11",
       "drupal/feeds": "^3.0@alpha",

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -1845,3 +1845,17 @@ function ecms_base_update_9099(array &$sandbox): void {
     $active_storage->write('workflows.workflow.editorial', $workflow_source->read('workflows.workflow.editorial'));
   }
 }
+
+/**
+ * Updates to run for the 0.10.1 tag. Install new modules.
+ */
+function ecms_base_update_9100(array &$sandbox): void {
+
+  $modules_to_install = [
+    'entity_usage',
+    'focal_point',
+    'iek',
+  ];
+
+  \Drupal::service('module_installer')->install($modules_to_install);
+}

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -1847,17 +1847,9 @@ function ecms_base_update_9099(array &$sandbox): void {
 }
 
 /**
- * Updates to run for the 0.10.1 tag. Install new modules and update config.
+ * Updates to run for the 0.10.1 tag. Import updated config.
  */
 function ecms_base_update_9100(array &$sandbox): void {
-
-  // Install new modules.
-  $modules_to_install = [
-    'entity_usage',
-    'focal_point',
-    'iek',
-  ];
-  \Drupal::service('module_installer')->install($modules_to_install);
 
   // Update config to make "Event List Type" field non-required".
   $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -1847,15 +1847,32 @@ function ecms_base_update_9099(array &$sandbox): void {
 }
 
 /**
- * Updates to run for the 0.10.1 tag. Install new modules.
+ * Updates to run for the 0.10.1 tag. Install new modules and update config.
  */
 function ecms_base_update_9100(array &$sandbox): void {
 
+  // Install new modules.
   $modules_to_install = [
     'entity_usage',
     'focal_point',
     'iek',
   ];
-
   \Drupal::service('module_installer')->install($modules_to_install);
+
+  // Update config to make "Event List Type" field non-required".
+  $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
+
+  /** @var \Drupal\Core\Config\FileStorage $install_source */
+  $ecms_event_config_source = new FileStorage($path . "/features/custom/ecms_event/config/install/");
+
+  /** @var \Drupal\Core\Config\StorageInterface $active_storage */
+  $active_storage = \Drupal::service('config.storage');
+
+  $updated_ecms_event_config = [
+    'field.field.paragraph.event_list.field_event_list_type',
+  ];
+
+  foreach ($updated_ecms_event_config as $config) {
+    $active_storage->write("{$config}", $ecms_event_config_source->read("{$config}"));
+  }
 }

--- a/ecms_base/features/custom/ecms_event/config/install/field.field.paragraph.event_list.field_event_list_type.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.field.paragraph.event_list.field_event_list_type.yml
@@ -11,7 +11,7 @@ entity_type: paragraph
 bundle: event_list
 label: 'Event type'
 description: '(Optional) Select a specific event type to show only events of that type. If not selected all events of all types will be shown.'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
- Updates Event Type field config to be non-required
  - `field.field.paragraph.event_list.field_event_list_type.yml`
- Adds update hook `ecms_base_update_9100` to get new field config from the `ecms_event` feature's config directory, and save it to active config

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
- Check config setting at:
  - `/admin/structure/paragraphs_type/event_list/fields/paragraph.event_list.field_event_list_type`
- Make test content:
  - Create a node of a type that offers "Event list" in its flex components, e.g. Basic Page; verify you can save a page that does have an "Event List" component added, but that does not have a value for the "Event Type" field
  - `/node/add/basic_page` => Add an "Event List" paragraph to the components section.

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |Y
| Documentation reflects changes? |N
| `CHANGELOG` reflects changes? |Y
| Unit/Functional tests cover changes? |N
| Did you perform browser testing? |Y
| Did you provide detail in the summary on how and where to test this branch? |Y
| Risk level |L
| Relevant links | [RIGA-383](https://thinkoomph.jira.com/browse/RIGA-383)
