### PR TITLE
Updated the features module for Drupal 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,9 @@
                 "2827921 - Exception thrown by responsive srcset images when the image is not yet in the file system (such as with Stage File Proxy)": "https://www.drupal.org/files/issues/2827921-remove-missing-responsive-image-width-exception.patch",
                 "2741187 - 39 - Allow usage of WYSIWYG in views text area fields": "https://gist.githubusercontent.com/pfrilling/91262eb9ca72ec66704027344ebc0e56/raw/cba7ef0284684d1db59c193e5a06968a36b73a02/gistfile1.txt"
             },
+            "drupal/features": {
+                "3447460 - D11 Upgrades": "https://gist.githubusercontent.com/pfrilling/e27933a1a4b8577d3d69d0d4f0bec6a2/raw/0c5df9bd798a0298a6a1c2675ec34881c290aff2/gistfile1.txt"
+            },
             "drupal/iek": {
                 "3430975 - #7 Drupal 11 upgrade": "https://www.drupal.org/files/issues/2025-04-10/iek.1.x-dev.rector.patch",
                 "3430975 - #9 Drupal 11 upgrade": "https://www.drupal.org/files/issues/2025-04-10/interdiff-last-bot.6938818.txt"
@@ -133,7 +136,7 @@
         "drupal/entity_usage": "^2.0@beta",
         "drupal/extlink": "^2.0",
         "drupal/facets": "^2.0",
-        "drupal/features": "^3.11",
+        "drupal/features": "3.x-dev",
         "drupal/feeds": "^3.0@RC",
         "drupal/feeds_ex": "^1.0@beta",
         "drupal/field_group": "^3.4",


### PR DESCRIPTION
## Summary / Approach
This pull request updates the `composer.json` file to include a new patch reference for Drupal features and modifies the version constraint for the `drupal/features` package. These changes are part of ongoing work to support Drupal 11 upgrades.

### Updates related to Drupal features:

* Added a new patch reference for Drupal 11 upgrades under `drupal/features`. This patch supports compatibility improvements for the upcoming Drupal version. (`[composer.jsonR54-R56](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R54-R56)`)
* Changed the version constraint for the `drupal/features` package from `^3.11` to `3.x-dev` to allow for development versions that may include necessary updates for Drupal 11 compatibility. (`[composer.jsonL136-R139](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L136-R139)`)

[RIGA-685](https://thinkoomph.jira.com/browse/RIGA-685)