### PR TITLE
Riga 558/feeds fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-588: Added new feeds parser plugin for press releases.
 
 ### Changed
 

--- a/ecms_base/modules/custom/ecms_feeds/src/Feeds/Parser/EcmsPressReleaseParser.php
+++ b/ecms_base/modules/custom/ecms_feeds/src/Feeds/Parser/EcmsPressReleaseParser.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ecms_feeds\Feeds\Parser;
+
+use Drupal\feeds\Exception\EmptyFeedException;
+use Drupal\feeds\FeedInterface;
+use Drupal\feeds\Feeds\Parser\SyndicationParser;
+use Drupal\feeds\Result\FetcherResultInterface;
+use Drupal\feeds\Result\ParserResultInterface;
+use Drupal\feeds\StateInterface;
+use Laminas\Feed\Reader\Exception\ExceptionInterface;
+use Laminas\Feed\Reader\Reader;
+
+/**
+ * Define a RSS feed parser specific for ri.gov press releases.
+ *
+ * This will place the <categories> into the feed_agency field for mapping.
+ *
+ * @FeedsParser(
+ *   id = "ecms_agency_syndication",
+ *   title = @Translation("RI.gov Agency Syndication"),
+ *   description = @Translation("RSS syndication that includes the agency in the channel.")
+ * )
+ */
+class EcmsPressReleaseParser extends SyndicationParser {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function parse(
+    FeedInterface $feed,
+    FetcherResultInterface $fetcher_result,
+    StateInterface $state,
+  ): ParserResultInterface {
+    /** @var \Drupal\feeds\Result\ParserResultInterface $result */
+    $results = parent::parse($feed, $fetcher_result, $state);
+
+    $raw = $fetcher_result->getRaw();
+    if (!strlen(trim($raw))) {
+      throw new EmptyFeedException();
+    }
+
+    try {
+      $channel = Reader::importString($raw);
+    }
+    catch (ExceptionInterface $e) {
+      $args = [
+        '%site' => $feed->label() ?? '',
+        '%error' => trim($e->getMessage()),
+      ];
+      throw new \RuntimeException(sprintf('The feed from %s seems to be broken because of error "%s".', $args['%site'], $args['%error']));
+    }
+
+    $agencies = $channel->getCategories()->getValues();
+
+    $agency = (empty($agencies)) ? '' : $agencies[0];
+
+    foreach ($results as $item) {
+      $item->set('feed_agency', $agency);
+    }
+
+    return $results;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMappingSources(): array {
+    $mappings = parent::getMappingSources();
+
+    $mappings['feed_agency'] = [
+      'label' => $this->t('Feed agency'),
+      'description' => $this->t('The agency that published the press release (<channel>).'),
+    ];
+
+    return $mappings;
+  }
+
+}


### PR DESCRIPTION
## Summary / Approach
This adds a new feeds parser to handle the agency field by mapping the `<category>` channel field to the `field_agency`.

## Testing Instruction(s)
Create a new feed, select the `RI.gov Agency Syndication` and map the agency fields. Import and confirm the value is set on the items.

## Metadata
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |Yes
| Documentation reflects changes? | No
| `CHANGELOG` reflects changes? |yes
| Unit/Functional tests cover changes? |No
| Did you perform browser testing? |Yes
| Did you provide detail in the summary on how and where to test this branch? | no
| Risk level |low
| Relevant links | [RIGA-558](https://thinkoomph.jira.com/browse/RIGA-558)
