### PR TITLE
Add update hook to uninstall drupal/advagg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-434: Add ecms_base_update_9104 to uninstall drupal/advagg.
 
 ### Changed
+- RIGA-434: Uninstall advagg by default, so it has to be explicitly enabled.
 
 ### Deprecated
 

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -1988,3 +1988,17 @@ function ecms_base_update_9103(array &$sandbox): void {
     }
   }
 }
+
+/**
+ * Updates to run for the 0.10.9 tag. Uninstall advagg module by default.
+ */
+function ecms_base_update_9104(array &$sandbox): void {
+
+  // Now advagg will have to be turned on intentionally, instead of by default.
+  $modules_to_uninstall = [
+    'advagg',
+  ];
+
+  \Drupal::service('module_installer')->uninstall($modules_to_uninstall);
+
+}


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
Uninstalls Advanced Aggregation, so it is opt-in for site admins instead of enabled by default.

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
Go to Extend `/admin/modules` and verify Advanced Aggregation is available to be enabled, but is not currently installed/enabled.
AKA verify checkbox is unchecked.

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |
| Documentation reflects changes? |
| `CHANGELOG` reflects changes? |
| Unit/Functional tests cover changes? |
| Did you perform browser testing? |
| Did you provide detail in the summary on how and where to test this branch? |
| Risk level |
| Relevant links | JIRA issue, bug reports, security alerts, etc.
