### PR TITLE
Riga 833/memcache fix

### DIFF
--- a/.ddev/addon-metadata/memcached/manifest.yaml
+++ b/.ddev/addon-metadata/memcached/manifest.yaml
@@ -1,0 +1,8 @@
+name: memcached
+repository: ddev/ddev-memcached
+version: v1.1.8
+install_date: "2026-03-31T16:31:54-04:00"
+project_files:
+    - docker-compose.memcached.yaml
+global_files: []
+removal_actions: []

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -28,26 +28,28 @@ corepack_enable: true
 # If the name is omitted, the project will take the name of the enclosing directory,
 # which is useful if you want to have a copy of the project side by side with this one.
 
-# type: <projecttype>  # backdrop, cakephp, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress
-# See https://ddev.readthedocs.io/en/stable/users/quickstart/ for more
+# type: <projecttype>  # backdrop, cakephp, codeigniter, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, drupal12, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress
+# See https://docs.ddev.com/en/stable/users/quickstart/ for more
 # information on the different project types
 
 # docroot: <relative_path> # Relative path to the directory containing index.php.
 
-# php_version: "8.3"  # PHP version to use, "5.6" through "8.4"
+# php_version: "8.4"  # PHP version to use, "5.6" through "8.5"
 
 # You can explicitly specify the webimage but this
 # is not recommended, as the images are often closely tied to DDEV's' behavior,
 # so this can break upgrades.
 
-# webimage: <docker_image>  # nginx/php docker image.
+# webimage: <docker_image>
+# It’s unusual to change this option, and we don’t recommend it without Docker experience and a good reason.
+# Typically, this means additions to the existing web image using a .ddev/web-build/Dockerfile.*
 
 # database:
 #   type: <dbtype> # mysql, mariadb, postgres
 #   version: <version> # database version, like "10.11" or "8.0"
 #   MariaDB versions can be 5.5-10.8, 10.11, 11.4, 11.8
 #   MySQL versions can be 5.5-8.0, 8.4
-#   PostgreSQL versions can be 9-17
+#   PostgreSQL versions can be 9-18
 
 # router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)
 # router_https_port: <port> # Port for https (defaults to global configuration, usually 443)
@@ -57,27 +59,18 @@ corepack_enable: true
 # "ddev xdebug" to enable Xdebug and "ddev xdebug off" to disable it work better,
 # as leaving Xdebug enabled all the time is a big performance hit.
 
-# xhgui_https_port: 8142
-# Can be used to change the router https port for xhgui application
+# xhgui_http_port: "8143"
+# xhgui_https_port: "8142"
+# The XHGui ports can be changed from the default 8143 and 8142
 # Very rarely used
 
-# xhgui_http_port: 8143
-# Can be used to change the router http port for xhgui application
-# Very rarely used
-
-# host_xhgui_port: 8142
-# Can be used to change the host binding port of the xhgui
+# host_xhgui_port: "8142"
+# Can be used to change the host binding port of the XHGui
 # application. Rarely used; only when port conflict and
 # bind_all_ports is used (normally with router disabled)
 
-# xhprof_enabled: false  # Set to true to enable Xhprof and "ddev start" or "ddev restart"
-# Note that for most people the commands
-# "ddev xhprof" to enable Xhprof and "ddev xhprof off" to disable it work better,
-# as leaving Xhprof enabled all the time is a big performance hit.
-
 # xhprof_mode: [prepend|xhgui|global]
-# Set to "xhgui" to enable XHGui features
-# "xhgui" will become default in a future major release
+# Default is "xhgui"
 
 # webserver_type: nginx-fpm, apache-fpm, generic
 
@@ -95,7 +88,7 @@ corepack_enable: true
 # commands are executed.
 
 # composer_version: "2"
-# You can set it to "" or "2" (default) for Composer v2 or "1" for Composer v1
+# You can set it to "" or "2" (default) for Composer v2
 # to use the latest major version available at the time your container is built.
 # It is also possible to use each other Composer version channel. This includes:
 #   - 2.2 (latest Composer LTS version)
