### PR TITLE
Remove unneeded access check from search response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIGA-426: Remove unneeded access check from search response.
 
 ### Security
 

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -342,7 +342,6 @@ function ecms_preprocess_views_view_unformatted(array &$variables): void {
 
   if ($variables['view']->id() === "acquia_search") {
     $variables['search_link'] = "https://www.ri.gov/search/result.php?q=" . \Drupal::request()->query
-      ->accessCheck(FALSE)
       ->get('search_api_fulltext');
   }
 }


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->

- D10 now requires accessCheck() functions on all entity queries.
- An access check had been accidentally placed on a Response query instead, which is not an available method
  - This removes the unneeded access check.

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |Y
| Documentation reflects changes? |N
| `CHANGELOG` reflects changes? |Y
| Unit/Functional tests cover changes? |N
| Did you perform browser testing? |Y
| Did you provide detail in the summary on how and where to test this branch? |Y
| Risk level |L
| Relevant links | [RIGA-426](https://thinkoomph.jira.com/browse/RIGA-426)
