### PR TITLE
Prepare CHANGELOG for 0.10.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
-- RIGA-322: Update development scripts to use PHP 8.1.
 
 ### Deprecated
 
@@ -21,6 +20,10 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 
 ### Security
+
+## [0.10.4] - 2023-09-28
+### Changed
+- RIGA-322: Update development scripts to use PHP 8.1.
 
 ## [0.10.3] - 2023-08-31
 ### Changed
@@ -1113,7 +1116,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-37: Fixed the develop script to properly pull in the pattern lab repo.
 - RIG-89: Fixed the Ecms API to work with syndicating translations.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.3...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.4...HEAD
+[0.10.4]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.3...0.10.4
 [0.10.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.2...0.10.3
 [0.10.2]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.1...0.10.2
 [0.10.1]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.0...0.10.1


### PR DESCRIPTION
## [0.10.4] - 2023-09-28
### Changed
- RIGA-322: Update development scripts to use PHP 8.1.