### PR TITLE
Riga 463/patch path redirect import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Fixed
 - RIGA-458: Fixed the workflow error.
 - RIGA-458: Fixed the site installation error.
+- RIGA-463: Patched the path redirect import module.
 
 ### Security
 

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,9 @@
             },
             "drupal/search_api": {
                 "3321499 - #19 - Call to a member function preExecute() on null in SearchApiTimeCache::generateResultsKey()": "https://www.drupal.org/files/issues/2023-12-05/search_api-Call_to_a_member_function_preExecute%28%29_on_null-3321499.patch"
+            },
+            "drupal/path_redirect_import": {
+                "3395257 - #3 - Change CSV file upload location to private.": "https://www.drupal.org/files/issues/2023-10-19/3395257-change-csv-file-3_0.patch"
             }
         },
         "preserve-paths": [],


### PR DESCRIPTION
## Summary / Approach
Add a patch to allow paths to be imported.

## Testing Instruction(s)
Enable the module and import a csv file with redirects.

## Screenshots
n/a

## Metadata
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |yes
| Documentation reflects changes? |no
| `CHANGELOG` reflects changes? |yes
| Unit/Functional tests cover changes? |n/a
| Did you perform browser testing? |yes
| Did you provide detail in the summary on how and where to test this branch? |yes
| Risk level |low
| Relevant links | [RIGA-463](https://thinkoomph.jira.com/browse/RIGA-463)