@@ -103,14 +96,12 @@ corepack_enable: true
 #   - preview
 #   - snapshot
 # Alternatively, an explicit Composer version may be specified, for example "2.2.18".
-# To reinstall Composer after the image was built, run "ddev debug rebuild".
+# To reinstall Composer after the image was built, run "ddev utility rebuild".
 
-# nodejs_version: "22"
+# nodejs_version: "24"
 # change from the default system Node.js version to any other version.
-# See https://ddev.readthedocs.io/en/stable/users/configuration/config/#nodejs_version for more information
-# and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation,
-# Note that using of 'ddev nvm' is discouraged because "nodejs_version" is much easier to use,
-# can specify any version, and is more robust than using 'nvm'.
+# See https://docs.ddev.com/en/stable/users/configuration/config/#nodejs_version for more information
+# and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation.
 
 # corepack_enable: false
 # Change to 'true' to 'corepack enable' and gain access to latest versions of yarn/pnpm
@@ -143,7 +134,7 @@ corepack_enable: true
 
 # ddev_version_constraint: ""
 # Example:
-# ddev_version_constraint: ">= 1.22.4"
+# ddev_version_constraint: ">= 1.24.8"
 # This will enforce that the running ddev version is within this constraint.
 # See https://github.com/Masterminds/semver#checking-version-constraints for
 # supported constraint formats
@@ -170,10 +161,8 @@ corepack_enable: true
 #   - "global":  uses the value from the global config.
 #   - "none":    disables performance optimization for this project.
 #   - "mutagen": enables Mutagen for this project.
-#   - "nfs":     enables NFS for this project.
 #
-# See https://ddev.readthedocs.io/en/stable/users/install/performance/#nfs
-# See https://ddev.readthedocs.io/en/stable/users/install/performance/#mutagen
+# See https://docs.ddev.com/en/stable/users/install/performance/#mutagen
 
 # fail_on_hook_fail: False
 # Decide whether 'ddev start' should be interrupted by a failing hook
@@ -202,10 +191,10 @@ corepack_enable: true
 # The mailpit port is not normally bound on the host at all, instead being routed
 # through ddev-router, but it can be bound directly to localhost if specified here.
 
-# webimage_extra_packages: [php7.4-tidy, php-bcmath]
+# webimage_extra_packages: ['php${DDEV_PHP_VERSION}-tidy', 'php${DDEV_PHP_VERSION}-yac']
 # Extra Debian packages that are needed in the webimage can be added here
 
-# dbimage_extra_packages: [telnet,netcat]
+# dbimage_extra_packages: [netcat, telnet, sudo]
 # Extra Debian packages that are needed in the dbimage can be added here
 
 # use_dns_when_possible: true
@@ -217,12 +206,15 @@ corepack_enable: true
 # project_tld: ddev.site
 # The top-level domain used for project URLs
 # The default "ddev.site" allows DNS lookup via a wildcard
-# If you prefer you can change this to "ddev.local" to preserve
-# pre-v1.9 behavior.
 
-# ngrok_args: --basic-auth username:pass1234
-# Provide extra flags to the "ngrok http" command, see
-# https://ngrok.com/docs/agent/config/v3/#agent-configuration or run "ngrok http -h"
+# share_default_provider: ngrok
+# The default share provider to use for "ddev share"
+# Defaults to global configuration, usually "ngrok"
+# Can be "ngrok" or "cloudflared" or the name of a custom provider from .ddev/share-providers/
+
+# share_provider_args: --basic-auth username:pass1234
+# Provide extra flags to the share provider script
+# See https://docs.ddev.com/en/stable/users/configuration/config/#share_provider_args
 
 # disable_settings_management: false
 # If true, DDEV will not create CMS-specific settings files like
@@ -300,7 +292,7 @@ corepack_enable: true
 # Many DDEV commands can be extended to run tasks before or after the
 # DDEV command is executed, for example "post-start", "post-import-db",
 # "pre-composer", "post-composer"
