### PR TITLE
Update development scripts to use PHP 8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
+- RIGA-322: Update development scripts to use PHP 8.1.
 
 ### Deprecated
 

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -16,8 +16,8 @@ PATTERN_LAB_REPOSITORY_NAME="state-of-rhode-island-ecms/ecms_patternlab"
 COMPOSER="$(which composer)"
 COMPOSER_BIN_DIR="$(composer config bin-dir)"
 DOCROOT="web"
-DRUPAL_CORE_VERSION="9.4.8"
-PHP_VERSION="8.0"
+DRUPAL_CORE_VERSION="9.5.11"
+PHP_VERSION="8.1"
 
 # Whether the source directory should be deleted before rebuilding lando
 DELETE_SRC=0


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
To sync with the PHP 8.0 => 8.1 upgrade on Acquia site factory,
this updates version of PHP and Drupal/core for the develop script

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |Y
| Documentation reflects changes? |N
| `CHANGELOG` reflects changes? |Y
| Unit/Functional tests cover changes? |N
| Did you perform browser testing? |Y
| Did you provide detail in the summary on how and where to test this branch? |Y
| Risk level |M
| Relevant links | [RIGA-414](https://thinkoomph.jira.com/browse/RIGA-414)
