### PR TITLE
Add the book contrib module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,6 +105,7 @@
         "drupal/autologout": "^2.0.0",
         "drupal/better_exposed_filters": "^7.0.5",
         "drupal/bigmenu": "^2.0@RC",
+        "drupal/book": "^1.0.0",
         "drupal/captcha": "^2.0",
         "drupal/classy": "^2.0",
         "drupal/commerce": "^3.0.2",


### PR DESCRIPTION
Adds the book contributed module for Drupal 11 prep.

[RIGA-728](https://thinkoomph.jira.com/browse/RIGA-728)