### PR TITLE
RIGA 511: Add global notification type V2

### DIFF
--- a/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_form_display.node.basic_page.default.yml
+++ b/ecms_base/features/custom/ecms_basic_page/config/install/core.entity_form_display.node.basic_page.default.yml
@@ -1,4 +1,3 @@
-uuid: 9df1df4c-97d8-4d9a-9de9-2bcc259b38f4
 langcode: en
 status: true
 dependencies:
@@ -19,8 +18,6 @@ dependencies:
     - paragraphs
     - path
     - text
-_core:
-  default_config_hash: qnXlW0wIHBCaApAHPJ-a23_Cq0nZsu0Sddvzi2pko6A
 id: node.basic_page.default
 targetEntityType: node
 bundle: basic_page

--- a/ecms_base/features/custom/ecms_emergency_notification/config/install/core.entity_form_display.node.emergency_notification.default.yml
+++ b/ecms_base/features/custom/ecms_emergency_notification/config/install/core.entity_form_display.node.emergency_notification.default.yml
@@ -3,11 +3,14 @@ status: true
 dependencies:
   config:
     - field.field.node.emergency_notification.field_emergency_background_color
+    - field.field.node.emergency_notification.field_emergency_expire_date
     - field.field.node.emergency_notification.field_emergency_message
+    - field.field.node.emergency_notification.field_emergency_weight
     - node.type.emergency_notification
     - workflows.workflow.editorial
   module:
     - content_moderation
+    - datetime
     - path
     - text
 id: node.emergency_notification.default
@@ -27,6 +30,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_emergency_expire_date:
+    type: datetime_default
+    weight: 126
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_emergency_message:
     type: text_textarea
     weight: 52
@@ -34,6 +43,12 @@ content:
     settings:
       rows: 5
       placeholder: ''
+    third_party_settings: {  }
+  field_emergency_weight:
+    type: options_select
+    weight: 127
+    region: content
+    settings: {  }
     third_party_settings: {  }
   langcode:
     type: language_select

--- a/ecms_base/features/custom/ecms_emergency_notification/config/install/core.entity_view_display.node.emergency_notification.default.yml
+++ b/ecms_base/features/custom/ecms_emergency_notification/config/install/core.entity_view_display.node.emergency_notification.default.yml
@@ -3,9 +3,12 @@ status: true
 dependencies:
   config:
     - field.field.node.emergency_notification.field_emergency_background_color
+    - field.field.node.emergency_notification.field_emergency_expire_date
     - field.field.node.emergency_notification.field_emergency_message
+    - field.field.node.emergency_notification.field_emergency_weight
     - node.type.emergency_notification
   module:
+    - datetime
     - options
     - text
     - user
@@ -26,12 +29,28 @@ content:
     third_party_settings: {  }
     weight: 101
     region: content
+  field_emergency_expire_date:
+    type: datetime_default
+    label: above
+    settings:
+      timezone_override: ''
+      format_type: medium
+    third_party_settings: {  }
+    weight: 103
+    region: content
   field_emergency_message:
     type: text_default
     label: above
     settings: {  }
     third_party_settings: {  }
     weight: 102
+    region: content
+  field_emergency_weight:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 104
     region: content
   links:
     settings: {  }

--- a/ecms_base/features/custom/ecms_emergency_notification/config/install/core.entity_view_display.node.emergency_notification.teaser.yml
+++ b/ecms_base/features/custom/ecms_emergency_notification/config/install/core.entity_view_display.node.emergency_notification.teaser.yml
@@ -4,7 +4,9 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.emergency_notification.field_emergency_background_color
+    - field.field.node.emergency_notification.field_emergency_expire_date
     - field.field.node.emergency_notification.field_emergency_message
+    - field.field.node.emergency_notification.field_emergency_weight
     - node.type.emergency_notification
   module:
     - user
@@ -28,6 +30,8 @@ hidden:
   entity_print_view_pdf: true
   entity_print_view_word_docx: true
   field_emergency_background_color: true
+  field_emergency_expire_date: true
   field_emergency_message: true
+  field_emergency_weight: true
   langcode: true
   search_api_excerpt: true

--- a/ecms_base/features/custom/ecms_emergency_notification/config/install/field.field.node.emergency_notification.field_emergency_expire_date.yml
+++ b/ecms_base/features/custom/ecms_emergency_notification/config/install/field.field.node.emergency_notification.field_emergency_expire_date.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_emergency_expire_date
+    - node.type.emergency_notification
+  module:
+    - datetime
+id: node.emergency_notification.field_emergency_expire_date
+field_name: field_emergency_expire_date
+entity_type: node
+bundle: emergency_notification
+label: 'Expiration Date'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    default_date_type: relative
+    default_date: '+30 days'
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/ecms_base/features/custom/ecms_emergency_notification/config/install/field.field.node.emergency_notification.field_emergency_weight.yml
+++ b/ecms_base/features/custom/ecms_emergency_notification/config/install/field.field.node.emergency_notification.field_emergency_weight.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_emergency_weight
+    - node.type.emergency_notification
+  module:
+    - options
+id: node.emergency_notification.field_emergency_weight
+field_name: field_emergency_weight
+entity_type: node
+bundle: emergency_notification
+label: Weight
+description: 'Add a sorting weight to the notification. 9 being the highest priority and appearing first in the list. -9 being the lowest priority and appearing last.'
+required: true
+translatable: false
+default_value:
+  -
+    value: '0'
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/ecms_base/features/custom/ecms_emergency_notification/config/install/field.field.node.emergency_notification.field_emergency_weight.yml
+++ b/ecms_base/features/custom/ecms_emergency_notification/config/install/field.field.node.emergency_notification.field_emergency_weight.yml
@@ -16,7 +16,7 @@ required: true
 translatable: false
 default_value:
   -
