### PR TITLE
Updated the Microsoft API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Removed
 
 ### Fixed
+- RIGA-647: Changed endpoint for Microsoft API.
 
 ### Security
 

--- a/ecms_base/config/install/openid_connect.client.windows_aad.yml
+++ b/ecms_base/config/install/openid_connect.client.windows_aad.yml
@@ -17,7 +17,7 @@ settings:
     method: 0
     mappings: ''
     strict: false
-  userinfo_graph_api_wa: 1
+  userinfo_graph_api_wa: 2
   userinfo_graph_api_use_other_mails: false
   userinfo_update_email: true
   hide_email_address_warning: true


### PR DESCRIPTION
## Summary / Approach
The Azure API Endpoint v1.6 was deprecated, causing the logins to break. This config is overridden on the systems, but I wanted to change it here to ensure it is captured and codified.

See: https://www.drupal.org/project/openid_connect_windows_aad/issues/3518500#comment-16064261

I left the update hook off as it is not required in this instance because of the configuration override.

[RIGA-647](https://thinkoomph.jira.com/browse/RIGA-647)