### PR TITLE
Commenting out the roles as it breaks the installation

### DIFF
--- a/ecms_base/recipes/ecms_api_press_release_publisher/recipe.yml
+++ b/ecms_base/recipes/ecms_api_press_release_publisher/recipe.yml
@@ -6,11 +6,11 @@ recipes:
 install:
   - ecms_api_press_release_publisher
 
-config:
-  # This will work after upgrade to ^10.4.
-  #  strict: false
-  import:
-    ecms_api_publisher:
-      - user.role.ecms_api_publisher
-    ecms_api_recipient:
-      - user.role.ecms_api_recipient
+#config:
+#  # This will work after upgrade to ^10.4.
+#  #  strict: false
+#  import:
+#    ecms_api_publisher:
+#      - user.role.ecms_api_publisher
+#    ecms_api_recipient:
+#      - user.role.ecms_api_recipient


### PR DESCRIPTION
Fixes the automated script to remove the role import until Core is upgraded to 10.4.

[RIGA-512](https://thinkoomph.jira.com/browse/RIGA-614)