### PR TITLE
Uninstall layout_builder_expose_all_field_blocks module

### DIFF
--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -2435,6 +2435,7 @@ function ecms_base_update_10214(array &$sandbox): void {
 
   $modules_to_uninstall = [
     'media_revisions_ui',
+    'layout_builder_expose_all_field_blocks',
   ];
 
   // Uninstall the unnecessary modules.


### PR DESCRIPTION
## Summary / Approach
Uninstall the deprecated `layout_builder_expose_all_field_blocks` module
[RIGA-692](https://thinkoomph.jira.com/browse/RIGA-692)