### PR TITLE
Riga 570/enable opengraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-570: Added metatag_open_graph to the base install.
 
 ### Changed
 

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -59,6 +59,7 @@ dependencies:
   - menu_link_content
   - menu_ui
   - metatag
+  - metatag_open_graph
   - moderated_content_bulk_publish
   - moderation_dashboard
   - node

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -2251,3 +2251,16 @@ function ecms_base_update_10206(array &$sandbox): void {
   ];
   \Drupal::service('module_installer')->install($modules_to_install);
 }
+
+/**
+ * Install new modules after updating contrib modules.
+ *
+ * Runs as part of 1.1.1 tag.
+ */
+function ecms_base_update_10207(array &$sandbox): void {
+
+  $modules_to_install = [
+    'metatag_open_graph',
+  ];
+  \Drupal::service('module_installer')->install($modules_to_install);
+}


### PR DESCRIPTION
## Summary / Approach
This adds the metatag_open_graph submodule as a requirement for installation and an update hook to install it on all existing sites.

## Metadata
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |yes
| Documentation reflects changes? |no
| `CHANGELOG` reflects changes? |yes
| Unit/Functional tests cover changes? |no
| Did you perform browser testing? |yes
| Did you provide detail in the summary on how and where to test this branch? |no
| Risk level |low
| Relevant links | [RIGA-570](https://thinkoomph.jira.com/browse/RIGA-570)
