### PR TITLE
Use transform relative function for file URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
+- RIGA-378: Change from absolute to relative file path for downloadable files.
 
 ### Deprecated
 

--- a/ecms_base/modules/custom/ecms_distribution/ecms_distribution.module
+++ b/ecms_base/modules/custom/ecms_distribution/ecms_distribution.module
@@ -251,14 +251,3 @@ function ecms_distribution_preprocess_menu(&$variables): void {
     }
   }
 }
-
-/**
- * Implements hook_file_url_alter().
- */
-function ecms_distribution_file_url_alter(&$uri) {
-  $config = \Drupal::service('config.factory')->get('ecms.settings');
-  $use_absolute_path = $config->get('use_file_path');
-  if ($use_absolute_path) {
-    $uri = \Drupal::service('file_url_generator')->transformRelative($uri);
-  }
-}

--- a/ecms_base/modules/custom/ecms_distribution/ecms_distribution.module
+++ b/ecms_base/modules/custom/ecms_distribution/ecms_distribution.module
@@ -251,3 +251,14 @@ function ecms_distribution_preprocess_menu(&$variables): void {
     }
   }
 }
+
+/**
+ * Implements hook_file_url_alter().
+ */
+function ecms_distribution_file_url_alter(&$uri) {
+  $config = \Drupal::service('config.factory')->get('ecms.settings');
+  $use_absolute_path = $config->get('use_file_path');
+  if ($use_absolute_path) {
+    $uri = \Drupal::service('file_url_generator')->transformRelative($uri);
+  }
+}

--- a/ecms_base/themes/custom/ecms/config/schema/ecms.schema.yml
+++ b/ecms_base/themes/custom/ecms/config/schema/ecms.schema.yml
@@ -91,4 +91,4 @@ ecms.settings:
       label: 'Language code'
     use_file_path:
       type: integer
-      label: 'Use absolute file path for download links'
+      label: 'Use specific file path for download links'

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -218,10 +218,17 @@ function ecms_preprocess_media__file(array &$variables): void {
   $file_size_raw = $media->get('field_file_size')->value;
   $variables['file_size'] = _filesize_formatted(intval($file_size_raw));
 
-  // Grab file url, accounting for global "use absolute file" setting.
+  // Grab file URL, accounting for global "use absolute file" setting.
   $variables['file_url'] = '/media/' . $media->id() . '/download?language=' . $language;
   if (theme_get_setting('use_file_path')) {
-    $variables['file_url'] = file_create_url($media->get('field_file')->entity->uri->value);
+    // Get service for generating and converting file URLs.
+    $file_url_generator = \Drupal::service('file_url_generator');
+    // Get URL with specific file path, as opposed to Drupal-routed media path.
+    $file_url = $file_url_generator->generateAbsoluteString(
+      $media->get('field_file')->entity->uri->value
+    );
+    // Convert to file path without base domain, so it will be site-agnostic.
+    $variables['file_url'] = $file_url_generator->transformRelative($file_url);
   }
 
   // Set the description.

--- a/ecms_base/themes/custom/ecms/theme-settings.php
+++ b/ecms_base/themes/custom/ecms/theme-settings.php
@@ -141,7 +141,8 @@ function ecms_form_system_theme_settings_alter(&$form, FormStateInterface $form_
   $form['ecms_files']['use_file_path'] = [
     '#type' => 'checkbox',
     '#default_value' => theme_get_setting('use_file_path'),
-    '#title' => t('Use absolute file path for download links.'),
+    '#title' => t('Use specific file path for download links'),
+    '#description' => t('Use specific file path for download links, instead of Drupal media path.'),
   ];
 
   // Footer settings.


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
There was an existing feature that makes File-type media downloads use the actual directory path of a file, rather than using the Drupal routed media version.

E.g. when this setting is turned on it would use `/sites/default/files/..path/to/file/location../{file_name}` instead of `/media/{ ID }/download`

This sometimes caused a problem when it gave the full and absolute URL (including domain)

This PR updates code to use the relative path (excluding domain) so it will be site-agnostic.

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |Y
| Documentation reflects changes? |N
| `CHANGELOG` reflects changes? |Y
| Unit/Functional tests cover changes? |N
| Did you perform browser testing? |Y
| Did you provide detail in the summary on how and where to test this branch? |Y
| Risk level |L
| Relevant links | [RIGA-378](https://thinkoomph.jira.com/browse/RIGA-378)