### PR TITLE
Updated patches for gtranslate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
                 "2741187 - 39 - Allow usage of WYSIWYG in views text area fields": "https://gist.githubusercontent.com/pfrilling/91262eb9ca72ec66704027344ebc0e56/raw/cba7ef0284684d1db59c193e5a06968a36b73a02/gistfile1.txt"
             },
             "drupal/gtranslate": {
-                "3375925 - TypeError: array_values(): Argument #1 ($array) must be of type array": "https://www.drupal.org/files/issues/2023-08-31/gtranslate-3375925-update-default-config-11.diff",
+                "3375925 - TypeError: array_values(): Argument #1 ($array) must be of type array": "https://gist.githubusercontent.com/pfrilling/46564b443070ee4285cebbcbd5eeeb55/raw/6b04f8cb0823f70ea36abf3e1248f0fb7f405d0e/gistfile1.txt",
                 "3555400: Add schema for gtranslate.settings ": "https://www.drupal.org/files/issues/2025-10-31/3555400-add-schema-gtranslate-6.patch",
-                "RIGA-826: Portuguese Langugage": "https://gist.githubusercontent.com/pfrilling/5b43049ad0f6b78ac882abb27148ff5d/raw/0919102bb4c14f8824beb2396b6483d9395002f8/gtranslate-allow-portuguese.patch"
+                "RIGA-826: Portuguese Langugage": "https://gist.githubusercontent.com/pfrilling/5b43049ad0f6b78ac882abb27148ff5d/raw/43a8807906addaed7e9a31e22825ec9db784ff43/gtranslate-allow-portuguese.patch"
             },
             "drupal/iek": {
                 "3430975 - #7 Drupal 11 upgrade": "https://www.drupal.org/files/issues/2025-04-10/iek.1.x-dev.rector.patch",


### PR DESCRIPTION
## Summary / Approach
GTranslate's latest update broke require patches. This updates those patches to be utilized.

[RIGA-848](https://thinkoomph.jira.com/browse/RIGA-848)