### PR TITLE
RIGA 534: Fix Consumer Creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIGA-534: Fix consumer creation
 
 ### Security
 

--- a/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiPublisherInstall.php
+++ b/ecms_base/modules/custom/ecms_api_publisher/src/EcmsApiPublisherInstall.php
@@ -118,6 +118,7 @@ class EcmsApiPublisherInstall {
 
     $values = [
       'user_id' => $user->id(),
+      'client_id' => $this->t('eCMS Publisher'),
       'roles' => [self::PUBLISHER_ROLE],
       'label' => $this->t('eCMS Publisher'),
       'description' => $this->t('An oAuth client to receive endpoints from an eCMS recipient site.'),

--- a/ecms_base/modules/custom/ecms_api_recipient/src/EcmsApiRecipientInstall.php
+++ b/ecms_base/modules/custom/ecms_api_recipient/src/EcmsApiRecipientInstall.php
@@ -115,6 +115,7 @@ class EcmsApiRecipientInstall {
 
     $values = [
       'user_id' => $user->id(),
+      'client_id' => $this->t('eCMS Recipient'),
       'roles' => [self::RECIPIENT_ROLE],
       'label' => $this->t('eCMS Recipient'),
       'description' => $this->t('An oAuth client to receive content from an eCMS publishing site.'),


### PR DESCRIPTION
## Summary / Approach
Fix an error where there is a missing value when Consumers are created for eCMS API Publishers and Recipients

## Testing Instruction(s)
As a site admin, enable the ecms Publisher module (if it is not already enabled). Go to `/admin/config/services/consumer` and verify that the page loads without error.

## Metadata
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? | yes
| Documentation reflects changes? | yes
| `CHANGELOG` reflects changes? | yes
| Unit/Functional tests cover changes? | yes
| Did you perform browser testing? | yes
| Did you provide detail in the summary on how and where to test this branch? | yes
| Risk level | low
| Relevant links | [RIGA-534](https://thinkoomph.jira.com/browse/RIGA-534)