-# See https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/ for more
+# See https://docs.ddev.com/en/stable/users/extend/custom-commands/ for more
 # information on the commands that can be extended and the tasks you can define
 # for them. Example:
 #hooks:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -169,6 +169,10 @@ jobs:
         working-directory: ${{ env.DRUPAL_DIRECTORY }}
         run: ../vendor/bin/phpunit --configuration=/var/www/phpunit-ci.xml --testsuite=unit --no-coverage
 
+      - name: Run kernel tests.
+        working-directory: ${{ env.DRUPAL_DIRECTORY }}
+        run: ../vendor/bin/phpunit --configuration=/var/www/phpunit-ci.xml --testsuite=kernel --no-coverage
+
       - name: Copy default settings file
         run: cp /var/www/html/sites/default/default.settings.php /var/www/html/sites/default/settings.php
 

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -109,7 +109,7 @@ jobs:
       image: drupalci/php-${{ matrix.php_version }}-ubuntu-apache:production
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8
         ports:
           - 33306:3306
         env:

--- a/ecms_base/modules/custom/ecms_distribution/ecms_distribution.services.yml
+++ b/ecms_base/modules/custom/ecms_distribution/ecms_distribution.services.yml
@@ -1,0 +1,25 @@
+services:
+  # ViewsData lives in cache.default, which routes to the shared
+  # memcache pool on ACSF. Each site stores an independent copy (per-site key
+  # prefix), creating pool pressure proportional to site count. When the pool
+  # is near capacity (observed at ~86% in production), LRU eviction causes
+  # cache misses and concurrent rebuilds across load-balanced servers. Because
+  # the Drupal memcache module splits entries larger than item_size_max into
+  # multiple chunks, a concurrent read can retrieve a partially-written entry
+  # and deserialize a handler definition with entity_type: '', causing
+  # PluginNotFoundException and Varnish cache poisoning platform-wide.
+  #
+  # Give ViewsData its own cache bin backed directly by the database.
+  # The database write is atomic — no chunk-splitting, no race window.
+  # cache.default (and cache.discovery) remain in memcache for everything else.
+  cache.views_data:
+    class: Drupal\Core\Cache\DatabaseBackend
+    arguments:
+      - '@database'
+      - '@cache_tags.invalidator.checksum'
+      - 'views_data'
+      - '@serialization.phpserialize'
+      - '@datetime.time'
+    tags:
+      - { name: cache.bin }
+

--- a/ecms_base/modules/custom/ecms_distribution/ecms_distribution.services.yml
+++ b/ecms_base/modules/custom/ecms_distribution/ecms_distribution.services.yml
@@ -2,12 +2,12 @@ services:
   # ViewsData lives in cache.default, which routes to the shared
   # memcache pool on ACSF. Each site stores an independent copy (per-site key
   # prefix), creating pool pressure proportional to site count. When the pool
-  # is near capacity (observed at ~86% in production), LRU eviction causes
-  # cache misses and concurrent rebuilds across load-balanced servers. Because
-  # the Drupal memcache module splits entries larger than item_size_max into
-  # multiple chunks, a concurrent read can retrieve a partially-written entry
-  # and deserialize a handler definition with entity_type: '', causing
-  # PluginNotFoundException and Varnish cache poisoning platform-wide.
+  # is near capacity, LRU eviction causes cache misses and concurrent rebuilds
+  # across load-balanced servers. Because the Drupal memcache module splits
+  # entries larger than item_size_max into multiple chunks, a concurrent read
+  # can retrieve a partially-written entry and deserialize a handler definition
+  # with entity_type: '', causing PluginNotFoundException and
+  # Varnish cache poisoning platform-wide.
   #
   # Give ViewsData its own cache bin backed directly by the database.
   # The database write is atomic — no chunk-splitting, no race window.

--- a/ecms_base/modules/custom/ecms_distribution/src/EcmsDistributionServiceProvider.php
+++ b/ecms_base/modules/custom/ecms_distribution/src/EcmsDistributionServiceProvider.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * Overrides views.views_data to use a database-backed cache bin.
  *