-    value: '0'
+    value: 0
 default_value_callback: ''
 settings: {  }
-field_type: list_string
+field_type: list_integer

--- a/ecms_base/features/custom/ecms_emergency_notification/config/install/field.storage.node.field_emergency_expire_date.yml
+++ b/ecms_base/features/custom/ecms_emergency_notification/config/install/field.storage.node.field_emergency_expire_date.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_emergency_expire_date
+field_name: field_emergency_expire_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_emergency_notification/config/install/field.storage.node.field_emergency_weight.yml
+++ b/ecms_base/features/custom/ecms_emergency_notification/config/install/field.storage.node.field_emergency_weight.yml
@@ -7,65 +7,65 @@ dependencies:
 id: node.field_emergency_weight
 field_name: field_emergency_weight
 entity_type: node
-type: list_string
+type: list_integer
 settings:
   allowed_values:
     -
-      value: '9'
+      value: 9
       label: '9'
     -
-      value: '8'
+      value: 8
       label: '8'
     -
-      value: '7'
+      value: 7
       label: '7'
     -
-      value: '6'
+      value: 6
       label: '6'
     -
-      value: '5'
+      value: 5
       label: '5'
     -
-      value: '4'
+      value: 4
       label: '4'
     -
-      value: '3'
+      value: 3
       label: '3'
     -
-      value: '2'
+      value: 2
       label: '2'
     -
-      value: '1'
+      value: 1
       label: '1'
     -
-      value: '0'
-      label: none
+      value: 0
+      label: default
     -
-      value: '-1'
+      value: -1
       label: '-1'
     -
-      value: '-2'
+      value: -2
       label: '-2'
     -
-      value: '-3'
+      value: -3
       label: '-3'
     -
-      value: '-4'
+      value: -4
       label: '-4'
     -
-      value: '-5'
+      value: -5
       label: '-5'
     -
-      value: '-6'
+      value: -6
       label: '-6'
     -
-      value: '-7'
+      value: -7
       label: '-7'
     -
-      value: '-8'
+      value: -8
       label: '-8'
     -
-      value: '-9'
+      value: -9
       label: '-9'
   allowed_values_function: ''
 module: options

--- a/ecms_base/features/custom/ecms_emergency_notification/config/install/field.storage.node.field_emergency_weight.yml
+++ b/ecms_base/features/custom/ecms_emergency_notification/config/install/field.storage.node.field_emergency_weight.yml
@@ -1,0 +1,77 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_emergency_weight
+field_name: field_emergency_weight
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: '9'
+      label: '9'
+    -
+      value: '8'
+      label: '8'
+    -
+      value: '7'
+      label: '7'
+    -
+      value: '6'
+      label: '6'
+    -
+      value: '5'
+      label: '5'
+    -
+      value: '4'
+      label: '4'
+    -
+      value: '3'
+      label: '3'
+    -
+      value: '2'
+      label: '2'
+    -
+      value: '1'
+      label: '1'
+    -
+      value: '0'
+      label: none
+    -
+      value: '-1'
+      label: '-1'
+    -
+      value: '-2'
+      label: '-2'
+    -
+      value: '-3'
+      label: '-3'
+    -
+      value: '-4'
+      label: '-4'
+    -
+      value: '-5'
+      label: '-5'
+    -
+      value: '-6'
+      label: '-6'
+    -
+      value: '-7'
+      label: '-7'
+    -
+      value: '-8'
+      label: '-8'
+    -
+      value: '-9'
+      label: '-9'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_emergency_notification/ecms_emergency_notification.info.yml
+++ b/ecms_base/features/custom/ecms_emergency_notification/ecms_emergency_notification.info.yml
@@ -7,6 +7,7 @@ dependencies:
   - 'drupal:content_moderation'
   - 'drupal:content_translation'
   - 'drupal:contextual'
+  - 'drupal:datetime'
   - 'drupal:field'
   - 'drupal:filter'
   - 'drupal:media'


### PR DESCRIPTION
## Summary / Approach
This PR adds two fields to the Emergency Notification content type that is part of a feature.
In addition, an item in the basic page feature is changed since the script to remove UUIDs was run on the codebase.

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests cover changes? | n/a
| Did you perform browser testing? | yes
| Did you provide detail in the summary on how and where to test this branch? | no
| Risk level | low
| Relevant links | [RIGA-511](https://thinkoomph.jira.com/browse/RIGA-511)
