### PR TITLE
Riga 526/patch update

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
 
       - name: Check PHP Version
         run: php -v
@@ -72,11 +72,11 @@ jobs:
           path: /tmp/drupal-build.tar.gz
 
   test-php:
-    name: Test the site with PHP 8.1
+    name: Test the site with PHP 8.2
     needs: build
     runs-on: ubuntu-latest
     container:
-      image: drupalci/php-8.1-apache:production
+      image: drupalci/php-8.2-apache:production
     services:
       mysql:
         image: mysql:5.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
+- RIGA-526: Added patch to allow subprofiles to work with Drupal Core ^10.3
+- RIGA-526: Fixed develop and ci-develop scripts to use 10.3.x & php 8.2.
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
                 "3049332 - PHP message: Error: Call to a member function getEntityTypeId() on null (Layout Builder)": "https://www.drupal.org/files/issues/2024-01-09/drupal-core--2024-01-09--3049332-85.patch",
                 "2827921 - Exception thrown by responsive srcset images when the image is not yet in the file system (such as with Stage File Proxy)": "https://www.drupal.org/files/issues/2827921-remove-missing-responsive-image-width-exception.patch",
                 "3308838 - EntityRepository::getTranslationFromContext() function forcibly adds default entity language to fallback candidates": "https://www.drupal.org/files/issues/2024-02-22/drupal-3308838-fix-fallback-to-default-lang-42.patch",
-                "3413508 - 55 - Admin page access denied even when access is given to child items": "https://gist.githubusercontent.com/pfrilling/564587c071e5fe5cbbba5a8f94a7c654/raw/ac50b2bec1e85c17bf3c0e9972283aaf19cc9272/gistfile1.txt",
                 "2741187 - 39 - Allow usage of WYSIWYG in views text area fields": "https://gist.githubusercontent.com/pfrilling/91262eb9ca72ec66704027344ebc0e56/raw/cba7ef0284684d1db59c193e5a06968a36b73a02/gistfile1.txt"
             },
             "drupal/paragraphs": {

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "extra": {
         "patches": {
             "drupal/core": {
-                "3266057 - #121 - Allow profiles to define a base/parent profile [continue of #1356276]": "https://www.drupal.org/files/issues/2023-12-05/3266057-121.patch",
+                "3266057 - #129 - Allow profiles to define a base/parent profile [continue of #1356276]": "https://www.drupal.org/files/issues/2024-07-03/3266057-129.patch",
                 "2794431 - [META] Formalize translations support (#102)": "https://www.drupal.org/files/issues/2020-09-29/jsonapi_add_and_update_translations_support-2794431-102.patch",
                 "3049332 - PHP message: Error: Call to a member function getEntityTypeId() on null (Layout Builder)": "https://www.drupal.org/files/issues/2024-01-09/drupal-core--2024-01-09--3049332-85.patch",
                 "2827921 - Exception thrown by responsive srcset images when the image is not yet in the file system (such as with Stage File Proxy)": "https://www.drupal.org/files/issues/2827921-remove-missing-responsive-image-width-exception.patch",

--- a/scripts/ci-develop.sh
+++ b/scripts/ci-develop.sh
@@ -15,7 +15,7 @@ PATTERN_LAB_REPOSITORY_NAME="state-of-rhode-island-ecms/ecms_patternlab"
 COMPOSER="$(which composer)"
 COMPOSER_BIN_DIR="$(composer config bin-dir)"
 DOCROOT="web"
-DRUPAL_CORE_VERSION="10.2.4"
+DRUPAL_CORE_VERSION="10.3"
 
 # Move up a directory.
 cd ..

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -16,8 +16,8 @@ PATTERN_LAB_REPOSITORY_NAME="state-of-rhode-island-ecms/ecms_patternlab"
 COMPOSER="$(which composer)"
 COMPOSER_BIN_DIR="$(composer config bin-dir)"
 DOCROOT="web"
-DRUPAL_CORE_VERSION="10.2.4"
-PHP_VERSION="8.1"
+DRUPAL_CORE_VERSION="10.3"
+PHP_VERSION="8.2"
 
 # Whether the source directory should be deleted before rebuilding lando
 DELETE_SRC=0
@@ -119,7 +119,7 @@ $COMPOSER require "drupal/core-recommended:${DRUPAL_CORE_VERSION}" --no-update
 $COMPOSER require "drupal/core-vendor-hardening:${DRUPAL_CORE_VERSION}" --no-update
 $COMPOSER remove "drupal/devel" --no-update
 
-echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} $LANDO init --name $APP_NAME --recipe drupal10 --option php=$PHP_VERSION --webroot $DOCROOT --source cwd\n\n"
+echo -e "${FG_C}${BG_C} EXECUTING ${NO_C} $LANDO init --name $APP_NAME --recipe drupal10 --option php=$PHP_VERSION --option database=mysql:5.7 --webroot $DOCROOT --source cwd\n\n"
 $LANDO init --name ${APP_NAME} --recipe drupal10 --option php=${PHP_VERSION} --webroot ${DOCROOT} --source cwd
 
 # Check for a lando local file.
@@ -135,6 +135,7 @@ else
     echo -e  "${FG_C}${BG_C}Pattern lab git repository found at${NO_C}: $PATTERN_LAB_FULL_PATH, symlinking for development."
     LANDO_SERVICES="services:
   appserver:
+    composer_version: 2-latest
     overrides:
       environment:
         SIMPLETEST_BASE_URL: 'https://appserver'
@@ -154,6 +155,7 @@ else
     echo -e  "${FG_C}${BG_C}Pattern lab git repository NOT found at${NO_C}: $PATTERN_LAB_FULL_PATH, ignoring symlink."
     LANDO_SERVICES="services:
   appserver:
+    composer_version: 2-latest
     run_as_root:
       - echo 'deb http://deb.debian.org/debian stretch-backports main' >> /etc/apt/sources.list && apt-get update && apt-get install -y -t stretch-backports sqlite3 libsqlite3-dev
     overrides:


### PR DESCRIPTION
## Summary
Updated Drupal Core to 10.3  and removed/updated patch

## Metadata
| Question | Answer |
|----------|--------|
| Did you use a meaningful pull request title? | yes
| Did you apply meaningful labels to the pull request? | yes
| Did you perform a self review first? | yes
| Documentation reflects changes? | n/a
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests reflect changes? | n/a
| Did you perform browser testing? | yes
| Risk level | Low
| Relevant links | [RIGA-526](https://thinkoomph.jira.com/browse/RIGA-526)