- * services.yml definitions are merged in module load order, so an override
+ * The services.yml definitions are merged in module load order, so an override
  * in ecms_distribution.services.yml can be silently overwritten by
  * views.services.yml if views loads later. ServiceProvider::alter() runs
  * after all *.services.yml files are merged, guaranteeing the override sticks.

--- a/ecms_base/modules/custom/ecms_distribution/src/EcmsDistributionServiceProvider.php
+++ b/ecms_base/modules/custom/ecms_distribution/src/EcmsDistributionServiceProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ecms_distribution;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceModifierInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Overrides views.views_data to use a database-backed cache bin.
+ *
+ * services.yml definitions are merged in module load order, so an override
+ * in ecms_distribution.services.yml can be silently overwritten by
+ * views.services.yml if views loads later. ServiceProvider::alter() runs
+ * after all *.services.yml files are merged, guaranteeing the override sticks.
+ *
+ * @see ecms_distribution.services.yml
+ */
+class EcmsDistributionServiceProvider implements ServiceModifierInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container): void {
+    if ($container->hasDefinition('views.views_data')) {
+      $container->getDefinition('views.views_data')
+        ->setArgument(0, new Reference('cache.views_data'));
+    }
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_distribution/tests/src/Kernel/ViewsDataCacheOverrideNoViewsTest.php
+++ b/ecms_base/modules/custom/ecms_distribution/tests/src/Kernel/ViewsDataCacheOverrideNoViewsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ecms_distribution\Kernel;
+
+use Drupal\ecms_distribution\EcmsDistributionServiceProvider;
+use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Verifies EcmsDistributionServiceProvider::alter() is safe without views.
+ *
+ * Uses a container compiled without the views module to confirm that alter()
+ * does not throw when views.views_data is not registered — guarding against
+ * a fatal error if ecms_distribution is ever enabled without views.
+ *
+ * Kept in a separate class from ViewsDataCacheOverrideTest because $modules
+ * is static: the views module must be absent from the compiled container for
+ * this test to be meaningful.
+ *
+ * @see \Drupal\ecms_distribution\EcmsDistributionServiceProvider
+ */
+#[Group('ecms_distribution')]
+#[CoversClass(EcmsDistributionServiceProvider::class)]
+class ViewsDataCacheOverrideNoViewsTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'ecms_distribution',
+  ];
+
+  /**
+   * alter() does not throw when views.views_data is absent from the container.
+   *
+   * Tests against the real compiled kernel container (not a hand-built stub)
+   * to confirm the hasDefinition() guard in alter() works under actual
+   * bootstrap conditions.
+   */
+  public function testAlterIsNoopWhenViewsNotPresent(): void {
+    $this->assertFalse(
+      $this->container->hasDefinition('views.views_data'),
+      'Precondition: views.views_data must not be registered. If this fails, ' .
+      'the views module was loaded and the test is not exercising the no-op path.'
+    );
+
+    $provider = new EcmsDistributionServiceProvider();
+
+    // Must not throw when views.views_data is absent.
+    $provider->alter($this->container);
+
+    // Container is unchanged.
+    $this->assertFalse($this->container->hasDefinition('views.views_data'));
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_distribution/tests/src/Kernel/ViewsDataCacheOverrideTest.php
+++ b/ecms_base/modules/custom/ecms_distribution/tests/src/Kernel/ViewsDataCacheOverrideTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\ecms_distribution\Kernel;
 
 use Drupal\Core\Cache\DatabaseBackend;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\ecms_distribution\EcmsDistributionServiceProvider;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\views\ViewsData;

--- a/ecms_base/modules/custom/ecms_distribution/tests/src/Kernel/ViewsDataCacheOverrideTest.php
+++ b/ecms_base/modules/custom/ecms_distribution/tests/src/Kernel/ViewsDataCacheOverrideTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ecms_distribution\Kernel;
+
+use Drupal\Core\Cache\DatabaseBackend;
+use Drupal\ecms_distribution\EcmsDistributionServiceProvider;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\views\ViewsData;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Verifies that views.views_data uses a database-backed cache bin.
+ *
+ * The fix has two parts:
+ *   1. ecms_distribution.services.yml defines cache.views_data as a
+ *      DatabaseBackend, giving ViewsData its own atomic cache bin.
+ *   2. EcmsDistributionServiceProvider::alter() rewires views.views_data to
+ *      inject @cache.views_data instead of @cache.default. The ServiceProvider
+ *      runs after all *.services.yml files are merged, so the override cannot
+ *      be silently overwritten by views.services.yml loading after us.
+ *
+ * @see \Drupal\ecms_distribution\EcmsDistributionServiceProvider
+ * @see https://thinkoomph.jira.com/browse/ONSA-833
+ * @see ecms_distribution.services.yml
+ */
+#[Group('ecms_distribution')]
+#[CoversClass(EcmsDistributionServiceProvider::class)]
+class ViewsDataCacheOverrideTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'views',
+    'ecms_distribution',
+  ];
+
+  /**
+   * The service provider rewires views.views_data to use @cache.views_data.
+   *
+   * This tests the alter() method directly: builds a minimal ContainerBuilder
+   * that mimics the pre-alter state (views.views_data using @cache.default),
+   * runs the provider, and asserts the first argument was replaced.
+   *
+   * This is the authoritative test for the service provider class. The kernel
+   * tests below validate the compiled result, but this test isolates the
+   * provider's own logic independently of the full container compile.
+   */
+  public function testAlterRewiresViewsDataToViewsDataCacheBin(): void {
+    $container = new ContainerBuilder();
+
+    // Register a stand-in for views.views_data using @cache.default, matching
+    // the pre-alter state from views.services.yml.
+    $container->register('views.views_data', ViewsData::class)
+      ->addArgument(new Reference('cache.default'));
+
+    $provider = new EcmsDistributionServiceProvider();
+    $provider->alter($container);
+
+    $arguments = $container->getDefinition('views.views_data')->getArguments();
+    $first_arg = reset($arguments);
+
+    $this->assertInstanceOf(Reference::class, $first_arg);
+    $this->assertSame(
+      'cache.views_data',
+      (string) $first_arg,
+      'alter() must replace the first argument of views.views_data with ' .
+      '@cache.views_data. If this fails, the service provider is not ' .
+      'overriding the cache backend and ViewsData will write to cache.default ' .
+      '(memcache), leaving the RIGA-833 race condition open.'
+    );
+  }
+
+  /**
+   * The cache.views_data bin resolves to a DatabaseBackend in the container.
+   *
+   * Validates the service definition in ecms_distribution.services.yml.
+   */
+  public function testViewsDataCacheBinIsDatabaseBackend(): void {
+    $cache = $this->container->get('cache.views_data');
+    $this->assertInstanceOf(
+      DatabaseBackend::class,
+      $cache,
+      'cache.views_data must be a DatabaseBackend. A memcache backend here ' .
+      'allows concurrent workers to race on multipart chunk writes, producing ' .
+      'partially-deserialized handler definitions with entity_type: "" (RIGA-833).'
+    );
+  }
+
+  /**
+   * The compiled container injects a DatabaseBackend into views.views_data.
+   *
+   * Validates that both the services.yml definition and the ServiceProvider
+   * alter() work together correctly end-to-end in the full compiled container.
+   */
+  public function testViewsDataServiceReceivesDatabaseCacheBackend(): void {
+    $views_data = $this->container->get('views.views_data');
+    $this->assertInstanceOf(ViewsData::class, $views_data);
+
+    $reflection = new \ReflectionProperty($views_data, 'cacheBackend');
+    $cache = $reflection->getValue($views_data);
+
+    $this->assertInstanceOf(
+      DatabaseBackend::class,
+      $cache,
+      'views.views_data must be injected with a DatabaseBackend. If this ' .
+      'fails, EcmsDistributionServiceProvider::alter() is not taking effect ' .
+      'and ViewsData is still writing to cache.default (memcache), leaving ' .
+      'the RIGA-833 multipart write-race condition open.'
+    );
+  }
+
+}

