### PR TITLE
Added tab and tab group components

### DIFF
--- a/ecms_base/themes/custom/ecms/components/canvas/tabs/tab-group/_tab-group.scss
+++ b/ecms_base/themes/custom/ecms/components/canvas/tabs/tab-group/_tab-group.scss
@@ -1,0 +1,14 @@
+.canvas-tab-group {
+  background-color: var(--c__navy);
+  padding: 5rem var(--section-sides, 1rem) 2.5rem;
+
+  // Tablist injected by JS above the panels.
+  &__tablist {
+    align-items: flex-end;
+    display: flex;
+    gap: 1.25rem;
+    padding: 0 2rem;
+    position: relative;
+    z-index: 2;
+  }
+}

--- a/ecms_base/themes/custom/ecms/components/canvas/tabs/tab-group/tab-group.component.yml
+++ b/ecms_base/themes/custom/ecms/components/canvas/tabs/tab-group/tab-group.component.yml
@@ -1,0 +1,25 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Canvas Tab Group
+status: experimental
+group: RI.Gov
+description: |
+  Accessible tab group. Place one or more Canvas Tab components in the `tabs`
+  slot. The component collects each Tab's button into a shared tablist and
+  wires up all ARIA attributes and keyboard navigation automatically.
+
+slots:
+  tabs:
+    title: Tabs
+    description: Place one or more Canvas Tab components here.
+
+libraryOverrides:
+  js:
+    tab-group.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
+
+thirdPartySettings:
+  sdcStorybook:
+    disabledStories:
+      - all

