### PR TITLE
Prepare CHANGELOG for 0.10.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.10.5] - 2023-10-19
+### Added
 - RIGA-322: Add hook 'ecms_base_update_9101' to import updated role config.
 - RIGA-401: Add hook 'ecms_base_update_9102' to install new modules.
 - RIGA-401: Add hook 'ecms_base_update_9103' to import new module config.
@@ -61,8 +74,6 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Fixed
 - RIGA-429: Add check for unrouted links to fix layout builder error.
-
-### Security
 
 ## [0.10.4] - 2023-09-28
 ### Changed
@@ -1159,7 +1170,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIG-37: Fixed the develop script to properly pull in the pattern lab repo.
 - RIG-89: Fixed the Ecms API to work with syndicating translations.
 
-[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.4...HEAD
+[Unreleased]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.5...HEAD
+[0.10.5]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.4...0.10.5
 [0.10.4]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.3...0.10.4
 [0.10.3]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.2...0.10.3
 [0.10.2]: https://github.com/State-of-Rhode-Island-eCMS/ecms_profile/compare/0.10.1...0.10.2


### PR DESCRIPTION
## [0.10.5] - 2023-10-19
### Added
- RIGA-322: Add hook 'ecms_base_update_9101' to import updated role config.
- RIGA-401: Add hook 'ecms_base_update_9102' to install new modules.
- RIGA-401: Add hook 'ecms_base_update_9103' to import new module config.
- RIGA-401: Add drupal/focal_point ^2.0.1 to composer.json.
- RIGA-401: Add drupal/iek (Image effect kit) ^1.3 to composer.json.
- RIGA-401: Add drupal/entity_usage ^2.0@beta to composer.json.
- RIGA-415: Add drupal/advagg ^6.0@alpha to composer.json.
- RIGA-415: Add drupal/conditional_fields ^4.0@alpha to composer.json.
- RIGA-415: Add drupal/field_group ^3.4 to composer.json.
- RIGA-415: Add drupal/quick_node_clone ^1.16 to composer.json.

### Changed
- RIGA-322: Update drupal/core-recommended version constraints to also include ^10.0.
- RIGA-322: Include ^10 in core_version_requirement for custom modules, themes, and features.
- RIGA-322: Update development scripts to use PHP 8.1.
- RIGA-322: Update better_exposed_filters version constraint ^5.0 => ^6.0.
- RIGA-322: Update captcha version constraint ^1.2 => ^2.0.
- RIGA-322: Update components version constraint ^2.0 => ^3.0@beta.
- RIGA-322: Update google_tag version constraint ^1.4 => ^2.0.
- RIGA-322: Update google_translator version constraint ^1.0@RC => ^2.1.
- RIGA-322: Update language_cookie version constraint 1.x-dev => ^2.0.
- RIGA-322: Update menu_block version constraint 1.x-dev => ^1.10.
- RIGA-322: Update simple_menu_permissions version constraint ^1.4 => ^2.0.
- RIGA-322: Update svg_image version constraint ^1.14 => ^3.0.
- RIGA-322: Update twig_tweak version constraint ^2.8 => ^3.2.
- RIGA-322: Update webform_encrypt version constraint 1.x-dev@dev => ^2.0@alpha.
- RIGA-322: Update migrate_plus version constraint ^5.1 => ^6.0.
- RIGA-322: Update migrate_tools version constraint ^5.0 => ^6.0.
- RIGA-322: Update views_database_connector version constraint ^1.4 => ^2.0.
- RIGA-322: Update patch for drupal/paragraphs, issue 2887353, comment 54 => 58.

### Deprecated
- RIGA-322: Switch 'assertArrayEquals()' method call to resolve deprecation error.
- RIGA-322: Switch 'drupal_get_path()' method calls to resolve deprecation error.
- RIGA-322: Switch 'file_create_url()' method calls to resolve deprecation error.
- RIGA-322: Switch 'render()' method calls to resolve deprecation error.
- RIGA-322: Add an explicit 'accessCheck()' to all entity queries.

### Removed
- RIGA-322: Remove module drupal/views_ajax_get from composer.
- RIGA-322: Remove orphaned permission 'create content in disabled language'.
- RIGA-322: Remove orphaned permission 'schedule publishing of nodes'.
- RIGA-322: Remove orphaned permission 'translate icon media'.
- RIGA-322: Remove orphaned permission 'translate modal node'.
- RIGA-322: Remove orphaned permission 'translate webform node'.
- RIGA-322: Remove orphaned permission 'update paragraph content button'.
- RIGA-322: Remove orphaned permission 'view disabled languages'.
- RIGA-322: Remove orphaned permission 'view scheduled content'.

### Fixed
- RIGA-429: Add check for unrouted links to fix layout builder error.