--- a/phpunit-ci.xml
+++ b/phpunit-ci.xml
@@ -36,6 +36,10 @@
             <directory>/var/www/html/profiles/contrib/ecms_profile/*/modules/custom/*/tests/src/Functional</directory>
             <directory>/var/www/html/profiles/contrib/ecms_profile/*/features/custom/*/tests/src/Functional</directory>
         </testsuite>
+      <testsuite name="kernel">
+        <directory>/var/www/html/profiles/contrib/ecms_profile/*/modules/custom/*/tests/src/Kernel</directory>
+        <directory>/var/www/html/profiles/contrib/ecms_profile//*/features/custom/*/tests/src/Kernel</directory>
+      </testsuite>
         <testsuite name="existing">
           <!-- Assumes tests are namespaced as \Drupal\Tests\custom_foo\ExistingSite. -->
           <directory>/var/www/html/profiles/contrib/ecms_profile/*/tests/src/ExistingSite</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -39,6 +39,10 @@
             <directory>./*/modules/custom/*/tests/src/Functional</directory>
             <directory>./*/features/custom/*/tests/src/Functional</directory>
         </testsuite>
+      <testsuite name="kernel">
+        <directory>./*/modules/custom/*/tests/src/Kernel</directory>
+        <directory>./*/features/custom/*/tests/src/Kernel</directory>
+      </testsuite>
         <testsuite name="existing">
           <!-- Assumes tests are namespaced as \Drupal\Tests\custom_foo\ExistingSite. -->
           <directory>./*/tests/src/ExistingSite</directory>