--- a/ecms_base/themes/custom/ecms/components/canvas/tabs/tab-group/tab-group.js
+++ b/ecms_base/themes/custom/ecms/components/canvas/tabs/tab-group/tab-group.js
@@ -1,0 +1,143 @@
+/**
+ * @file Canvas Tab Group — builds the tablist and wires keyboard navigation.
+ *
+ * Each Canvas Tab component renders a [data-canvas-tab-button] and a
+ * [data-canvas-tab-panel] inside a [data-canvas-tab] wrapper. This script
+ * collects those buttons into a shared tablist, assigns ARIA attributes, and
+ * implements the W3C ARIA Tabs keyboard pattern.
+ *
+ * https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+ *
+ * The DOM manipulation (moving buttons into a shared tablist) is skipped when
+ * running inside Canvas's preview iframe. Canvas renders pages in a same-origin
+ * iframe whose element carries data-canvas-preview="true"; window.frameElement
+ * exposes that attribute to the inner document. All Tab components remain
+ * intact and individually selectable for editing in that context.
+ */
+
+(function (Drupal, once) {
+  'use strict';
+
+  let groupCounter = 0;
+
+  /**
+   * Activate a tab button and show its paired panel.
+   *
+   * @param {HTMLElement} button - The tab button to activate.
+   * @param {HTMLElement[]} allButtons - Every button in this group.
+   */
+  function activateTab(button, allButtons) {
+    allButtons.forEach((b) => {
+      b.setAttribute('aria-selected', 'false');
+      b.setAttribute('tabindex', '-1');
+      b.classList.remove('canvas-tab__button--active');
+
+      const panel = document.getElementById(b.getAttribute('aria-controls'));
+      if (panel) {
+        panel.setAttribute('hidden', '');
+      }
+    });
+
+    button.setAttribute('aria-selected', 'true');
+    button.setAttribute('tabindex', '0');
+    button.classList.add('canvas-tab__button--active');
+
+    const activePanel = document.getElementById(button.getAttribute('aria-controls'));
+    if (activePanel) {
+      activePanel.removeAttribute('hidden');
+    }
+  }
+
+  /**
+   * Initialise a single tab group widget.
+   *
+   * @param {HTMLElement} group
+   */
+  function initGroup(group) {
+    const tabEls = Array.from(group.querySelectorAll(':scope > [data-canvas-tab]'));
+    if (!tabEls.length) return;
+
+    const id = ++groupCounter;
+
+    // Build tablist element and prepend it to the group.
+    const tablist = document.createElement('div');
+    tablist.className = 'canvas-tab-group__tablist';
+    tablist.setAttribute('role', 'tablist');
+    group.insertBefore(tablist, group.firstChild);
+
+    const buttons = [];
+
+    tabEls.forEach((tabEl, i) => {
+      const button = tabEl.querySelector('[data-canvas-tab-button]');
+      const panel = tabEl.querySelector('[data-canvas-tab-panel]');
+      if (!button || !panel) return;
+
+      const tabId = `canvas-tab-${id}-${i + 1}`;
+      const panelId = `canvas-panel-${id}-${i + 1}`;
+
+      // Wire ARIA.
+      button.id = tabId;
+      button.setAttribute('role', 'tab');
+      button.setAttribute('aria-controls', panelId);
+      button.setAttribute('aria-selected', i === 0 ? 'true' : 'false');
+      button.setAttribute('tabindex', i === 0 ? '0' : '-1');
+      if (i === 0) button.classList.add('canvas-tab__button--active');
+
+      panel.id = panelId;
+      panel.setAttribute('role', 'tabpanel');
+      panel.setAttribute('aria-labelledby', tabId);
+      panel.setAttribute('tabindex', '0');
+      if (i !== 0) panel.setAttribute('hidden', '');
+
+      // Move button from its canvas-tab wrapper into the shared tablist.
+      tablist.appendChild(button);
+      buttons.push(button);
+    });
+
+    // Click and keyboard handling.
+    buttons.forEach((button, index) => {
+      button.addEventListener('click', () => activateTab(button, buttons));
+
+      button.addEventListener('keydown', (event) => {
+        let newIndex = null;
+
+        if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+          newIndex = (index + 1) % buttons.length;
+        } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+          newIndex = (index - 1 + buttons.length) % buttons.length;
+        } else if (event.key === 'Home') {
+          newIndex = 0;
+        } else if (event.key === 'End') {
+          newIndex = buttons.length - 1;
+        }
+
+        if (newIndex !== null) {
+          event.preventDefault();
+          activateTab(buttons[newIndex], buttons);
+          buttons[newIndex].focus();
+        }
+      });
+    });
+  }
+
+  Drupal.behaviors.canvasTabGroup = {
+    attach(context) {
+      // Canvas renders the page inside a same-origin iframe whose element has
+      // data-canvas-preview="true". Skip DOM manipulation in that context so
+      // every Tab component stays intact and is individually selectable for
+      // editing.
+      try {
+        if (
+          window.frameElement &&
+          window.frameElement.getAttribute('data-canvas-preview') === 'true'
+        ) {
+          return;
+        }
+      } catch (e) {
+        // Cross-origin frameElement access throws; not a Canvas preview frame.
+      }
+
+      once('canvas-tab-group', '[data-canvas-tab-group]', context).forEach(initGroup);
+    },
+  };
+})(Drupal, once);

