### PR TITLE
RIGA-520: Change migration source

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -101,7 +101,7 @@ jobs:
         run: php -v
 
       - name: Retrieve the build artifact.
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: drupal-build.tar.gz
           path: /var/www/

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -66,7 +66,7 @@ jobs:
         run: tar -czf /tmp/drupal-build.tar.gz .
 
       - name: Upload the artifact.
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: drupal-build.tar.gz
           path: /tmp/drupal-build.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
+- RIGA-520: Update the source file for English Health migration.
 
 ### Deprecated
 

--- a/ecms_base/modules/custom/ecms_health_file_migration/config/install/migrate_plus.migration.health_file_json_to_file.yml
+++ b/ecms_base/modules/custom/ecms_health_file_migration/config/install/migrate_plus.migration.health_file_json_to_file.yml
@@ -54,7 +54,6 @@ source:
       name: title
       label: Title
       selector: /language/en/title
-
   ids:
     id:
       type: integer

--- a/ecms_base/modules/custom/ecms_health_file_migration/config/install/migrate_plus.migration.health_file_json_to_file.yml
+++ b/ecms_base/modules/custom/ecms_health_file_migration/config/install/migrate_plus.migration.health_file_json_to_file.yml
@@ -7,6 +7,9 @@ destination:
   plugin: 'entity:file'
 
 source:
+  constants:
+    DRUPAL_FILE_DIRECTORY: 'public://'
+    DIRECTORY_SEPERATOR: '/'
   plugin: url
   data_fetcher_plugin: http
   urls:
@@ -27,10 +30,7 @@ source:
       label: Topic
       selector: topic
     -
-      name: profession
-      label: Profession
-      selector: profession
-    -
+
       name: type_of_material
       label: 'Type of Material'
       selector: type_of_material
@@ -54,21 +54,7 @@ source:
       name: title
       label: Title
       selector: /language/en/title
-    -
-      name: date_published
-      label: Date Published
-      selector: date_published
-    -
-      name: order_form
-      label: Order Form
-      selector: order_form
-    -
-      name: date_covered
-      label: Date Covered
-      selector: date_covered
-    - name: disease
-      label: Disease
-      selector: disease
+
   ids:
     id:
       type: integer

--- a/ecms_base/modules/custom/ecms_health_file_migration/config/install/migrate_plus.migration.health_file_json_to_file.yml
+++ b/ecms_base/modules/custom/ecms_health_file_migration/config/install/migrate_plus.migration.health_file_json_to_file.yml
@@ -7,27 +7,29 @@ destination:
   plugin: 'entity:file'
 
 source:
-  constants:
-    DRUPAL_FILE_DIRECTORY: 'public://'
-    DIRECTORY_SEPERATOR: '/'
   plugin: url
   data_fetcher_plugin: http
+  urls:
+    - 'https://health.ri.gov/rss/pubs/publications-total-en.json.php'
   data_parser_plugin: json
-  # The JSON source file URL for the migration.
-  urls: 'https://health.ri.gov/rss/pubs/publications-media-en.json.php'
-  # Under 'fields', we list the data items to be imported. The first level keys
-  # are the source field names we want to populate (the names to be used as
-  # sources in the process configuration below). For each field we're importing,
-  # we provide a label (optional - this is for display in migration tools) and
-  # an selector (xpath) for retrieving that value. It's important to note that this xpath
-  # is relative to the elements retrieved by item_selector.
-
   item_selector: '[*]'
   fields:
     -
       name: id
-      label: 'ID'
+      label: ID
       selector: id
+    -
+      name: entity
+      label: Entity
+      selector: entity
+    -
+      name: topic
+      label: Topic
+      selector: topic
+    -
+      name: profession
+      label: Profession
+      selector: profession
     -
       name: type_of_material
       label: 'Type of Material'
@@ -52,11 +54,24 @@ source:
       name: title
       label: Title
       selector: /language/en/title
+    -
+      name: date_published
+      label: Date Published
+      selector: date_published
+    -
+      name: order_form
+      label: Order Form
+      selector: order_form
+    -
+      name: date_covered
+      label: Date Covered
+      selector: date_covered
+    - name: disease
+      label: Disease
+      selector: disease
   ids:
     id:
       type: integer
