### PR TITLE
Disable cache and preprocess from the js

### DIFF
--- a/ecms_base/modules/custom/ecms_languages/ecms_languages.module
+++ b/ecms_base/modules/custom/ecms_languages/ecms_languages.module
@@ -120,7 +120,10 @@ function ecms_languages_libraries_js_alter(
     // Append to the version number to ensure the latest version is loaded.
     // This is necessary to prevent caching issues since our ecms_translator
     // block is extending from this library.
+    // Disable preprocess and caching to ensure the version is appended.
     $originalVersion = $javascript['modules/contrib/google_translator/js/init.js']['version'];
     $javascript['modules/contrib/google_translator/js/init.js']['version'] = sprintf('%s-%s', $originalVersion, \Drupal::VERSION);
+    $javascript['modules/contrib/google_translator/js/init.js']['cache'] = FALSE;
+    $javascript['modules/contrib/google_translator/js/init.js']['preprocess'] = FALSE;
   }
 }


### PR DESCRIPTION
## Summary / Approach
Disable preprocessing for the language js to bypass cache issue.