### PR TITLE
Revoked missing permissions

### DIFF
--- a/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
+++ b/ecms_base/modules/custom/ecms_workflow/src/EcmsWorkflowBundleCreate.php
@@ -450,6 +450,10 @@ class EcmsWorkflowBundleCreate {
       $role->revokePermission("edit any {$contentType} content");
     }
 
+    if ($role->hasPermission("edit own {$contentType} content")) {
+      $role->revokePermission("edit own {$contentType} content");
+    }
+
     if ($role->hasPermission("delete any {$contentType} content")) {
       $role->revokePermission("delete any {$contentType} content");
     }


### PR DESCRIPTION
## Summary / Approach
Extends #558  and revokes the missing `edit own {type} content`.