-
-  # Use the ID as the key unique migration identifier.
   keys:
     - id
 

--- a/ecms_base/modules/custom/ecms_health_file_migration/config/install/migrate_plus.migration.health_file_redirect.yml
+++ b/ecms_base/modules/custom/ecms_health_file_migration/config/install/migrate_plus.migration.health_file_redirect.yml
@@ -13,21 +13,29 @@ migration_tags: null
 migration_group: files_json_to_resource_media
 label: 'Setup file redirects for the ecms_health_file migration.'
 source:
-  constants:
-    DRUPAL_FILE_DIRECTORY: sites/default/files
-    DIRECTORY_SEPERATOR: /
-    REDIRECT_CODE: 301
   plugin: url
   data_fetcher_plugin: http
-  data_parser_plugin: json
   urls:
-    - 'https://health.ri.gov/rss/pubs/publications-media-en.json.php'
+    - 'https://health.ri.gov/rss/pubs/publications-total-en.json.php'
+  data_parser_plugin: json
   item_selector: '[*]'
   fields:
     -
       name: id
       label: ID
       selector: id
+    -
+      name: entity
+      label: Entity
+      selector: entity
+    -
+      name: topic
+      label: Topic
+      selector: topic
+    -
+      name: profession
+      label: Profession
+      selector: profession
     -
       name: type_of_material
       label: 'Type of Material'
@@ -52,6 +60,21 @@ source:
       name: title
       label: Title
       selector: /language/en/title
+    -
+      name: date_published
+      label: Date Published
+      selector: date_published
+    -
+      name: order_form
+      label: Order Form
+      selector: order_form
+    -
+      name: date_covered
+      label: Date Covered
+      selector: date_covered
+    - name: disease
+      label: Disease
+      selector: disease
   ids:
     id:
       type: integer

--- a/ecms_base/modules/custom/ecms_health_file_migration/config/install/migrate_plus.migration.health_file_redirect.yml
+++ b/ecms_base/modules/custom/ecms_health_file_migration/config/install/migrate_plus.migration.health_file_redirect.yml
@@ -13,29 +13,21 @@ migration_tags: null
 migration_group: files_json_to_resource_media
 label: 'Setup file redirects for the ecms_health_file migration.'
 source:
+  constants:
+    DRUPAL_FILE_DIRECTORY: sites/default/files
+    DIRECTORY_SEPERATOR: /
+    REDIRECT_CODE: 301
   plugin: url
   data_fetcher_plugin: http
+  data_parser_plugin: json
   urls:
     - 'https://health.ri.gov/rss/pubs/publications-total-en.json.php'
-  data_parser_plugin: json
   item_selector: '[*]'
   fields:
     -
       name: id
       label: ID
       selector: id
-    -
-      name: entity
-      label: Entity
-      selector: entity
-    -
-      name: topic
-      label: Topic
-      selector: topic
-    -
-      name: profession
-      label: Profession
-      selector: profession
     -
       name: type_of_material
       label: 'Type of Material'
@@ -60,21 +52,6 @@ source:
       name: title
       label: Title
       selector: /language/en/title
-    -
-      name: date_published
-      label: Date Published
-      selector: date_published
-    -
-      name: order_form
-      label: Order Form
-      selector: order_form
-    -
-      name: date_covered
-      label: Date Covered
-      selector: date_covered
-    - name: disease
-      label: Disease
-      selector: disease
   ids:
     id:
       type: integer


### PR DESCRIPTION
## Summary / Approach
Update the config files that describe 
- health_file_json_to_file
- health_file_redirect

Update the source to be the same as the one for
- health_file_json_to_resource_media

That is, set it to https://health.ri.gov/rss/pubs/publications-total-en.json.php

## Metadata
<!-- Please fill out ALL metadata. Use N/A when necessary. -->
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests cover changes? | no
| Did you perform browser testing? | yes
| Did you provide detail in the summary on how and where to test this branch? | no
| Risk level | low
| Relevant links | [RIGA-520](https://thinkoomph.jira.com/browse/RIGA-520)
