### PR TITLE
Fixed the permission issue with Layout Builder and Media Library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIGA-524: Fixed layout builder issue with media library.
 
 ### Security
 

--- a/ecms_base/modules/custom/ecms_layout/ecms_layout.module
+++ b/ecms_base/modules/custom/ecms_layout/ecms_layout.module
@@ -7,8 +7,11 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Url;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\media_library\MediaLibraryState;
 
 /**
  * Implements hook_plugin_filter_TYPE__CONSUMER_alter().
@@ -87,4 +90,44 @@ function _ecms_layout_block_exclude_list(): array {
   return [
     'system_menu_block:tools',
   ];
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_create_access().
+ *
+ * This fixes RIGA-524
+ * @see https://www.drupal.org/project/drupal/issues/3106315
+ */
+function ecms_layout_block_content_create_access(
+  AccountInterface $account,
+  array $context,
+  string $entity_bundle,
+): AccessResult {
+  // Get the path info from the main request.
+  $mainRequest = \Drupal::requestStack()->getMainRequest();
+  $pathInfo = $mainRequest->getPathInfo();
+
+  // Get the route information from the path.
+  $router = \Drupal::service('router.no_access_checks');
+  $match = $router->match($pathInfo);
+
+  $route_name = $match['_route'] ?? NULL;
+
+  if ($route_name === 'media_library.ui') {
+    /** @var \Drupal\media_library\MediaLibraryState $state */
+    $state = MediaLibraryState::fromRequest(\Drupal::request());
+    $openerParameters = $state->getOpenerParameters();
+
+    // The field widget ends with `-settings-block_form` when adding a block.
+    // using layout builder.
+    if (
+      isset($openerParameters['field_widget_id']) &&
+      str_ends_with($openerParameters['field_widget_id'], ':-settings-block_form')
+    ) {
+      return AccessResult::allowedIfHasPermission($account, 'create and edit custom blocks');
+    }
+  }
+
+  // No opinion.
+  return AccessResult::neutral();
 }

--- a/ecms_base/modules/custom/ecms_layout/ecms_layout.module
+++ b/ecms_base/modules/custom/ecms_layout/ecms_layout.module
@@ -95,7 +95,6 @@ function _ecms_layout_block_exclude_list(): array {
 /**
  * Implements hook_ENTITY_TYPE_create_access().
  *
- * This fixes RIGA-524
  * @see https://www.drupal.org/project/drupal/issues/3106315
  */
 function ecms_layout_block_content_create_access(

--- a/ecms_base/modules/custom/ecms_layout/ecms_layout.module
+++ b/ecms_base/modules/custom/ecms_layout/ecms_layout.module
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Url;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
 use Drupal\media_library\MediaLibraryState;
 
 /**


### PR DESCRIPTION
## Summary / Approach
This fixes an issue where adding media within a layout builder block gives a permission error. This is a known bug in Core. See: https://www.drupal.org/project/drupal/issues/3106315

## Testing Instruction(s)
As a site admin, add a new layout page and add a custom block that contains a `media` library widget.

## Screenshots
n/a

## Metadata
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |yes
| Documentation reflects changes? |no
| `CHANGELOG` reflects changes? |yes
| Unit/Functional tests cover changes? |no
| Did you perform browser testing? |yes
| Did you provide detail in the summary on how and where to test this branch? |yes
| Risk level |low
| Relevant links | [RIGA-524](https://thinkoomph.jira.com/browse/RIGA-524)
