### PR TITLE
Add agency select field to the Press Release content type through features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ## [Unreleased]
 ### Added
 - RIGA-522: Added the HAL module.
+- RIGA-514: Add agency select field to the Press Release content type through features
 
 ### Changed
 

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.entity_form_display.node.press_release.default.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.entity_form_display.node.press_release.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.press_release.field_agency
     - field.field.node.press_release.field_meta_tags_press_release
     - field.field.node.press_release.field_press_release_body
     - field.field.node.press_release.field_press_release_date
@@ -31,40 +32,48 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_agency:
+    type: options_buttons
+    weight: 129
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_meta_tags_press_release:
+    type: metatag_firehose
     weight: 128
+    region: content
     settings:
       sidebar: true
+      use_details: true
     third_party_settings: {  }
-    type: metatag_firehose
-    region: content
   field_press_release_body:
+    type: text_textarea_with_summary
     weight: 121
+    region: content
     settings:
       rows: 9
       summary_rows: 3
       placeholder: ''
       show_summary: false
     third_party_settings: {  }
-    type: text_textarea_with_summary
-    region: content
   field_press_release_date:
+    type: datetime_default
     weight: 122
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: datetime_default
-    region: content
   field_press_release_links:
+    type: link_default
     weight: 123
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_press_release_paragraphs:
     type: entity_reference_paragraphs
     weight: 125
+    region: content
     settings:
       title: 'Content Component'
       title_plural: 'Content Components'
@@ -73,35 +82,34 @@ content:
       form_display_mode: default
       default_paragraph_type: _none
     third_party_settings: {  }
-    region: content
   field_press_release_promotions:
+    type: entity_reference_autocomplete
     weight: 127
+    region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_press_release_source:
+    type: text_textarea
     weight: 124
+    region: content
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-    type: text_textarea
-    region: content
   field_press_release_topics:
+    type: entity_reference_autocomplete
     weight: 126
+    region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   langcode:
     type: language_select
     weight: 2
@@ -112,8 +120,8 @@ content:
   moderation_state:
     type: moderation_state_default
     weight: 100
-    settings: {  }
     region: content
+    settings: {  }
     third_party_settings: {  }
   path:
     type: path
@@ -123,10 +131,10 @@ content:
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 15
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
@@ -134,19 +142,24 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 120
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 16
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
@@ -164,12 +177,12 @@ content:
   uid:
     type: entity_reference_autocomplete
     weight: 5
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
-    region: content
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.entity_view_display.node.press_release.default.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.entity_view_display.node.press_release.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.press_release.field_agency
     - field.field.node.press_release.field_meta_tags_press_release
     - field.field.node.press_release.field_press_release_body
     - field.field.node.press_release.field_press_release_date
@@ -24,35 +25,35 @@ bundle: press_release
 mode: default
 content:
   content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
-    settings: {  }
-    third_party_settings: {  }
   field_meta_tags_press_release:
-    weight: 8
+    type: metatag_empty_formatter
     label: above
     settings: {  }
     third_party_settings: {  }
-    type: metatag_empty_formatter
+    weight: 8
     region: content
   field_press_release_body:
-    weight: 1
+    type: text_default
     label: above
     settings: {  }
     third_party_settings: {  }
-    type: text_default
+    weight: 1
     region: content
   field_press_release_date:
-    weight: 2
+    type: datetime_default
     label: above
     settings:
-      format_type: medium
       timezone_override: ''
+      format_type: medium
     third_party_settings: {  }
-    type: datetime_default
+    weight: 2
     region: content
   field_press_release_links:
-    weight: 3
+    type: link
     label: above
     settings:
       trim_length: 80
@@ -61,42 +62,46 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    type: link
+    weight: 3
     region: content
   field_press_release_paragraphs:
     type: entity_reference_revisions_entity_view
-    weight: 5
     label: above
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
+    weight: 5
     region: content
   field_press_release_promotions:
-    weight: 7
+    type: entity_reference_entity_view
     label: hidden
     settings:
       view_mode: teaser
       link: false
     third_party_settings: {  }
-    type: entity_reference_entity_view
+    weight: 7
     region: content
   field_press_release_source:
-    weight: 4
+    type: text_default
     label: above
     settings: {  }
     third_party_settings: {  }
-    type: text_default
+    weight: 4
     region: content
   field_press_release_topics:
-    weight: 6
+    type: entity_reference_label
     label: above
     settings:
       link: true
     third_party_settings: {  }
-    type: entity_reference_label
+    weight: 6
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
+  field_agency: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/ecms_base/features/custom/ecms_press_release/config/install/core.entity_view_display.node.press_release.teaser.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/core.entity_view_display.node.press_release.teaser.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.press_release.field_agency
     - field.field.node.press_release.field_meta_tags_press_release
     - field.field.node.press_release.field_press_release_body
     - field.field.node.press_release.field_press_release_date
@@ -23,23 +24,27 @@ mode: teaser
 content:
   field_press_release_body:
     type: text_summary_or_trimmed
-    weight: 0
-    region: content
     label: hidden
     settings:
       trim_length: 200
     third_party_settings: {  }
+    weight: 0
+    region: content
   field_press_release_date:
     type: datetime_default
-    weight: 1
-    region: content
     label: hidden
     settings:
-      format_type: medium
       timezone_override: ''
+      format_type: medium
     third_party_settings: {  }
+    weight: 1
+    region: content
 hidden:
   content_moderation_control: true
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
+  field_agency: true
   field_meta_tags_press_release: true
   field_press_release_links: true
   field_press_release_paragraphs: true

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_agency.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_agency.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_agency
+    - node.type.press_release
+  module:
+    - options
+id: node.press_release.field_agency
+field_name: field_agency
+entity_type: node
+bundle: press_release
+label: Agency
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_body.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_body.yml
@@ -19,4 +19,5 @@ default_value_callback: ''
 settings:
   display_summary: true
   required_summary: false
+  allowed_formats: {  }
 field_type: text_with_summary

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_source.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_press_release_source.yml
@@ -16,5 +16,6 @@ required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats: {  }
 field_type: text_long

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_agency.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_agency.yml
@@ -1,0 +1,155 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_agency
+field_name: field_agency
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: administration_department_of
+      label: 'Administration, Department of'
+    -
+      value: attorney_general_office_of
+      label: 'Attorney General, Office of'
+    -
+      value: attorney_general_consumer_news_and_alerts
+      label: 'Attorney General: Consumer News and Alerts'
+    -
+      value: attorney_general_open_government
+      label: 'Attorney General: Open Government'
+    -
+      value: board_of_elections
+      label: 'Board of Elections'
+    -
+      value: business_regulation_department_of
+      label: 'Business Regulation, Department of'
+    -
+      value: child_advocate_office_of_the
+      label: 'Child Advocate, Office of the'
+    -
+      value: contractor_registration_board
+      label: 'Contractor Registration Board'
+    -
+      value: department_of_children_youth_and_families
+      label: 'Department of Children, Youth and Families'
+    -
+      value: department_of_corrections
+      label: 'Department of Corrections'
+    -
+      value: department_of_human_services
+      label: 'Department of Human Services'
+    -
+      value: department_of_labor_and_training
+      label: 'Department of Labor and Training'
+    -
+      value: division_of_elderly_affairs
+      label: 'Division of Elderly Affairs'
+    -
+      value: division_of_municipal_finance
+      label: 'Division of Municipal Finance'
+    -
+      value: economic_recovery_and_reinvestment_office_of
+      label: 'Economic Recovery and Reinvestment, Office of'
+    -
+      value: emergency_management_agency
+      label: 'Emergency Management Agency'
+    -
+      value: en_espanol
+      label: 'En Espanol'
+    -
+      value: energy_resources_office_of
+      label: 'Energy Resources, Office of'
+    -
+      value: environmental_management_department_of
+      label: 'Environmental Management, Department of'
+    -
+      value: ethics_commission
+      label: 'Ethics Commission'
+    -
+      value: general_treasurer_office_of_the
+      label: 'General Treasurer, Office of the'
+    -
+      value: governor_mckee_executive_orders
+      label: 'Governor McKee Executive Orders'
+    -
+      value: governor_mckee_speeches
+      label: 'Governor McKee Speeches'
+    -
+      value: governor_office_of_the
+      label: 'Governor, Office of the'
+    -
+      value: health_and_human_services_executive_office_of
+      label: 'Health and Human Services, Executive Office of'
+    -
+      value: health_department_of
+      label: 'Health, Department of'
+    -
+      value: health_department_of_beach_monitoring
+      label: 'Health, Department of: Beach Monitoring'
+    -
+      value: health_department_of_drinking_water
+      label: 'Health, Department of: Drinking Water'
+    -
+      value: historical_preservation_and_heritage_commission
+      label: 'Historical Preservation and Heritage Commission'
+    -
+      value: labor_and_training_department_of
+      label: 'Labor and Training, Department of'
+    -
+      value: lt_governor_office_of_the
+      label: 'LT. Governor, Office of the'
+    -
+      value: minority_business_enterprise
+      label: 'Minority Business Enterprise'
+    -
+      value: motor_vehicles_division_of
+      label: 'Motor Vehicles, Division of'
+    -
+      value: office_of_diversity_equity_opportunity
+      label: 'Office of Diversity, Equity & Opportunity'
+    -
+      value: office_or_the_health_insurance_commissioner
+      label: 'Office or the Health Insurance Commissioner'
+    -
+      value: public_safety_department_of
+      label: 'Public Safety, Department of'
+    -
+      value: revenue_department_of
+      label: 'Revenue, Department of'
+    -
+      value: rhode_island_state_council_on_the_arts
+      label: 'Rhode Island State Council on the Arts'
+    -
+      value: ri_commerce_corporation
+      label: 'RI Commerce Corporation'
+    -
+      value: ri_higher_education_assistance_authority
+      label: 'RI Higher Education Assistance Authority'
+    -
+      value: secretary_of_state_office_of_the
+      label: 'Secretary of State, Office of the'
+    -
+      value: state_police_of_rhode_island
+      label: 'State Police of Rhode Island'
+    -
+      value: taxation_division_of
+      label: 'Taxation, Division of'
+    -
+      value: transportation_department_of
+      label: 'Transportation, Department of'
+    -
+      value: water_resources_board
+      label: 'Water Resources Board'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_press_release/ecms_press_release.info.yml
+++ b/ecms_base/features/custom/ecms_press_release/ecms_press_release.info.yml
@@ -1,30 +1,31 @@
 name: 'Press release'
 description: 'Provides Press release content type and related configuration.'
 type: module
