### PR TITLE
Revoked the site_admin permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIGA-471: Fixed a misconfigured permission.
 
 ### Security
 

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
                 "2794431 - [META] Formalize translations support (#102)": "https://www.drupal.org/files/issues/2020-09-29/jsonapi_add_and_update_translations_support-2794431-102.patch",
                 "3049332 - PHP message: Error: Call to a member function getEntityTypeId() on null (Layout Builder)": "https://www.drupal.org/files/issues/2024-01-09/drupal-core--2024-01-09--3049332-85.patch",
                 "2827921 - Exception thrown by responsive srcset images when the image is not yet in the file system (such as with Stage File Proxy)": "https://www.drupal.org/files/issues/2827921-remove-missing-responsive-image-width-exception.patch",
-                "3308838 - EntityRepository::getTranslationFromContext() function forcibly adds default entity language to fallback candidates": "https://www.drupal.org/files/issues/2024-02-22/drupal-3308838-fix-fallback-to-default-lang-42.patch"
+                "3308838 - EntityRepository::getTranslationFromContext() function forcibly adds default entity language to fallback candidates": "https://www.drupal.org/files/issues/2024-02-22/drupal-3308838-fix-fallback-to-default-lang-42.patch",
+                "3413508 - 55 - Admin page access denied even when access is given to child items": "https://gist.githubusercontent.com/pfrilling/564587c071e5fe5cbbba5a8f94a7c654/raw/ac50b2bec1e85c17bf3c0e9972283aaf19cc9272/gistfile1.txt"
             },
             "drupal/paragraphs": {
                 "2901390 - Integrity constraint violation: 1048 Column 'langcode' cannot be null": "https://www.drupal.org/files/issues/2020-06-25/paragraphs-2901390-51.patch",

--- a/ecms_base/config/install/user.role.site_admin.yml
+++ b/ecms_base/config/install/user.role.site_admin.yml
@@ -100,7 +100,6 @@ permissions:
   - 'administer menu'
   - 'administer redirects'
   - 'administer scheduled transitions'
-  - 'administer site configuration'
   - 'administer sitemap settings'
   - 'administer social-navigation menu items'
   - 'administer themes'

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -2132,3 +2132,16 @@ function ecms_base_update_10200(array &$sandbox): void {
     $active_storage->write("{$config}", $install_source->read("{$config}"));
   }
 }
+
+/**
+ * Revoke the site_admin role's permission to administer site configuration.
+ */
+function ecms_base_update_10201(array &$sandbox): void {
+  // Revoke permissions from the site_admin role.
+  /** @var \Drupal\user\RoleInterface $siteAdminRole */
+  $siteAdminRole = \Drupal::entityTypeManager()
+    ->getStorage('user_role')
+    ->load('site_admin');
+  $siteAdminRole->revokePermission('administer site configuration');
+  $siteAdminRole->save();
+}

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -2158,4 +2158,3 @@ function ecms_base_update_10202(array &$sandbox): void {
   $siteAdminRole->revokePermission('administer site configuration');
   $siteAdminRole->save();
 }
-


### PR DESCRIPTION
## Summary / Approach
The `site_admin` role had an elevated permission. This revokes that from all new and existing sites.

## Testing Instruction(s)
Install the update and confirm that the `site_admin` no longer has the `administer site configuration` permission.

## Screenshots
n/a

## Metadata
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |yes
| Documentation reflects changes? |no
| `CHANGELOG` reflects changes? |yes
| Unit/Functional tests cover changes? |no
| Did you perform browser testing? |yes
| Did you provide detail in the summary on how and where to test this branch? |yes
| Risk level |low
| Relevant links | [RIGA-471](https://thinkoomph.jira.com/browse/RIGA-471)
