### PR TITLE
Locked pathauto to 1.14 to allow installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -169,7 +169,7 @@
         "drupal/paragraphs": "^1.20",
         "drupal/password_policy": "^4.0",
         "drupal/path_redirect_import": "^2.0",
-        "drupal/pathauto": "^1.8",
+        "drupal/pathauto": "1.14",
         "drupal/publishcontent": "^1.3",
         "drupal/purge_file": "^1.2",
         "drupal/quick_node_clone": "^1.16",


### PR DESCRIPTION
Pathauto 1.15 broke the installation of `ecms_base`. This is a temporary fix to ensure that CI builds succeed.
