### PR TITLE
Riga 815/restrict oauth routes

### DIFF
--- a/ecms_base/modules/custom/ecms_api/ecms_api.services.yml
+++ b/ecms_base/modules/custom/ecms_api/ecms_api.services.yml
@@ -7,7 +7,7 @@ services:
 
   ecms_api_helper:
     class: Drupal\ecms_api\EcmsApiHelper
-    arguments: ['@entity_type.manager', '@stream_wrapper.public']
+    arguments: ['@entity_type.manager', '@stream_wrapper.public', '@request_stack']
 
   ecms_api.oauth_route_restriction_subscriber:
     class: Drupal\ecms_api\EventSubscriber\OAuthRouteRestrictionSubscriber

--- a/ecms_base/modules/custom/ecms_api/ecms_api.services.yml
+++ b/ecms_base/modules/custom/ecms_api/ecms_api.services.yml
@@ -8,3 +8,8 @@ services:
   ecms_api_helper:
     class: Drupal\ecms_api\EcmsApiHelper
     arguments: ['@entity_type.manager', '@stream_wrapper.public']
+
+  ecms_api.oauth_route_restriction_subscriber:
+    class: Drupal\ecms_api\EventSubscriber\OAuthRouteRestrictionSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/ecms_base/modules/custom/ecms_api/src/EcmsApiBase.php
+++ b/ecms_base/modules/custom/ecms_api/src/EcmsApiBase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\ecms_api;
 
