### PR TITLE
Added a patch to allow ckeditor in views global areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-488: Added WYSIWYG to views filtered text
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
                 "3049332 - PHP message: Error: Call to a member function getEntityTypeId() on null (Layout Builder)": "https://www.drupal.org/files/issues/2024-01-09/drupal-core--2024-01-09--3049332-85.patch",
                 "2827921 - Exception thrown by responsive srcset images when the image is not yet in the file system (such as with Stage File Proxy)": "https://www.drupal.org/files/issues/2827921-remove-missing-responsive-image-width-exception.patch",
                 "3308838 - EntityRepository::getTranslationFromContext() function forcibly adds default entity language to fallback candidates": "https://www.drupal.org/files/issues/2024-02-22/drupal-3308838-fix-fallback-to-default-lang-42.patch",
-                "3413508 - 55 - Admin page access denied even when access is given to child items": "https://gist.githubusercontent.com/pfrilling/564587c071e5fe5cbbba5a8f94a7c654/raw/ac50b2bec1e85c17bf3c0e9972283aaf19cc9272/gistfile1.txt"
+                "3413508 - 55 - Admin page access denied even when access is given to child items": "https://gist.githubusercontent.com/pfrilling/564587c071e5fe5cbbba5a8f94a7c654/raw/ac50b2bec1e85c17bf3c0e9972283aaf19cc9272/gistfile1.txt",
+                "2741187 - 39 - Allow usage of WYSIWYG in views text area fields": "https://gist.githubusercontent.com/pfrilling/91262eb9ca72ec66704027344ebc0e56/raw/cba7ef0284684d1db59c193e5a06968a36b73a02/gistfile1.txt"
             },
             "drupal/paragraphs": {
                 "2901390 - Integrity constraint violation: 1048 Column 'langcode' cannot be null": "https://www.drupal.org/files/issues/2020-06-25/paragraphs-2901390-51.patch",


### PR DESCRIPTION
## Summary / Approach
Patches Drupal Core to allow for the WYSIWYG in a views global text area.

## Testing Instruction(s)
Edit a view, add a global text area to a view header and confirm that the WYSIWYG is available.

## Screenshots

## Metadata
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? | yes
| Documentation reflects changes? | no
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests cover changes? | no
| Did you perform browser testing? | yes
| Did you provide detail in the summary on how and where to test this branch? | yes
| Risk level | low
| Relevant links | [RIGA-488](https://thinkoomph.jira.com/browse/RIGA-488)
