### PR TITLE
Riga 601/mysql upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ## [Unreleased]
 ### Added
+- RIGA-601: Added the `drupal/mysql57` module as a requirement.
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -159,6 +159,7 @@
         "drupal/migration_tools": "^2.8",
         "drupal/moderated_content_bulk_publish": "^2.0",
         "drupal/moderation_dashboard": "^2.0",
+        "drupal/mysql57": "^1.0",
         "drupal/office_hours": "^1.3",
         "drupal/openid_connect": "^3.0",
         "drupal/openid_connect_windows_aad": "^2.0@beta",

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -126,6 +126,7 @@ install:
   - media_entity_file_replace
   - media_file_delete
   - media_revisions_ui
+  - mysql57
   - update
 
 # Theme dependencies for the distribution.

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -2342,3 +2342,16 @@ function ecms_base_update_10210(): void {
   $newBlock->setRegion('emergency_notification');
   $newBlock->save();
 }
+
+/**
+ * Install new modules after updating contrib modules.
+ *
+ * Runs as part of 1.1.3 tag.
+ */
+function ecms_base_update_10211(array &$sandbox): void {
+
+  $modules_to_install = [
+    'mysql57',
+  ];
+  \Drupal::service('module_installer')->install($modules_to_install);
+}


### PR DESCRIPTION
## Summary / Approach
Adds the `drupal/mysql57` contributed module and installs it for all sites through an update hook.

## Testing Instruction(s)
Confirm the module is enabled and the site is functioning normally.

## Screenshots
n/a

## Metadata
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |yes
| Documentation reflects changes? |no
| `CHANGELOG` reflects changes? |yes
| Unit/Functional tests cover changes? |n/a
| Did you perform browser testing? |yes
| Did you provide detail in the summary on how and where to test this branch? |yes
| Risk level |low
| Relevant links | [RIGA-601](https://thinkoomph.jira.com/browse/RIGA-601)