+use Drupal\Component\Utility\Crypt;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Url;
@@ -32,6 +33,19 @@ abstract class EcmsApiBase {
    * The API endpoint prefix.
    */
   const API_ENDPOINT = 'EcmsApi';
+
+  /**
+   * Header identifying the requesting site's hostname.
+   */
+  const ORIGIN_HEADER = 'X-ECMS-Origin';
+
+  /**
+   * Header carrying the HMAC-signed environment identifier.
+   *
+   * Format: "{AH_SITE_ENVIRONMENT}:{Crypt::hmacBase64(ECMS_SHARED_SECRET, env)}"
+   * Falls back to "local" with no signature when running outside Acquia.
+   */
+  const ENV_HEADER = 'X-ECMS-Env';
 
   /**
    * Allowed HTTP methods to accept for submission to the API endpoints.
@@ -125,6 +139,34 @@ abstract class EcmsApiBase {
   }
 
   /**
+   * Build the ECMS authentication headers for outbound API requests.
+   *
+   * Sends the current site's hostname as X-ECMS-Origin (for logging/audit)
+   * and an HMAC-signed environment identifier as X-ECMS-Env. On local dev
+   * (no AH_SITE_ENVIRONMENT or ECMS_SHARED_SECRET), the env value falls back
+   * to "local" without a signature — satisfying the .htaccess presence check
+   * while the EventSubscriber skips validation entirely.
+   *
+   * @return array
+   *   Associative array of header name => value.
+   */
+  protected function getEcmsRequestHeaders(): array {
+    $env = (string) getenv('AH_SITE_ENVIRONMENT') ?: 'local';
+    $sharedSecret = (string) getenv('ECMS_SHARED_SECRET');
+
+    $envHeaderValue = $env;
+    if (!empty($sharedSecret)) {
+      $signature = Crypt::hmacBase64($env, $sharedSecret);
+      $envHeaderValue = "{$env}:{$signature}";
+    }
+
+    return [
+      self::ORIGIN_HEADER => \Drupal::requestStack()->getCurrentRequest()->getHost(),
+      self::ENV_HEADER => $envHeaderValue,
+    ];
+  }
+
+  /**
    * Get an access token to authorize the request.
    *
    * @param \Drupal\Core\Url $url
@@ -155,6 +197,7 @@ abstract class EcmsApiBase {
         'client_secret' => $client_secret,
         'scope' => $scope,
       ],
+      'headers' => $this->getEcmsRequestHeaders(),
       'verify' => $verify,
     ];
 

--- a/ecms_base/modules/custom/ecms_api/src/EcmsApiBase.php
+++ b/ecms_base/modules/custom/ecms_api/src/EcmsApiBase.php
@@ -161,7 +161,7 @@ abstract class EcmsApiBase {
     }
 
     return [
-      self::ORIGIN_HEADER => \Drupal::requestStack()->getCurrentRequest()->getHost(),
+      self::ORIGIN_HEADER => $this->ecmsApiHelper->getCurrentRequest()->getHost(),
       self::ENV_HEADER => $envHeaderValue,
     ];
   }

--- a/ecms_base/modules/custom/ecms_api/src/EcmsApiBase.php
+++ b/ecms_base/modules/custom/ecms_api/src/EcmsApiBase.php
@@ -42,7 +42,7 @@ abstract class EcmsApiBase {
   /**
    * Header carrying the HMAC-signed environment identifier.
    *
-   * Format: "{AH_SITE_ENVIRONMENT}:{Crypt::hmacBase64(ECMS_SHARED_SECRET, env)}"
+   * Format: {AH_SITE_ENVIRONMENT}:{Crypt::hmacBase64(ECMS_SHARED_SECRET, env)}
    * Falls back to "local" with no signature when running outside Acquia.
    */
   const ENV_HEADER = 'X-ECMS-Env';

--- a/ecms_base/modules/custom/ecms_api/src/EcmsApiBase.php
+++ b/ecms_base/modules/custom/ecms_api/src/EcmsApiBase.php
@@ -42,7 +42,7 @@ abstract class EcmsApiBase {
   /**
    * Header carrying the HMAC-signed environment identifier.
    *
-   * Format: {AH_SITE_ENVIRONMENT}:{Crypt::hmacBase64(ECMS_SHARED_SECRET, env)}
+   * Format: {AH_SITE_ENVIRONMENT}:{Crypt::hmacBase64(env, ECMS_SHARED_SECRET)}
    * Falls back to "local" with no signature when running outside Acquia.
    */
   const ENV_HEADER = 'X-ECMS-Env';
@@ -160,8 +160,11 @@ abstract class EcmsApiBase {
       $envHeaderValue = "{$env}:{$signature}";
     }
 
+    $currentRequest = $this->ecmsApiHelper->getCurrentRequest();
+    $originHeaderValue = ($currentRequest !== NULL) ? $currentRequest->getHost() : 'localhost';
+
     return [
-      self::ORIGIN_HEADER => $this->ecmsApiHelper->getCurrentRequest()->getHost(),
+      self::ORIGIN_HEADER => $originHeaderValue,
       self::ENV_HEADER => $envHeaderValue,
     ];
   }

--- a/ecms_base/modules/custom/ecms_api/src/EcmsApiHelper.php
+++ b/ecms_base/modules/custom/ecms_api/src/EcmsApiHelper.php
@@ -6,6 +6,8 @@ namespace Drupal\ecms_api;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StreamWrapper\PublicStream;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Helper service for the ecms_api base class.
@@ -29,6 +31,13 @@ class EcmsApiHelper {
   private $publicStreamWrapper;
 
   /**
+   * The request.stack service.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
    * EcmsApiHelper constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
@@ -36,9 +45,10 @@ class EcmsApiHelper {
    * @param \Drupal\Core\StreamWrapper\PublicStream $publicStream
    *   The stream_wrapper.public service.
    */
-  public function __construct(EntityTypeManagerInterface $entityTypeManager, PublicStream $publicStream) {
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, PublicStream $publicStream, RequestStack $requestStack) {
     $this->entityTypeManager = $entityTypeManager;
     $this->publicStreamWrapper = $publicStream;
+    $this->requestStack = $requestStack;
   }
 
   /**
@@ -71,6 +81,16 @@ class EcmsApiHelper {
     $realpath = $this->publicStreamWrapper->realpath();
 
     return "{$realpath}/{$host}{$path}";
+  }
+
+  /**
+   * Get the current request object.
+   *
+   * @return \Symfony\Component\HttpFoundation\Request|null
+   *   The current request object.
+   */
+  public function getCurrentRequest(): ?Request {
+    return $this->requestStack->getCurrentRequest();
   }
 
 }

--- a/ecms_base/modules/custom/ecms_api/src/EcmsApiHelper.php
+++ b/ecms_base/modules/custom/ecms_api/src/EcmsApiHelper.php
@@ -44,6 +44,8 @@ class EcmsApiHelper {
    *   The entity_type.manager service.
    * @param \Drupal\Core\StreamWrapper\PublicStream $publicStream
    *   The stream_wrapper.public service.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+   *   The request.stack service.
    */
   public function __construct(EntityTypeManagerInterface $entityTypeManager, PublicStream $publicStream, RequestStack $requestStack) {
     $this->entityTypeManager = $entityTypeManager;

--- a/ecms_base/modules/custom/ecms_api/src/EventSubscriber/OAuthRouteRestrictionSubscriber.php
+++ b/ecms_base/modules/custom/ecms_api/src/EventSubscriber/OAuthRouteRestrictionSubscriber.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ecms_api\EventSubscriber;
+
+use Drupal\Component\Utility\Crypt;
+use Drupal\ecms_api\EcmsApiBase;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Restricts access to the /oauth/token endpoint.
+ *
+ * On Acquia environments (AH_SITE_ENVIRONMENT is set), requires incoming
+ * requests to carry an X-ECMS-Env header containing an HMAC-signed
+ * environment identifier. This prevents external bots from consuming server
+ * resources and enforces environment isolation (staging cannot authenticate
+ * against production and vice versa).
+ *
+ * The .htaccess layer enforces header presence before PHP boots; this
+ * subscriber handles HMAC validation and environment matching.
+ *
+ * @package Drupal\ecms_api\EventSubscriber
+ */
+class OAuthRouteRestrictionSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The Acquia environment variable name.
+   */
+  const AH_ENV_VAR = 'AH_SITE_ENVIRONMENT';
+
+  /**
+   * The shared secret environment variable name.
+   */
+  const SHARED_SECRET_VAR = 'ECMS_SHARED_SECRET';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [KernelEvents::REQUEST => ['onRequest', 100]];
+  }
+
+  /**
+   * Validate ECMS authentication headers on /oauth/token requests.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
+   *   The kernel request event.
+   */
+  public function onRequest(RequestEvent $event): void {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+
+    if ($event->getRequest()->getPathInfo() !== '/oauth/token') {
+      return;
+    }
+
+    $currentEnv = getenv(self::AH_ENV_VAR);
+    if (empty($currentEnv)) {
+      // Not on Acquia — allow (local dev).
+      return;
+    }
+
+    $sharedSecret = getenv(self::SHARED_SECRET_VAR);
+    if (empty($sharedSecret)) {
+      // On Acquia but shared secret not configured — fail closed.
+      $event->setResponse(new JsonResponse(['error' => 'Forbidden'], 403));
+      return;
+    }
+
+    $envHeader = $event->getRequest()->headers->get(EcmsApiBase::ENV_HEADER);
+
+    if (empty($envHeader) || !str_contains($envHeader, ':')) {
+      $event->setResponse(new JsonResponse(['error' => 'Forbidden'], 403));
+      return;
+    }
+
+    // Header format: "{env}:{hmac-signature}".
+    [$originEnv, $signature] = explode(':', $envHeader, 2);
+
+    // Verify the HMAC signature to prevent spoofing.
+    $expectedSignature = Crypt::hmacBase64($originEnv, $sharedSecret);
+    if (!hash_equals($expectedSignature, $signature)) {
+      $event->setResponse(new JsonResponse(['error' => 'Forbidden'], 403));
+      return;
+    }
+
+    // Verify the publisher's environment matches this recipient's environment.
+    if ($originEnv !== $currentEnv) {
+      $event->setResponse(new JsonResponse(['error' => 'Forbidden'], 403));
+    }
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_api/tests/src/Unit/EcmsApiBaseTest.php
+++ b/ecms_base/modules/custom/ecms_api/tests/src/Unit/EcmsApiBaseTest.php
@@ -74,6 +74,14 @@ class EcmsApiBaseTest extends UnitTestCase {
   const ACCESS_TOKEN = 'test-access-token-123';
 
   /**
+   * The test ECMS request headers returned by the mocked getEcmsRequestHeaders.
+   */
+  const ECMS_REQUEST_HEADERS = [
+    'X-ECMS-Origin' => 'test.example.com',
+    'X-ECMS-Env' => 'local',
+  ];
+
+  /**
    * The oauth success return values.
    */
   const OAUTH_SUCCESS = [
@@ -388,6 +396,7 @@ class EcmsApiBaseTest extends UnitTestCase {
         'client_secret' => self::CLIENT_SECRET,
         'scope' => self::CLIENT_SCOPE,
       ],
+      'headers' => self::ECMS_REQUEST_HEADERS,
       'verify' => TRUE,
     ];
 
@@ -433,7 +442,12 @@ class EcmsApiBaseTest extends UnitTestCase {
         $this->entityToJsonApi,
         $this->ecmsApiHelper,
       ])
+      ->onlyMethods(['getEcmsRequestHeaders'])
       ->getMock();
+
+    $ecmsApi->expects($this->once())
+      ->method('getEcmsRequestHeaders')
+      ->willReturn(self::ECMS_REQUEST_HEADERS);
 
     $getAccessToken = new \ReflectionMethod(EcmsApiBase::class, 'getAccessToken');
     $getAccessToken->setAccessible(TRUE);

--- a/ecms_base/modules/custom/ecms_api/tests/src/Unit/EcmsApiBaseTest.php
+++ b/ecms_base/modules/custom/ecms_api/tests/src/Unit/EcmsApiBaseTest.php
@@ -27,11 +27,13 @@ use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use phpmock\MockBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
+use Drupal\Component\Utility\Crypt;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Unit tests for the EcmsApiBase class.
@@ -1602,6 +1604,106 @@ class EcmsApiBaseTest extends UnitTestCase {
 
     $this->assertEquals(58, $relationships['field_test']['meta']['target_revision_id']);
 
+  }
+
+  /**
+   * Test getEcmsRequestHeaders() directly.
+   *
+   * @param string|null $ahEnv
+   *   Value for AH_SITE_ENVIRONMENT, or NULL to leave unset.
+   * @param string|null $secret
+   *   Value for ECMS_SHARED_SECRET, or NULL to leave unset.
+   * @param string|null $requestHost
+   *   Host to return from the current request, or NULL to simulate no request.
+   * @param string $expectedOrigin
+   *   Expected value of X-ECMS-Origin header.
+   * @param string $expectedEnv
+   *   Expected value of X-ECMS-Env header.
+   */
+  #[DataProvider('dataProviderForGetEcmsRequestHeaders')]
+  public function testGetEcmsRequestHeaders(
+    ?string $ahEnv,
+    ?string $secret,
+    ?string $requestHost,
+    string $expectedOrigin,
+    string $expectedEnv,
+  ): void {
+    if ($ahEnv !== NULL) {
+      putenv("AH_SITE_ENVIRONMENT={$ahEnv}");
+    }
+    if ($secret !== NULL) {
+      putenv("ECMS_SHARED_SECRET={$secret}");
+    }
+
+    $this->ecmsApiHelper = $this->getMockBuilder(EcmsApiHelper::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['getCurrentRequest'])
+      ->getMock();
+
+    $mockRequest = $requestHost !== NULL ? Request::create('/', 'GET', [], [], [], ['HTTP_HOST' => $requestHost]) : NULL;
+
+    $this->ecmsApiHelper->expects($this->once())
+      ->method('getCurrentRequest')
+      ->willReturn($mockRequest);
+
+    $ecmsApi = $this->getMockBuilder(EcmsApiBase::class)
+      ->setConstructorArgs([
+        $this->httpclient,
+        $this->entityToJsonApi,
+        $this->ecmsApiHelper,
+      ])
+      ->getMock();
+
+    $method = new \ReflectionMethod(EcmsApiBase::class, 'getEcmsRequestHeaders');
+    $headers = $method->invoke($ecmsApi);
+
+    $this->assertEquals($expectedOrigin, $headers[EcmsApiBase::ORIGIN_HEADER]);
+    $this->assertEquals($expectedEnv, $headers[EcmsApiBase::ENV_HEADER]);
+
+    putenv('AH_SITE_ENVIRONMENT');
+    putenv('ECMS_SHARED_SECRET');
+  }
+
+  /**
+   * Data provider for testGetEcmsRequestHeaders().
+   *
+   * @return array[]
+   *   Keyed test cases.
+   */
+  public static function dataProviderForGetEcmsRequestHeaders(): array {
+    $secret = 'test-secret';
+    return [
+      'local dev — no env vars, has request' => [
+        NULL, NULL, 'example.ddev.site',
+        'example.ddev.site',
+        'local',
+      ],
+      'local dev — no env vars, no request (CLI)' => [
+        NULL, NULL, NULL,
+        'localhost',
+        'local',
+      ],
+      'env set, no secret, has request' => [
+        'test_env', NULL, 'site.example.com',
+        'site.example.com',
+        'test_env',
+      ],
+      'env set, secret set, has request — signed header' => [
+        'test_env', $secret, 'site.example.com',
+        'site.example.com',
+        'test_env:' . Crypt::hmacBase64('test_env', $secret),
+      ],
+      'env set, secret set, no request (CLI) — signed header, localhost origin' => [
+        'test_env', $secret, NULL,
+        'localhost',
+        'test_env:' . Crypt::hmacBase64('test_env', $secret),
+      ],
+      'custom domain, env set, secret set' => [
+        'test_env', $secret, 'custom.example.org',
+        'custom.example.org',
+        'test_env:' . Crypt::hmacBase64('test_env', $secret),
+      ],
+    ];
   }
 
 }

--- a/ecms_base/modules/custom/ecms_api/tests/src/Unit/EcmsApiHelperTest.php
+++ b/ecms_base/modules/custom/ecms_api/tests/src/Unit/EcmsApiHelperTest.php
@@ -12,6 +12,7 @@ use Drupal\file\FileInterface;
 use Drupal\Tests\UnitTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Unit tests for the EcmsApiHelper class.
@@ -41,6 +42,13 @@ class EcmsApiHelperTest extends UnitTestCase {
   private $publicStreamWrapper;
 
   /**
+   * Mock of the request_stack service.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack|\PHPUnit\Framework\MockObject\MockObject
+   */
+  private $requestStack;
+
+  /**
    * {@inheritDoc}
    */
   protected function setUp(): void {
@@ -48,6 +56,7 @@ class EcmsApiHelperTest extends UnitTestCase {
 
     $this->entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
     $this->publicStreamWrapper = $this->createMock(PublicStream::class);
+    $this->requestStack = $this->createMock(RequestStack::class);
   }
 
   /**
@@ -86,7 +95,7 @@ class EcmsApiHelperTest extends UnitTestCase {
       ->with('file')
       ->willReturn($fileStorage);
 
-    $testClass = new EcmsApiHelper($this->entityTypeManager, $this->publicStreamWrapper);
+    $testClass = new EcmsApiHelper($this->entityTypeManager, $this->publicStreamWrapper, $this->requestStack);
     $actual = $testClass->getFilePath(self::FILE_ID);
 
     $this->assertEquals($expected, $actual);

--- a/ecms_base/modules/custom/ecms_api/tests/src/Unit/EventSubscriber/OAuthRouteRestrictionSubscriberTest.php
+++ b/ecms_base/modules/custom/ecms_api/tests/src/Unit/EventSubscriber/OAuthRouteRestrictionSubscriberTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ecms_api\Unit\EventSubscriber;
+
+use Drupal\Component\Utility\Crypt;
+use Drupal\ecms_api\EventSubscriber\OAuthRouteRestrictionSubscriber;
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Unit tests for OAuthRouteRestrictionSubscriber.
+ *
+ * @package Drupal\Tests\ecms_api\Unit\EventSubscriber
+ */
+#[Group('ecms_api')]
+#[Group('ecms')]
+#[CoversClass(\Drupal\ecms_api\EventSubscriber\OAuthRouteRestrictionSubscriber::class)]
+class OAuthRouteRestrictionSubscriberTest extends UnitTestCase {
+
+  /**
+   * The shared secret used in tests.
+   */
+  const TEST_SECRET = 'test-shared-secret-abc';
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function tearDown(): void {
+    parent::tearDown();
+
+    // Clean up env vars to avoid polluting other tests.
+    putenv('AH_SITE_ENVIRONMENT');
+    putenv('ECMS_SHARED_SECRET');
+  }
+
+  /**
+   * Build a RequestEvent for the given path and headers.
+   *
+   * @param string $path
+   *   The request path.
+   * @param array $headers
+   *   Optional headers to set on the request.
+   * @param bool $mainRequest
+   *   Whether to simulate a main request (TRUE) or sub-request (FALSE).
+   *
+   * @return \Symfony\Component\HttpKernel\Event\RequestEvent
+   *   The configured event.
+   */
+  private function buildEvent(string $path, array $headers = [], bool $mainRequest = TRUE): RequestEvent {
+    $request = Request::create($path, 'POST');
+    foreach ($headers as $name => $value) {
+      $request->headers->set($name, $value);
+    }
+
+    $kernel = $this->createMock(HttpKernelInterface::class);
+    $requestType = $mainRequest ? HttpKernelInterface::MAIN_REQUEST : HttpKernelInterface::SUB_REQUEST;
+
+    return new RequestEvent($kernel, $request, $requestType);
+  }
+
+  /**
+   * Helper to compute a valid signed env header value.
+   *
+   * @param string $env
+   *   The environment value.
+   * @param string $secret
+   *   The shared secret.
+   *
+   * @return string
+   *   The header value in "{env}:{signature}" format.
+   */
+  private static function signedEnvHeader(string $env, string $secret): string {
+    return $env . ':' . Crypt::hmacBase64($env, $secret);
+  }
+
+  /**
+   * Test that getSubscribedEvents returns the expected event mapping.
+   */
+  public function testGetSubscribedEvents(): void {
+    $events = OAuthRouteRestrictionSubscriber::getSubscribedEvents();
+    $this->assertArrayHasKey('kernel.request', $events);
+    $this->assertEquals(['onRequest', 100], $events['kernel.request']);
+  }
+
+  /**
+   * Test onRequest with various scenarios.
+   *
+   * @param string|null $ahEnv
+   *   Value for AH_SITE_ENVIRONMENT, or NULL to leave unset.
+   * @param string|null $secret
+   *   Value for ECMS_SHARED_SECRET, or NULL to leave unset.
+   * @param string $path
+   *   The request URI path.
+   * @param array $headers
+   *   Request headers to include.
+   * @param bool $mainRequest
+   *   Whether this is a main request.
+   * @param bool $expectForbidden
+   *   TRUE if a 403 response is expected, FALSE if the event should pass through.
+   */
+  #[DataProvider('dataProviderForOnRequest')]
+  public function testOnRequest(
+    ?string $ahEnv,
+    ?string $secret,
+    string $path,
+    array $headers,
+    bool $mainRequest,
+    bool $expectForbidden,
+  ): void {
+    if ($ahEnv !== NULL) {
+      putenv("AH_SITE_ENVIRONMENT={$ahEnv}");
+    }
+    if ($secret !== NULL) {
+      putenv("ECMS_SHARED_SECRET={$secret}");
+    }
+
+    $event = $this->buildEvent($path, $headers, $mainRequest);
+    $subscriber = new OAuthRouteRestrictionSubscriber();
+    $subscriber->onRequest($event);
+
+    if ($expectForbidden) {
+      $response = $event->getResponse();
+      $this->assertInstanceOf(JsonResponse::class, $response);
+      $this->assertEquals(403, $response->getStatusCode());
+    }
+    else {
+      $this->assertNull($event->getResponse());
+    }
+  }
+
+  /**
+   * Data provider for testOnRequest().
+   *
+   * @return array[]
+   *   Keyed test cases.
+   */
+  public static function dataProviderForOnRequest(): array {
+    $secret = self::TEST_SECRET;
+
+    return [
+      'local dev — no env vars set' => [
+        NULL, NULL, '/oauth/token', [], TRUE, FALSE,
+      ],
+      'non-oauth path is ignored' => [
+        '01live', $secret, '/some/other/path', [], TRUE, FALSE,
+      ],
+      'sub-request is ignored' => [
+        '01live', $secret, '/oauth/token', [], FALSE, FALSE,
+      ],
+      'missing ECMS_SHARED_SECRET on Acquia — fail closed' => [
+        '01live', NULL, '/oauth/token', [], TRUE, TRUE,
+      ],
+      'missing X-ECMS-Env header' => [
+        '01live', $secret, '/oauth/token',
+        ['X-ECMS-Origin' => 'site.prod-riecms.acsitefactory.com'],
+        TRUE, TRUE,
+      ],
+      'X-ECMS-Env header has no colon separator' => [
+        '01live', $secret, '/oauth/token',
+        ['X-ECMS-Env' => '01live'],
+        TRUE, TRUE,
+      ],
+      'invalid HMAC signature' => [
+        '01live', $secret, '/oauth/token',
+        ['X-ECMS-Env' => '01live:bad-signature'],
+        TRUE, TRUE,
+      ],
+      'valid signature but cross-env (test claims prod)' => [
+        '01live', $secret, '/oauth/token',
+        ['X-ECMS-Env' => self::signedEnvHeader('01test', $secret)],
+        TRUE, TRUE,
+      ],
+      'valid signature but cross-env (prod claims test)' => [
+        '01test', $secret, '/oauth/token',
+        ['X-ECMS-Env' => self::signedEnvHeader('01live', $secret)],
+        TRUE, TRUE,
+      ],
+      'valid prod to prod' => [
+        '01live', $secret, '/oauth/token',
+        ['X-ECMS-Env' => self::signedEnvHeader('01live', $secret)],
+        TRUE, FALSE,
+      ],
+      'valid test to test' => [
+        '01test', $secret, '/oauth/token',
+        ['X-ECMS-Env' => self::signedEnvHeader('01test', $secret)],
+        TRUE, FALSE,
+      ],
+      'valid dev to dev' => [
+        '01dev', $secret, '/oauth/token',
+        ['X-ECMS-Env' => self::signedEnvHeader('01dev', $secret)],
+        TRUE, FALSE,
+      ],
+      'valid custom domain (tax.ri.gov) prod to prod' => [
+        '01live', $secret, '/oauth/token',
+        [
+          'X-ECMS-Origin' => 'tax.ri.gov',
+          'X-ECMS-Env' => self::signedEnvHeader('01live', $secret),
+        ],
+        TRUE, FALSE,
+      ],
+      'signature from wrong secret is rejected' => [
+        '01live', $secret, '/oauth/token',
+        ['X-ECMS-Env' => self::signedEnvHeader('01live', 'wrong-secret')],
+        TRUE, TRUE,
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
This pull request introduces a new security mechanism to restrict access to the `/oauth/token` endpoint, ensuring that only requests from the correct environment with a valid HMAC-signed header are allowed. It implements an event subscriber to enforce this, updates service definitions and helper classes to support the new headers, and adds comprehensive unit tests for the new logic.

**Security: OAuth endpoint restriction**
* Added `OAuthRouteRestrictionSubscriber` event subscriber to require a valid `X-ECMS-Env` HMAC-signed header on `/oauth/token` requests in Acquia environments, enforcing environment isolation and preventing unauthorized access. [[1]](diffhunk://#diff-2766a51d004757959a651dfae4c47600d7e40e309b18889d3adc45fc6b9b4b7cR1-R98) [[2]](diffhunk://#diff-7b1a92ed0208f3f3beb9598505f50f5d47f60647775350671659c3efba5cf234L10-R15)
* Introduced constants and a method in `EcmsApiBase` to generate and send the necessary authentication headers (`X-ECMS-Origin` and `X-ECMS-Env`) for outbound API requests. [[1]](diffhunk://#diff-17feb6a7c103462a0fbe3af5a127248e11a629cc91cbfdd7bc3ad22705e93080R37-R49) [[2]](diffhunk://#diff-17feb6a7c103462a0fbe3af5a127248e11a629cc91cbfdd7bc3ad22705e93080R141-R168) [[3]](diffhunk://#diff-17feb6a7c103462a0fbe3af5a127248e11a629cc91cbfdd7bc3ad22705e93080R200)

**Dependency injection and service updates**
* Updated `ecms_api_helper` service and `EcmsApiHelper` class to inject and expose the `request_stack` service, enabling retrieval of the current request for header generation. [[1]](diffhunk://#diff-7b1a92ed0208f3f3beb9598505f50f5d47f60647775350671659c3efba5cf234L10-R15) [[2]](diffhunk://#diff-8efcb0999ffb97fffe4fb2914f0fbc07985ad127101e973be8af9dba0f0d154aR9-R10) [[3]](diffhunk://#diff-8efcb0999ffb97fffe4fb2914f0fbc07985ad127101e973be8af9dba0f0d154aR33-R53) [[4]](diffhunk://#diff-8efcb0999ffb97fffe4fb2914f0fbc07985ad127101e973be8af9dba0f0d154aR88-R97)

**Testing**
* Added a new unit test class for `OAuthRouteRestrictionSubscriber`, covering all validation cases for the new header logic.
* Updated existing unit tests for `EcmsApiBase` and `EcmsApiHelper` to accommodate the new header requirements and constructor arguments. [[1]](diffhunk://#diff-6c6637c16c8210d59bd3a27ab6c8e48fcfddf30948d3adfb104f2df9b9b80cb5R76-R83) [[2]](diffhunk://#diff-6c6637c16c8210d59bd3a27ab6c8e48fcfddf30948d3adfb104f2df9b9b80cb5R399) [[3]](diffhunk://#diff-6c6637c16c8210d59bd3a27ab6c8e48fcfddf30948d3adfb104f2df9b9b80cb5R445-R451) [[4]](diffhunk://#diff-bd3ead8b57f5e10fc7630a245099c8bc03a743b1158c898f23b7c73c89a908a7R15) [[5]](diffhunk://#diff-bd3ead8b57f5e10fc7630a245099c8bc03a743b1158c898f23b7c73c89a908a7R44-R50) [[6]](diffhunk://#diff-bd3ead8b57f5e10fc7630a245099c8bc03a743b1158c898f23b7c73c89a908a7R59) [[7]](diffhunk://#diff-bd3ead8b57f5e10fc7630a245099c8bc03a743b1158c898f23b7c73c89a908a7L89-R98)

[RIGA-815](https://thinkoomph.jira.com/browse/RIGA-815)