### PR TITLE
Riga 602/uninstall tour module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Deprecated
 
 ### Removed
+- RIGA-602: Uninstall drupal/tour from base install.
 
 ### Fixed
 

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -91,7 +91,6 @@ dependencies:
   - syslog
   - taxonomy
   - toolbar
-  - tour
   - twig_tweak
   - views
   - webform

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -2342,3 +2342,20 @@ function ecms_base_update_10210(): void {
   $newBlock->setRegion('emergency_notification');
   $newBlock->save();
 }
+
+/**
+ * Unistall the drupal/tour module.
+ *
+ * Updates to run for the 1.1.3 tag.
+ */
+function ecms_base_update_10211(array &$sandbox): void {
+ 
+  // Disable existing modules.
+  $modules_to_uninstall = [
+    'tour',
+  ];
+
+  // Make sure necessary module is uninstalled.
+  \Drupal::service('module_installer')->uninstall($modules_to_uninstall);
+
+}

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -2349,7 +2349,6 @@ function ecms_base_update_10210(): void {
  * Updates to run for the 1.1.3 tag.
  */
 function ecms_base_update_10211(array &$sandbox): void {
- 
   // Disable existing modules.
   $modules_to_uninstall = [
     'tour',


### PR DESCRIPTION
 Uninstall drupal/tour from base install.
 
[ RIGA-602](https://thinkoomph.jira.com/browse/RIGA-602)