### PR TITLE
RIGA-458/Fixed the workflow permissions order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIGA_448: Fixed the workflow error.
 
 ### Security
 

--- a/ecms_base/modules/custom/ecms_workflow/ecms_workflow.info.yml
+++ b/ecms_base/modules/custom/ecms_workflow/ecms_workflow.info.yml
@@ -15,3 +15,4 @@ dependencies:
   - path
   - text
   - user
+  - scheduled_transitions

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -214,7 +214,6 @@ class EcmsWorkflowBundleCreate {
       return;
     }
 
-    $this->setRolePermissions($contentType);
     $this->addSchedulerSettings($contentType);
 
     // Assign the new content type to the editorial workflow.
@@ -264,6 +263,8 @@ class EcmsWorkflowBundleCreate {
       }
     }
 
+    // The permissions need to come last.
+    $this->setRolePermissions($contentType);
   }
 
   /**

--- a/scripts/ci-develop.sh
+++ b/scripts/ci-develop.sh
@@ -15,7 +15,7 @@ PATTERN_LAB_REPOSITORY_NAME="state-of-rhode-island-ecms/ecms_patternlab"
 COMPOSER="$(which composer)"
 COMPOSER_BIN_DIR="$(composer config bin-dir)"
 DOCROOT="web"
-DRUPAL_CORE_VERSION="10.2.2"
+DRUPAL_CORE_VERSION="10.2.4"
 
 # Move up a directory.
 cd ..

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -16,7 +16,7 @@ PATTERN_LAB_REPOSITORY_NAME="state-of-rhode-island-ecms/ecms_patternlab"
 COMPOSER="$(which composer)"
 COMPOSER_BIN_DIR="$(composer config bin-dir)"
 DOCROOT="web"
-DRUPAL_CORE_VERSION="10.2.2"
+DRUPAL_CORE_VERSION="10.2.4"
 PHP_VERSION="8.1"
 
 # Whether the source directory should be deleted before rebuilding lando


### PR DESCRIPTION
## Summary / Approach
Permissions were being set too early causing a permission not found error during the bundle create step for nodes.

## Testing Instruction(s)
Create a new content type and confirm no PHP error is thrown.

## Metadata
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests cover changes? | n/a
| Did you perform browser testing? | yes
| Did you provide detail in the summary on how and where to test this branch? | yes
| Risk level | low
| Relevant links | [RIGA-458](https://thinkoomph.jira.com/browse/RIGA-458)