--- a/ecms_base/themes/custom/ecms/components/canvas/tabs/tab-group/tab-group.twig
+++ b/ecms_base/themes/custom/ecms/components/canvas/tabs/tab-group/tab-group.twig
@@ -1,0 +1,28 @@
+{#
+  Canvas Tab Group
+  Wrapper for one or more Canvas Tab components. JavaScript collects each
+  Tab's button into a shared tablist rendered above the panels, then wires
+  ARIA attributes and keyboard navigation.
+
+  Slots:
+    tabs - Place Canvas Tab components here.
+
+  Usage:
+  {% embed "@canvas/tabs/tabs.twig" %}
+    {% block tabs %}
+      {% embed "@canvas/tab/tab.twig" with { label: 'Residents', icon: 'home' } %}
+        {% block panel %}
+          {% include "@canvas/text-cta/text-cta.twig" with { ... } %}
+        {% endblock %}
+      {% endembed %}
+      {% embed "@canvas/tab/tab.twig" with { label: 'Businesses', icon: 'globe' } %}
+        {% block panel %}
+          {% include "@canvas/grid/grid.twig" with { ... } %}
+        {% endblock %}
+      {% endembed %}
+    {% endblock %}
+  {% endembed %}
+#}
+<div class="canvas-tab-group" data-canvas-tab-group>
+  {% block tabs %}{% endblock %}
+</div>

--- a/ecms_base/themes/custom/ecms/components/canvas/tabs/tab/_tab.scss
+++ b/ecms_base/themes/custom/ecms/components/canvas/tabs/tab/_tab.scss
@@ -1,0 +1,79 @@
+.canvas-tab {
+  // Button — visual styles; layout/ARIA wired by Tab Group JS.
+  &__button {
+    align-items: center;
+    background-color: var(--c__cliff-walk--light);
+    border: 0;
+    border-radius: 8px;
+    // color drives both the label and the SVG icon via currentColor.
+    color: var(--c__quahog, #404040);
+    cursor: pointer;
+    display: flex;
+    gap: 0.625rem;
+    padding: 0.8125rem 1.5rem 0.8125rem 1rem;
+    position: relative;
+
+    &--active {
+      background-color: var(--c__cliff-walk);
+      border: 2px solid var(--c__cliff-walk--darkest--trans75, rgba(19, 134, 96, 0.75));
+      color: var(--c__navy);
+    }
+
+    &:hover:not(&--active) {
+      background-color: var(--c__cliff-walk);
+      color: var(--c__navy);
+    }
+
+    // Keyboard focus ring: white outline with a gap so it reads against both
+    // the navy group background and the cliff-walk button surface.
+    &:focus-visible {
+      outline: 3px solid var(--c__white, #fff);
+      outline-offset: 3px;
+    }
+  }
+
+  &__icon {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    height: 1.75rem;   // 28px — matches Figma icon canvas
+    justify-content: center;
+    width: 1.75rem;
+
+    svg {
+      fill: currentColor; // Inherits button color — always matches the label.
+      height: 1.75rem;    // Fill the full 28px canvas
+      width: 1.75rem;
+    }
+  }
+
+  &__label {
+    font-family: 'Work Sans', sans-serif;
+    font-size: 1.125rem; // 18px
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    line-height: 1.2;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  // Panel — shown/hidden and ARIA-wired by Tab Group JS.
+  &__panel {
+    background-color: #fff;
+    background-image:
+      linear-gradient(90deg, rgba(210, 203, 178, 0.1) 0%, rgba(210, 203, 178, 0.1) 100%),
+      linear-gradient(90deg, #fff 0%, #fff 100%);
+    border-radius: 0 8px 8px;
+    margin-top: -1.625rem; // pulls up behind the tablist row
+    position: relative;
+    z-index: 1;
+
+    &[hidden] {
+      display: none;
+    }
+  }
+
+  &__panel-inner {
+    padding: 4rem 2rem;
+  }
+}

--- a/ecms_base/themes/custom/ecms/components/canvas/tabs/tab/tab.component.yml
+++ b/ecms_base/themes/custom/ecms/components/canvas/tabs/tab/tab.component.yml
@@ -1,0 +1,72 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Canvas Tab
+status: experimental
+group: RI.Gov
+description: |
+  A single tab for use inside a Canvas Tab Group. The `label` and optional
+  `icon` define the tab button. Any Canvas component can be placed in the
+  `panel` slot to form the tab's content.
+
+  Place one or more of these inside a Canvas Tab Group's `tabs` slot.
+
+props:
+  type: object
+  required:
+    - label
+  properties:
+    label:
+      title: Label
+      type: string
+      examples: ['Residents']
+    icon:
+      title: Icon
+      type: string
+      enum:
+        - alarm-bell
+        - anchor-small
+        - arrow-right
+        - bus
+        - chevron-down
+        - chevron-left
+        - chevron-right
+        - close-x
+        - cog
+        - default-logo
+        - download
+        - feed
+        - file-excel
+        - file-generic
+        - file-pdf
+        - file-powerpoint
+        - file-word
+        - globe
+        - guillemot-left
+        - guillemot-right
+        - home
+        - icon-ios-share
+        - information
+        - link-external
+        - map
+        - map-marker
+        - maple-leaf
+        - plus-minus
+        - ri-state-seal
+        - search-glass
+        - social-blogger
+        - social-blusky
+        - social-facebook
+        - social-flickr
+        - social-instagram
+        - social-linkedin
+        - social-twitter
+        - social-youtube
+      examples: ['home']
+
+slots:
+  panel:
+    title: Tab Content
+
+thirdPartySettings:
+  sdcStorybook:
+    disabledStories:
+      - all

--- a/ecms_base/themes/custom/ecms/components/canvas/tabs/tab/tab.twig
+++ b/ecms_base/themes/custom/ecms/components/canvas/tabs/tab/tab.twig
@@ -1,0 +1,29 @@
+{#
+  Canvas Tab
+  A single tab item for use inside a Canvas Tab Group. Renders a button (for
+  the tab strip) and a panel (for the content area). The Tab Group's JS moves
+  the button into the shared tablist and wires up all ARIA attributes.
+
+  Props:
+    label - Visible tab label (required)
+    icon  - Optional icon name from the @icons SVG set (e.g. "home")
+
+  Slots:
+    panel - Content shown when this tab is active.
+#}
+<div class="canvas-tab" data-canvas-tab>
+  <button class="canvas-tab__button" data-canvas-tab-button type="button">
+    {% if icon %}
+      <span class="canvas-tab__icon" aria-hidden="true">
+        {% include '@icons/' ~ icon ~ '.svg' %}
+      </span>
+    {% endif %}
+    <span class="canvas-tab__label">{{ label }}</span>
+  </button>
+
+  <div class="canvas-tab__panel" data-canvas-tab-panel>
+    <div class="canvas-tab__panel-inner">
+      {% block panel %}{% endblock %}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This pull request introduces a new, accessible tab group component system for the Canvas design system. It provides both the markup and interactive JavaScript needed for a fully ARIA-compliant tab interface, along with configurable styling and documentation. The system is composed of a `Canvas Tab Group` wrapper and individual `Canvas Tab` items, allowing for flexible and accessible tabbed content areas.

**Component implementation and accessibility:**

* Added `tab-group.js`, which collects tab buttons into a shared tablist, wires up ARIA attributes, and implements keyboard navigation according to W3C ARIA Tabs guidelines. The script also detects Canvas preview mode and disables DOM manipulation in that context.
* Added `tab-group.twig` and `tab.twig` templates to define the markup structure for the tab group and individual tabs, supporting slots for flexible content insertion and ensuring semantic HTML for accessibility. [[1]](diffhunk://#diff-198428de0b9d95874cc7f8141fe985d67f11ecedf37931c86e855ee9f2e8486eR1-R28) [[2]](diffhunk://#diff-bc2554c407d4f63179363bcee8d70cca02051cc5235fafbfdf6a0049c22acff8R1-R29)

**Component configuration and documentation:**

* Added `tab-group.component.yml` and `tab.component.yml` files to document the components, define their props/slots, and configure integration with the design system and Storybook. [[1]](diffhunk://#diff-a4eba3c616350ce513d602a3b1f6a415e147469cb02f0bab5698b195fae095abR1-R25) [[2]](diffhunk://#diff-231789e37921686905961197948516df727ccbdaf499ab202979614b6a829b35R1-R72)

**Styling:**

* Added `_tab-group.scss` and `_tab.scss` files to style the tab group container, the tab buttons (including active/hover/focus states), icons, labels, and tab panels, ensuring a visually appealing and accessible interface. [[1]](diffhunk://#diff-0df5c3234924cd3f67d1c8dd72987447a62f0f8729b4cb02df57cc7a8162acfdR1-R14) [[2]](diffhunk://#diff-292a70f661a5368b12b1e06e4a73068fdd116929812beb1b81d9eb7d7ac7ed21R1-R79)