### PR TITLE
RIGA-627/press release content type update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Added
 
 ### Changed
+- RIGA-627: Press release content type field updates.
 
 ### Deprecated
 

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_agency.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.field.node.press_release.field_agency.yml
@@ -11,7 +11,7 @@ field_name: field_agency
 entity_type: node
 bundle: press_release
 label: Agency
-description: 'Agency category for press release syndication to display on <a href="http://ri.gov/" target="_blank">RIGOV</a>.'
+description: 'This field is used for the filter criteria on Ri.gov.'
 required: true
 translatable: false
 default_value: {  }

--- a/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_agency.yml
+++ b/ecms_base/features/custom/ecms_press_release/config/install/field.storage.node.field_agency.yml
@@ -44,6 +44,9 @@ settings:
       value: department_of_corrections
       label: 'Department of Corrections'
     -
+      value: department_of_housing
+      label: 'Department of Housing'
+    -
       value: department_of_human_services
       label: 'Department of Human Services'
     -
@@ -148,6 +151,9 @@ settings:
     -
       value: water_resources_board
       label: 'Water Resources Board'
+    -
+      value: other
+      label: 'Other'
   allowed_values_function: ''
 module: options
 locked: false


### PR DESCRIPTION
## Summary / Approach

- Add Dept of Housing and Other to the Press Release Agency Field.

- Add Help Text under agency field.  -- This field is used for the filter criteria on Ri.gov.


## Metadata
| Question | Answer |
|----------|--------|
| Did you apply meaningful labels to the pull request? |yes
| Documentation reflects changes? |no
| `CHANGELOG` reflects changes? |yes
| Unit/Functional tests cover changes? |no
| Did you perform browser testing? |yes
| Did you provide detail in the summary on how and where to test this branch? |no
| Risk level |low
| Relevant links | [RIGA-627](https://thinkoomph.jira.com/browse/RIGA-627)
