### PR TITLE
Added patch for webform_encrypt Drupal 11 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,11 @@
             },
             "drupal/path_redirect_import": {
                 "3395257 - #3 - Change CSV file upload location to private.": "https://www.drupal.org/files/issues/2023-10-19/3395257-change-csv-file-3_0.patch"
+            },
+            "drupal/webform_encrypt": {
+                "3462998 - #3 - Drupal 11 compatibility.": "https://www.drupal.org/files/issues/2025-05-30/3462998-6-2.0.x-webform_encrypt.patch"
             }
+
         },
         "preserve-paths": [],
         "drupal-scaffold": [],


### PR DESCRIPTION
## Summary / Approach
Added patches for getting webform_encrypt to be Drupal 11 compatible.
[RIGA-672](https://thinkoomph.jira.com/browse/RIGA-672)