-core_version_requirement: '^9 || ^10'
+core_version_requirement: '^9.4 || ^10'
 dependencies:
-  - content_moderation
-  - content_translation
-  - datetime
-  - ecms_paragraphs
-  - ecms_promotions
-  - ecms_workflow
-  - entity_reference_revisions
-  - field
-  - language
-  - link
-  - menu_ui
-  - metatag
-  - node
-  - paragraphs
-  - path
-  - pathauto
-  - rabbit_hole
-  - scheduled_transitions
-  - simple_sitemap
-  - taxonomy
-  - text
-  - user
-  - views
+  - ':ecms_paragraphs'
+  - ':ecms_promotions'
+  - ':ecms_workflow'
+  - 'drupal:content_moderation'
+  - 'drupal:content_translation'
+  - 'drupal:datetime'
+  - 'drupal:field'
+  - 'drupal:language'
+  - 'drupal:link'
+  - 'drupal:menu_ui'
+  - 'drupal:node'
+  - 'drupal:options'
+  - 'drupal:path'
+  - 'drupal:taxonomy'
+  - 'drupal:text'
+  - 'drupal:user'
+  - 'drupal:views'
+  - 'entity_reference_revisions:entity_reference_revisions'
+  - 'metatag:metatag'
+  - 'paragraphs:paragraphs'
+  - 'pathauto:pathauto'
+  - 'rabbit_hole:rabbit_hole'
+  - 'scheduled_transitions:scheduled_transitions'
+  - 'simple_sitemap:simple_sitemap'
 package: eCMS
 version: 9.x-1.0


### PR DESCRIPTION
## Summary / Approach
<!-- Include a summary of your changes that expands upon the title. -->
Added new agency select field to the Press Release content type through features 

## Testing Instruction(s)
<!-- Include a summary of how your changes should be tested, including any necessary links to the env used. -->

## Screenshots
<!-- If appropriate include necessary screenshots to show the feature on mobile and desktop views. -->

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? | yes
| Documentation reflects changes? | 
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests cover changes? | no
| Did you perform browser testing? | locally
| Did you provide detail in the summary on how and where to test this branch? | There is now an agency multi-select checkbox field on the Press Release content type
| Risk level | low
| Relevant links | RIGA-514
