### PR TITLE
Remove the Layout Builder Tabs patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Deprecated
 
 ### Removed
+- RIGA-490: Removed the patch for Layout Builder Tabs
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 - RIGA-475: Added the Media PDF Thumbnail module.
 
 ### Changed
- - RIGA-492: Changed the configuration for the basic page intro text field.
+- RIGA-492: Changed the configuration for the basic page intro text field.
+- RIGA-490: Changed the tabs.html.twig theme template to match the changes in V1.0.1 of the module template.
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -51,9 +51,6 @@
                 "2887353 - Paragraph Translation Sync": "https://www.drupal.org/files/issues/2023-09-07/paragraphs-translation-sync-2887353-58.patch"
 
             },
-            "drupal/layout_builder_tabs": {
-                "3305095 - The callable passed to the filter must be a Closure in sandbox mode": "https://www.drupal.org/files/issues/2022-09-06/3305095-3-error-500-on-save.patch"
-            },
             "drupal/layout_builder_iframe_modal": {
                 "3344339 - Hide the ‘Rebuild layout’ link in the layout builder actions area": "https://gist.githubusercontent.com/pfrilling/cce2cd4ce1f24e2c91a15fed0ce95412/raw/9058159f7ca199485692d3b4d1f052809ca8619d/3344339-hide-rebuild-layout-button.patch"
             },

--- a/ecms_base/themes/custom/ecms/templates/layout/tabs.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/layout/tabs.html.twig
@@ -21,21 +21,21 @@
 
 <!-- Nav tabs -->
 <ul class="tabs tab--primary layout-tabs">
-{% for block_id, block_data in blocks if content[region][block_id] %}
+{% for block_id, block_data in blocks|filter(v => v.content is not empty) %}
 {% set block_label = content[region][block_id]['content']['#title']['#markup'] %}
 {% if block_label is empty %}
   {% set block_label = content[region][block_id]['#configuration']['label'] %}
 {% endif %}
 <li class="tabs__tab"><a class="nav-item nav-link {{ loop.first ? 'is-active' }}"
   href="#panel-{{ block_id }}" id="tab-{{ block_id }}">
-  <div class="label"> {{ block_label }}</div>
+  <div class="label">{{ block_label }}</div>
 </a></li>
 {% endfor %}
 </ul>
 
 <!-- Tab panes -->
 <div class="tab-content">
-  {% for block_id, block_data in blocks if content[region][block_id] %}
+  {% for block_id, block_data in blocks|filter(v => v.content is not empty) %}
   <div class="tab-pane {{ loop.first ? 'active' }}" id="panel-{{ block_id }}">
     {{ content[region][block_id] }}
   </div>
@@ -44,7 +44,7 @@
 {% else %}
 {# Markup for layout builder #}
 <!-- Tab panes -->
-{% for block_id, block_data in blocks if content[region][block_id] %}
+{% for block_id, block_data in blocks %}
   {% if block_id starts with '#' %}
     {# Don't try to output attributes #}
   {% else %}


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
Remove the patch for Layout Builder Tabs and adjust the twig template for tabs to reflect changes that will be part of the newer version of the module. This branch cannot be tested with out a companion PR for the distribution. where the module is updated to 1.0.1. 

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->
- In Layout Builder, verify that the tabs option (for a section) is working as expected.
- View a content item to verify that the tabs are showing as expected.

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests cover changes? | n/a
| Did you perform browser testing? | yes
| Did you provide detail in the summary on how and where to test this branch? | yes
| Risk level | Low
| Relevant links | [RIGA-490](https://thinkoomph.jira.com/browse/RIGA-490)
