### PR TITLE
RIGA-492: Change the configuration for the basic page intro text field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIGA-475: Added the Media PDF Thumbnail module.
 
 ### Changed
+ - RIGA-492: Changed the configuration for the basic page intro text field.
 
 ### Deprecated
 

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -2162,7 +2162,7 @@ function ecms_base_update_10202(array &$sandbox): void {
 /**
  * Update configuration.
  *
- *   - basic page form display
+ *   - basic page form display.
  */
 function ecms_base_update_10203(array &$sandbox): void {
   // Get reference to config install directory.

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -2158,3 +2158,27 @@ function ecms_base_update_10202(array &$sandbox): void {
   $siteAdminRole->revokePermission('administer site configuration');
   $siteAdminRole->save();
 }
+
+/**
+ * Update configuration.
+ *   - basic page form display
+ */
+function ecms_base_update_10203(array &$sandbox): void {
+  // Get reference to config install directory.
+  $path = \Drupal::service('extension.list.profile')->getPath('ecms_base');
+  /** @var \Drupal\Core\Config\FileStorage $install_source */
+  $install_source = new FileStorage($path . "/config/install/");
+
+  // Get reference to active config storage.
+  /** @var \Drupal\Core\Config\StorageInterface $active_storage */
+  $active_storage = \Drupal::service('config.storage');
+
+  // Import config, now that environment is prepped with installed modules.
+  $new_module_config = [
+    'core.entity_form_display.node.basic_page.default',
+  ];
+
+  foreach ($new_module_config as $config) {
+    $active_storage->write("{$config}", $install_source->read("{$config}"));
+  }
+}

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -2161,6 +2161,7 @@ function ecms_base_update_10202(array &$sandbox): void {
 
 /**
  * Update configuration.
+ *
  *   - basic page form display
  */
 function ecms_base_update_10203(array &$sandbox): void {

--- a/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_form_display.node.basic_page.default.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_form_display.node.basic_page.default.yml
@@ -1,3 +1,4 @@
+uuid: 9df1df4c-97d8-4d9a-9de9-2bcc259b38f4
 langcode: en
 status: true
 dependencies:
@@ -11,12 +12,15 @@ dependencies:
     - node.type.basic_page
     - workflows.workflow.editorial
   module:
+    - allowed_formats
     - content_moderation
     - media_library
     - metatag
     - paragraphs
     - path
     - text
+_core:
+  default_config_hash: qnXlW0wIHBCaApAHPJ-a23_Cq0nZsu0Sddvzi2pko6A
 id: node.basic_page.default
 targetEntityType: node
 bundle: basic_page
@@ -43,8 +47,11 @@ content:
       rows: 9
       summary_rows: 3
       placeholder: ''
-      show_summary: false
-    third_party_settings: {  }
+      show_summary: true
+    third_party_settings:
+      allowed_formats:
+        hide_help: '0'
+        hide_guidelines: '0'
   field_basic_page_paragraphs:
     type: entity_reference_paragraphs
     weight: 3
@@ -110,6 +117,11 @@ content:
   publish_on:
     type: datetime_timestamp_no_default
     weight: 11
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
Update the basic page form configuration. Change the Intro Text field to Always show the summary field.

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
Navigate to /admin/structure/types/manage/basic_page/form-display
The Intro Text field should include `Summary field will always be visible`

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests cover changes? | no
| Did you perform browser testing? | yes
| Did you provide detail in the summary on how and where to test this branch? | yes
| Risk level | low
| Relevant links | [RIGA-492](https://thinkoomph.jira.com/browse/RIGA-75)