--- a/scripts/acsfd8+.memcache.settings.php
+++ b/scripts/acsfd8+.memcache.settings.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * @file
+ * Contains caching configuration.
+ */
+
+use Composer\Autoload\ClassLoader;
+
+/**
+ * Use memcache as cache backend.
+ *
+ * Autoload memcache classes and service container in case module is not
+ * installed. Avoids the need to patch core and allows for overriding the
+ * default backend when installing Drupal.
+ *
+ * @see https://www.drupal.org/node/2766509
+ *
+ * To avoid ACSF site install issues, added PHP_SAPI and site-install check.
+ *
+ * @see https://support.acquia.com/hc/en-us/articles/360047676154-Site-Factory-installations-fail-when-memcache-is-included
+ */
+
+if (
+  array_key_exists('memcache', $settings) &&
+  array_key_exists('servers', $settings['memcache']) &&
+  !empty($settings['memcache']['servers']) &&
+  !(PHP_SAPI === 'cli' && isset($_SERVER['argv']) &&
+    in_array('site-install', $_SERVER['argv']))
+) {
+
+  if (getenv('IS_DDEV_PROJECT') == 'true') {
+    // Enable memcache servers for ddev. This will be automatically
+    // set for the Acquia environments.
+    $settings['memcache']['servers'] = ['memcached:11211' => 'default'];
+  }
+
+  // Check for PHP Memcached libraries.
+  $memcache_exists = class_exists('Memcache', FALSE);
+  $memcached_exists = class_exists('Memcached', FALSE);
+  $memcache_services_yml = DRUPAL_ROOT . '/modules/contrib/memcache/memcache.services.yml';
+  $memcache_module_is_present = file_exists($memcache_services_yml);
+  if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
+    // Use Memcached extension if available.
+    if ($memcached_exists) {
+      $settings['memcache']['extension'] = 'Memcached';
+    }
+    if (class_exists(ClassLoader::class)) {
+      $class_loader = new ClassLoader();
+      $class_loader->addPsr4('Drupal\\memcache\\', DRUPAL_ROOT . '/modules/contrib/memcache/src');
+      $class_loader->register();
+      $settings['container_yamls'][] = $memcache_services_yml;
+
+      // Acquia Default Settings for the memcache module
+      // Default settings for the Memcache module.
+      // Enable compression for PHP 7.
+      $settings['memcache']['options'][Memcached::OPT_COMPRESSION] = TRUE;
+
+      // Set key_prefix to avoid drush cr flushing all bins on multisite.
+      $settings['memcache']['key_prefix'] = $conf['acquia_hosting_site_info']['db']['name'] . '_';
+
+      // Settings for SASL Authenticated Memcached.
+      $settings['memcache']['options'][Memcached::OPT_BINARY_PROTOCOL] = TRUE;
+
+      // Bootstrap cache.container with memcache rather than database.
+      $settings['bootstrap_container_definition'] = [
+        'parameters' => [],
+        'services' => [
+          'database' => [
+            'class' => 'Drupal\Core\Database\Connection',
+            'factory' => 'Drupal\Core\Database\Database::getConnection',
+            'arguments' => ['default'],
+          ],
+          'settings' => [
+            'class' => 'Drupal\Core\Site\Settings',
+            'factory' => 'Drupal\Core\Site\Settings::getInstance',
+          ],
+          'memcache.settings' => [
+            'class' => 'Drupal\memcache\MemcacheSettings',
+            'arguments' => ['@settings'],
+          ],
+          'memcache.factory' => [
+            'class' => 'Drupal\memcache\Driver\MemcacheDriverFactory',
+            'arguments' => ['@memcache.settings'],
+          ],
+          'memcache.timestamp.invalidator.bin' => [
+            'class' => 'Drupal\memcache\Invalidator\MemcacheTimestampInvalidator',
+            'arguments' => ['@memcache.factory', 'memcache_bin_timestamps', 0.001],
+          ],
+          'memcache.backend.cache.container' => [
+            'class' => 'Drupal\memcache\DrupalMemcacheInterface',
+            'factory' => ['@memcache.factory', 'get'],
+            'arguments' => ['container'],
+          ],
+          'cache_tags_provider.container' => [
+            'class' => 'Drupal\Core\Cache\DatabaseCacheTagsChecksum',
+            'arguments' => ['@database'],
+          ],
+          'cache.container' => [
+            'class' => 'Drupal\memcache\MemcacheBackend',
+            'arguments' => [
+              'container',
+              '@memcache.backend.cache.container',
+              '@cache_tags_provider.container',
+              '@memcache.timestamp.invalidator.bin',
+              '@memcache.settings',
+            ],
+          ],
+        ],
+      ];
+
+      // Use memcache for bootstrap, discovery, config instead of fast chained
+      // backend to properly invalidate caches on multiple webs.
+      // See https://www.drupal.org/node/2754947
+      $settings['cache']['bins']['bootstrap'] = 'cache.backend.memcache';
+      $settings['cache']['bins']['discovery'] = 'cache.backend.memcache';
+      $settings['cache']['bins']['config'] = 'cache.backend.memcache';
+
+      // Use memcache as the default bin.
+      $settings['cache']['default'] = 'cache.backend.memcache';
+    }
+  }
+}

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -110,6 +110,13 @@ if (file_exists(\$fast404Settings)) {
   require(\$fast404Settings);
 }" >> develop/web/sites/default/settings.php'
 
+## Install acsfd8+.memcache.settings.php
+ddev exec 'chmod +w develop/web/sites/default develop/web/sites/default/settings.php && cp scripts/acsfd8+.memcache.settings.php develop/web/sites/default/'
+ddev exec 'echo "\$memcacheSettings = sprintf(\"%s/%s/acsfd8+.memcache.settings.php\", \$app_root, \$site_path);
+if (file_exists(\$memcacheSettings)) {
+  require(\$memcacheSettings);
+}" >> develop/web/sites/default/settings.php'
+
 
 if [ "$PERFORMANCE_MODE" == "1" ]; then
   ddev stop


### PR DESCRIPTION
Moves views_data caching out of memcache and back into the database to lower cache sizes in memcache and to prevent PluginNotFound exceptions being thrown due to stale and/or improper caching.

[RIGA-833](https://thinkoomph.jira.com/browse/ONSA-833)