### PR TITLE
Added NodeInterface guard to conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIGA-531: Fixed error loading layout builder admin layout page.
 
 ### Security
 

--- a/ecms_base/themes/custom/ecms/ecms.theme
+++ b/ecms_base/themes/custom/ecms/ecms.theme
@@ -668,7 +668,10 @@ function ecms_preprocess_paragraph__numbered_step_item(&$variables): void {
 
   $parent = $variables['paragraph']->getParentEntity();
 
-  if ($parent->bundle() === 'basic_page') {
+  if (
+    $parent instanceof NodeInterface &&
+    $parent->bundle() === 'basic_page'
+  ) {
 
     // Get entity_reference_revisions field.
     $components = $parent->get('field_basic_page_paragraphs');


### PR DESCRIPTION
## Summary / Approach
This adds a guard clause to the conditional to prevent a `null` reference when loading the layout builder default layout screen.

## Testing Instruction(s)
Browse to `admin/structure/types/manage/licensee/display/default/layout` and confirm the page loads.

## Screenshots
n/a

## Metadata
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |yes
| Documentation reflects changes? |no
| `CHANGELOG` reflects changes? |yes
| Unit/Functional tests cover changes? |no
| Did you perform browser testing? |yes
| Did you provide detail in the summary on how and where to test this branch? |yes
| Risk level |low
| Relevant links | [RIGA-531](https://thinkoomph.jira.com/browse/RIGA-531)
