### PR TITLE
Prepare CHANGELOG for 0.10.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- RIGA-406: Update drupal/admin_toolbar 3.4.0 => 3.4.1
-- RIGA-406: Update drupal/easy_breadcrumb ^2.0 => 2.0.5
-- RIGA-406: Update drupal/metatag ^1.14 => ^1.26
-- RIGA-406: Update drupal/token ^1.7 => ^1.12
 
 ### Deprecated
 
@@ -24,6 +20,13 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+
+## [0.10.2] - 2023-08-10
+### Changed
+- RIGA-406: Update drupal/admin_toolbar 3.4.0 => 3.4.1.
+- RIGA-406: Update drupal/easy_breadcrumb ^2.0 => 2.0.5.
+- RIGA-406: Update drupal/metatag ^1.14 => ^1.26.
+- RIGA-406: Update drupal/token ^1.7 => ^1.12.
 
 ## [0.10.1] - 2023-07-27
 ### Added
@@ -1104,7 +1107,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-37: Fixed the develop script to properly pull in the pattern lab repo.
 - RIG-89: Fixed the Ecms API to work with syndicating translations.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.1...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.2...HEAD
+[0.10.2]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.1...0.10.2
 [0.10.1]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.0...0.10.1
 [0.10.0]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.9.31...0.10.0
 [0.9.31]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.9.30...0.9.31


### PR DESCRIPTION
## [0.10.2] - 2023-08-10
### Changed
- RIGA-406: Update drupal/admin_toolbar 3.4.0 => 3.4.1.
- RIGA-406: Update drupal/easy_breadcrumb ^2.0 => 2.0.5.
- RIGA-406: Update drupal/metatag ^1.14 => ^1.26.
- RIGA-406: Update drupal/token ^1.7 => ^1.12.