### PR TITLE
 RIGA-649/remove advagg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 ### Deprecated
 
 ### Removed
+- RIGA-649: Remove drupal/advagg
 
 ### Fixed
 - RIGA-597: Fixed SOLR field type that was causing log errors.

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,6 @@
         "drupal/address": "^1.8",
         "drupal/address_phonenumber": "^10.0",
         "drupal/admin_toolbar": "^3.4",
-        "drupal/advagg": "^6.0@alpha",
         "drupal/aggregator": "^2.2",
         "drupal/allowed_formats": "^3.0.0",
         "drupal/asset_injector": "^2.7",


### PR DESCRIPTION
Remove module "drupal/advagg"
[RIGA-649](https://thinkoomph.jira.com/browse/RIGA-649)