### PR TITLE
RIGA-676/remove media_revisions_ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ modified Semantic Versioning scheme. See the "Versioning scheme" section of the
 
 ### Removed
 - RIGA-649: Remove drupal/advagg
+- RIGA-245: Remove drupal/media_revisions_ui
 
 ### Fixed
 - RIGA-703: Fixed phpcodesniffer build error

--- a/composer.json
+++ b/composer.json
@@ -160,7 +160,6 @@
         "drupal/media_library_form_element": "^2.0.4",
         "drupal/media_library_theme_reset": "^2.0.0-beta1",
         "drupal/media_pdf_thumbnail": "^6.1@RC",
-        "drupal/media_revisions_ui": "^2.1",
         "drupal/memcache": "^2.2",
         "drupal/menu_admin_per_menu": "^1.5",
         "drupal/menu_block": "^1.10",


### PR DESCRIPTION
 RIGA-676: Remove drupal/media_revisions_ui
[RIGA-676](https://thinkoomph.jira.com/browse/RIGA-676)