### PR TITLE
Riga 588/update permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
+- RIGA-588: Revoked permission for the emergency_notification content.
+- RIGA-588: Unpublished all emergency_notification content.
 
 ### Deprecated
 

--- a/ecms_base/modules/custom/ecms_workflow/ecms_workflow.module
+++ b/ecms_base/modules/custom/ecms_workflow/ecms_workflow.module
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Drupal\ecms_workflow\EcmsWorkflowBundleCreate;
 use Drupal\node\Entity\Node;
 use Drupal\webform\WebformInterface;
 
@@ -22,6 +23,22 @@ function ecms_workflow_entity_bundle_create($entity_type_id, $bundle) : void {
     // Call the workflow service to update configuration.
     \Drupal::service('ecms_workflow.bundle_create')
       ->addContentTypeToWorkflow($bundle);
+
+    if ($bundle === 'emergency_notification') {
+      // @see RIGA-588.
+      // Call the workflow service to update configuration.
+      \Drupal::service('ecms_workflow.bundle_create')
+        ->revokeRolePermissions(
+          EcmsWorkflowBundleCreate::CONTENT_PUBLISHER_ROLE,
+          $bundle
+        );
+
+      \Drupal::service('ecms_workflow.bundle_create')
+        ->revokeRolePermissions(
+          EcmsWorkflowBundleCreate::CONTENT_AUTHOR_ROLE,
+          $bundle
+        );
+    }
   }
 
   // Set taxonomy permissions when a new bundle is created.

--- a/ecms_base/modules/custom/ecms_workflow/ecms_workflow.post_update.php
+++ b/ecms_base/modules/custom/ecms_workflow/ecms_workflow.post_update.php
@@ -29,7 +29,7 @@ function ecms_workflow_post_update_revoke_emergency_notification_permissions(): 
 }
 
 /**
- * Revoke permissions from non-drupal_admin roles.
+ * Unpublish/archive all emergency_notifications.
  */
 function ecms_workflow_post_update_unpublish_all_emergency_notifications(array &$sandbox): void {
   // @see RIGA-588.

--- a/ecms_base/modules/custom/ecms_workflow/ecms_workflow.post_update.php
+++ b/ecms_base/modules/custom/ecms_workflow/ecms_workflow.post_update.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @file
+ * ecms_workflow.post_update.php
+ */
+
+declare(strict_types=1);
+
+use Drupal\ecms_workflow\EcmsWorkflowBundleCreate;
+
+/**
+ * Revoke permissions from non-drupal_admin roles.
+ */
+function ecms_workflow_post_update_revoke_emergency_notification_permissions(): void {
+  // @see RIGA-588.
+  // Revoke permissions from non-drupal_admin roles.
+  \Drupal::service('ecms_workflow.bundle_create')
+    ->revokeRolePermissions(
+      EcmsWorkflowBundleCreate::CONTENT_PUBLISHER_ROLE,
+      'emergency_notification'
+    );
+
+  \Drupal::service('ecms_workflow.bundle_create')
+    ->revokeRolePermissions(
+      EcmsWorkflowBundleCreate::CONTENT_AUTHOR_ROLE,
+      'emergency_notification'
+    );
+}
+
+/**
+ * Revoke permissions from non-drupal_admin roles.
+ */
+function ecms_workflow_post_update_unpublish_all_emergency_notifications(array &$sandbox): void {
+  // @see RIGA-588.
+  $storage = \Drupal::entityTypeManager()
+    ->getStorage('node');
+
+  if (!isset($sandbox['nodes'])) {
+    $sandbox['nodes'] = $storage
+      ->getQuery()
+      ->condition('type', 'emergency_notification')
+      ->condition('status', 1)
+      ->accessCheck(FALSE)
+      ->execute();
+
+    $sandbox['progress'] = 0;
+    $sandbox['max'] = count($sandbox['nodes']);
+  }
+
+  while ($nid = array_shift($sandbox['nodes'])) {
+    $node = $storage->load($nid);
+    $node->setPublished(FALSE);
+    $node->moderation_state = 'archived';
+    try {
+      $node->save();
+    }
+    catch (\Exception $e) {
+      // Trap any errors.
+    }
+
+    $sandbox['progress']++;
+  }
+
+  $sandbox['#finished'] = empty($sandbox['max']) ? 1 : $sandbox['progress'] / $sandbox['max'];
+}

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -10,6 +10,8 @@ use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\user\RoleInterface;
+use Drupal\user\RoleStorage;
 
 /**
  * Add node bundles to the editorial workflow.
@@ -420,6 +422,53 @@ class EcmsWorkflowBundleCreate {
       catch (EntityStorageException $e) {
         // Trap any errors.
       }
+    }
+  }
+
+  /**
+   * Revoke content permissions from a role.
+   *
+   * @param string $role
+   *   The role to revoke permissions from.
+   * @param string $contentType
+   *   The content type to revoke permissions from.
+   */
+  public function revokeRolePermissions(string $role, string $contentType): void {
+    /** @var \Drupal\user\RoleStorage $storage */
+    $storage = $this->entityTypeManager->getStorage('user_role');
+
+    /** @var \Drupal\user\RoleInterfaceRoleInterface $role */
+    $role = $storage->load($role);
+
+    if (empty($role)) {
+      return;
+    }
+
+    if ($role->hasPermission("create {$contentType} content")) {
+      $role->revokePermission("create {$contentType} content");
+    }
+
+    if ($role->hasPermission("edit any {$contentType} content")) {
+      $role->revokePermission("edit any {$contentType} content");
+    }
+
+    if ($role->hasPermission("delete any {$contentType} content")) {
+      $role->revokePermission("delete any {$contentType} content");
+    }
+
+    if ($role->hasPermission("add scheduled transitions node {$contentType}")) {
+      $role->revokePermission("add scheduled transitions node {$contentType}");
+    }
+
+    if ($role->hasPermission("reschedule scheduled transitions node {$contentType}")) {
+      $role->revokePermission("reschedule scheduled transitions node {$contentType}");
+    }
+
+    try {
+      $role->save();
+    }
+    catch (EntityStorageException $e) {
+      return;
     }
   }
 

--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -10,8 +10,6 @@ use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\user\RoleInterface;
-use Drupal\user\RoleStorage;
 
 /**
  * Add node bundles to the editorial workflow.


### PR DESCRIPTION
## Summary / Approach
This 
1. adds a new method to revoke workflow permissions from roles
2. Revokes emergency notifications from non-drupal_admin roles.
3. Adds post update to remove role permissions from existing sites
4. Adds post update to unpublish all notifications.

## Testing Instruction(s)
- Confirm only `drupal_admin` has permission to create/edit emergency notification content types.
- Confirm all `emergency_notification` content types are archived/unpublished.

## Metadata
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |yes
| Documentation reflects changes? |no
| `CHANGELOG` reflects changes? |yes
| Unit/Functional tests cover changes? |no
| Did you perform browser testing? |yes
| Did you provide detail in the summary on how and where to test this branch? |yes
| Risk level |medium
| Relevant links | [RIGA-588](https://thinkoomph.jira.com/browse/RIGA-588)
