### PR TITLE
Address ADA compliance issues with various components

### DIFF
--- a/ecms_base/themes/custom/ecms/components/01-molecules/pagination/pagination.twig
+++ b/ecms_base/themes/custom/ecms/components/01-molecules/pagination/pagination.twig
@@ -15,7 +15,7 @@
     {# Add an ellipsis if there are further previous pages. #}
     {% if ellipses.previous %}
       <li class="qh__pagination__item">
-        <span class="qh__pagination__ellipses" aria-label="{{ 'Full list of pages is truncated'|t }}" role="text">&hellip;</span>
+        <span class="qh__pagination__ellipses" aria-label="{{ 'Full list of pages is truncated'|t }}">&hellip;</span>
       </li>
     {% endif %}
     {# Now generate the actual pager piece. #}
@@ -34,7 +34,7 @@
     {# Add an ellipsis if there are further next pages. #}
     {% if ellipses.previous %}
       <li class="qh__pagination__item">
-        <span class="qh__pagination__ellipses" aria-label="{{ 'Full list of pages is truncated'|t }}" role="text">&hellip;</span>
+        <span class="qh__pagination__ellipses" aria-label="{{ 'Full list of pages is truncated'|t }}">&hellip;</span>
       </li>
     {% endif %}
     {# Print next item if we are not on the last page. #}

--- a/ecms_base/themes/custom/ecms/components/01-molecules/site-branding/site-branding.twig
+++ b/ecms_base/themes/custom/ecms/components/01-molecules/site-branding/site-branding.twig
@@ -45,7 +45,7 @@
     </a>
 
     {% if logo_only == FALSE %}
-      <span class="qh__site-branding__name" role="text">
+      <span class="qh__site-branding__name">
       {% if (header_preprocess_values.top_line) %}
         <span class="qh__site-branding__name__top-line">{{ header_preprocess_values.top_line }}<span class="visually-hidden">, </span></span>
       {% endif %}

--- a/ecms_base/themes/custom/ecms/components/02-organisms/paragraphs/file-list/file-list.twig
+++ b/ecms_base/themes/custom/ecms/components/02-organisms/paragraphs/file-list/file-list.twig
@@ -5,7 +5,7 @@
       <h3>{{ list_title }}</h3>
     {% endif %}
 
-    <section class="qh__file-list__list" role="list">
+    <section class="qh__file-list__list">
       {{ files|raw }}
     </section>
   </div>

--- a/ecms_base/themes/custom/ecms/components/02-organisms/paragraphs/gallery/_gallery.scss
+++ b/ecms_base/themes/custom/ecms/components/02-organisms/paragraphs/gallery/_gallery.scss
@@ -27,6 +27,7 @@
   }
 
   &__button {
+    @include qh-button-reset();
     display: block;
     width: rem(44);
     height: rem(44);
@@ -39,9 +40,11 @@
     display: flex;
 
     &-radio {
+      @include qh-button-reset();
       display: block;
       height: rem(18);
       width: rem(18);
+      background: transparent;
       border: 1px solid var(--fc__default__fg);
       border-radius: rem(9);
       padding: 0;
@@ -115,7 +118,4 @@
     }
   }
 
-  button {
-    @include qh-button-reset();
-  }
 }

--- a/ecms_base/themes/custom/ecms/components/02-organisms/paragraphs/gallery/gallery.twig
+++ b/ecms_base/themes/custom/ecms/components/02-organisms/paragraphs/gallery/gallery.twig
@@ -1,18 +1,18 @@
 <div class="qh__gallery">
 
-  <div class="qh__gallery__slider" data-pid="{{ pid }}">
+  <div class="qh__gallery__slider" id="qh__gallery__slider-{{ pid }}" data-pid="{{ pid }}">
     {{ content }}
   </div>
 
   <div class="qh__gallery__controls" id="qh__gallery__controls-{{ pid }}" aria-label="Gallery navigation">
-    <button class="qh__gallery__button qh__gallery__button--prev" data-controls="prev" aria-controls="qh__gallery__slider">
+    <button class="qh__gallery__button qh__gallery__button--prev" data-controls="prev" aria-controls="qh__gallery__slider-{{ pid }}">
       <span class="qh__icon">
         {% include ('@icons/chevron-left.svg') %}
       </span>
       <span class="visually-hidden">Prev</span>
     </button>
 
-    <button class="qh__gallery__button qh__gallery__button--next" data-controls="next" aria-controls="qh__gallery__slider">
+    <button class="qh__gallery__button qh__gallery__button--next" data-controls="next" aria-controls="qh__gallery__slider-{{ pid }}">
       <span class="qh__icon">
         {% include ('@icons/chevron-right.svg') %}
       </span>
@@ -21,7 +21,7 @@
 
     <div class="qh__gallery__nav" id="qh__gallery__nav-{{ pid }}">
       {% for slide in slides_raw %}
-        <a class="qh__gallery__nav-radio"><span class="visually-hidden">Slide {{ loop.index }}</span></a>
+        <button type="button" class="qh__gallery__nav-radio"><span class="visually-hidden">Slide {{ loop.index }}</span></button>
       {% endfor %}
     </div>
   </div>

--- a/ecms_base/themes/custom/ecms/templates/content/node--event--full.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/content/node--event--full.html.twig
@@ -133,7 +133,8 @@
 
 <article class="qh__single-event">
   <header class="qh__single-event__header">
-    <h1 class="qh__h2">{{ title }}</h1>
+    {% set rendered_title = title|render|trim %}
+    <h1 class="qh__h2">{{ rendered_title ?: node.label }}</h1>
 
     {% if img|default %}
       <figure class="qh__single-event__image">


### PR DESCRIPTION
## Summary
Resolves four accessibility violations flagged in the recent audit.

## Changes

**1. Removed invalid `role="text"` attribute**
- `site-branding.twig` — on the site name span
- `pagination.twig` — on the ellipsis truncation indicator (same issue, fixed while here)

**2. Removed incorrect `role="list"` from File List component**
- `file-list.twig` — the section claimed to be a list but its children were not list items, and the wrapper could render empty when no files were attached.

**3. Event pages no longer render an empty heading**
- `node--event--full.html.twig` — the H1 now falls back to `node.label` if the preprocessed `title` renders empty. The H1 is always present.

**4. Fixed broken ARIA on Image Gallery navigation**
- `gallery.twig`
  - Added `id="qh__gallery__slider-{{ pid }}"` so the prev/next buttons' `aria-controls` references a real element.
  - Changed pagination dots from anchors (`a` tags) to real `button` elements for proper keyboard semantics.
- `_gallery.scss` — moved the `qh-button-reset` mixin inline on `&__button` and `&-radio` (removed the generic `button` selector) so the nav dots keep their circle styling now that they're real buttons.

## Test Plan

Use your browser's Inspect tool (right-click → Inspect) and check the element in the Elements panel.

- [ ] **Site branding** — inspect the site title in the header. The `qh__site-branding__name` span should not have a `role="text"` attribute.
- [ ] **Pagination** — on a paginated listing, inspect the ellipsis. The `qh__pagination__ellipses` span should not have a `role="text"` attribute.
- [ ] **File list** — inspect a File List paragraph. The `qh__file-list__list` section should not have a `role="list"` attribute. Also save a File List paragraph with zero files and confirm the page renders cleanly.
- [ ] **Event page** — open any Event. The heading element should always contain the event title.
- [ ] **Gallery ARIA** — on a page with a gallery, inspect the slider. It has an id like `qh__gallery__slider-123`. The prev/next buttons' `aria-controls` value matches that id. The pagination dots are `button` elements, not anchor tags.
- [ ] **Gallery keyboard** — tab into the gallery. Use left/right arrow keys to navigate