### PR TITLE
Enforce h1s to always be on landing pages

### DIFF
--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -560,3 +560,14 @@ function ecms_base_update_11213(): void {
 
   ecms_base_apply_recipes($recipes);
 }
+
+/**
+ * Apply recipe to expose landing_page title as a placeable field block.
+ */
+function ecms_base_update_11214(): void {
+  $recipes = [
+    'ecms_landing_page_title_block',
+  ];
+
+  ecms_base_apply_recipes($recipes);
+}

--- a/ecms_base/modules/custom/ecms_layout/ecms_layout.services.yml
+++ b/ecms_base/modules/custom/ecms_layout/ecms_layout.services.yml
@@ -1,0 +1,3 @@
+services:
+  Drupal\ecms_layout\LandingPageTitleDetector:
+    autowire: true

--- a/ecms_base/modules/custom/ecms_layout/src/Hook/EcmsLayoutHooks.php
+++ b/ecms_base/modules/custom/ecms_layout/src/Hook/EcmsLayoutHooks.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ecms_layout\Hook;
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\ecms_layout\LandingPageTitleDetector;
+
+/**
+ * Hook implementations for the ecms_layout module.
+ */
+class EcmsLayoutHooks {
+
+  public function __construct(
+    private readonly LandingPageTitleDetector $titleDetector,
+  ) {}
+
+  /**
+   * Implements hook_preprocess_node().
+   */
+  #[Hook('preprocess_node')]
+  public function preprocessNode(array &$variables): void {
+    $node = $variables['node'] ?? NULL;
+    if (!$node || $node->bundle() !== 'landing_page') {
+      return;
+    }
+    $variables['render_fallback_title'] = !$this->titleDetector->hasH1Block($node);
+  }
+
+  /**
+   * Implements hook_entity_bundle_field_info_alter().
+   *
+   * Makes the node title display-configurable on landing_page so it can be
+   * placed as a field_block in Layout Builder. See drupal.org/i/3036862.
+   */
+  #[Hook('entity_bundle_field_info_alter')]
+  public function entityBundleFieldInfoAlter(array &$fields, EntityTypeInterface $entity_type, string $bundle): void {
+    if ($entity_type->id() === 'node' && $bundle === 'landing_page' && isset($fields['title'])) {
+      $fields['title']->setDisplayConfigurable('view', TRUE);
+    }
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_layout/src/LandingPageTitleDetector.php
+++ b/ecms_base/modules/custom/ecms_layout/src/LandingPageTitleDetector.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ecms_layout;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\layout_builder\Plugin\SectionStorage\OverridesSectionStorage;
+use Drupal\layout_builder\SectionComponent;
+use Drupal\node\NodeInterface;
+
+/**
+ * Decides whether a landing_page node's layout already renders an <h1>.
+ */
+final class LandingPageTitleDetector {
+
+  private const ALWAYS_H1 = [
+    'inline_block:page_title_with_photo',
+    'field_block:node:landing_page:title',
+  ];
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * Returns TRUE if any component in the node's layout renders an <h1>.
+   */
+  public function hasH1Block(NodeInterface $node): bool {
+    if (!$node->hasField(OverridesSectionStorage::FIELD_NAME)) {
+      return FALSE;
+    }
+    $sections = $node->get(OverridesSectionStorage::FIELD_NAME);
+    foreach ($sections->getSections() as $section) {
+      foreach ($section->getComponents() as $component) {
+        if ($this->componentRendersH1($component)) {
+          return TRUE;
+        }
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Decides whether a single section component will render an <h1>.
+   */
+  private function componentRendersH1(SectionComponent $component): bool {
+    $plugin_id = $component->getPluginId();
+
+    if (in_array($plugin_id, self::ALWAYS_H1, TRUE)) {
+      return TRUE;
+    }
+
+    if ($plugin_id === 'inline_block:header_image_action') {
+      $config = $component->toArray()['configuration'] ?? [];
+      return $this->hiaTitleEnabled($config);
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Reads the header_image_action inline block's "use as H1" toggle.
+   */
+  private function hiaTitleEnabled(array $config): bool {
+    $revision_id = $config['block_revision_id'] ?? NULL;
+    if (!$revision_id) {
+      return FALSE;
+    }
+    $block = $this->entityTypeManager->getStorage('block_content')->loadRevision($revision_id);
+    if (!$block || !$block->hasField('field_hia_page_title_enabled')) {
+      return FALSE;
+    }
+    return (bool) $block->get('field_hia_page_title_enabled')->value;
+  }
+
+}

--- a/ecms_base/recipes/ecms_landing_page_title_block/recipe.yml
+++ b/ecms_base/recipes/ecms_landing_page_title_block/recipe.yml
@@ -1,0 +1,32 @@
+name: 'eCMS Landing Page — Allow Title Field Block'
+description: 'Exposes the node title as a placeable field_block in Layout Builder for the landing_page full view mode. Adds the title component to the view display (additively) and allowlists its field_block derivative.'
+type: 'eCMS'
+
+install:
+  - ecms_layout
+  - layout_builder
+  - layout_builder_restrictions
+
+config:
+  actions:
+    core.entity_view_display.node.landing_page.full:
+      createIfNotExists:
+        targetEntityType: node
+        bundle: landing_page
+        mode: full
+        status: true
+      setComponent:
+        name: title
+        options:
+          label: hidden
+          type: string
+          settings:
+            link_to_entity: false
+          third_party_settings: {  }
+          weight: -10
+          region: content
+      setProperties:
+        'third_party_settings.layout_builder_restrictions.entity_view_mode_restriction.allowlisted_blocks.Content fields':
+          - 'field_block:node:landing_page:field_add_modal'
+          - 'field_block:node:landing_page:title'
+          - 'field_block:user:user:changed'

--- a/ecms_base/themes/custom/ecms/assets/patterns/00-atoms/00-base/__variables.scss
+++ b/ecms_base/themes/custom/ecms/assets/patterns/00-atoms/00-base/__variables.scss
@@ -156,8 +156,8 @@ $st-size-l-value: $st-size-l-px / $text-base-size;
 $p-lh-s: 1.4;
 $p-lh-l: 1.5;
 
-$h1-lh-s: 1.05;
-$h1-lh-l: 1.1;
+$h1-lh-s: 1.2;
+$h1-lh-l: 1.3;
 
 $h2-lh-s: 1.15;
 $h2-lh-l: 1.25;

--- a/ecms_base/themes/custom/ecms/templates/content/node--landing-page.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/content/node--landing-page.html.twig
@@ -99,6 +99,17 @@
   {% endif %}
 
   <div{{ content_attributes.addClass('node__content') }}>
+
+    {% if render_fallback_title and node.label %}
+      <div class="qh__t__none">
+        <div class="qh-layout-section qh-layout-section--col-count-1 qh-layout-section--col-size-100">
+          <div class="qh-layout-section__col qh-layout-section__col--first">
+            <h1>{{ node.label }}</h1>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
     {{ content }}
 
     {{ modal }}

--- a/ecms_base/themes/custom/ecms/templates/fields/field--node--title--landing-page.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/fields/field--node--title--landing-page.html.twig
@@ -1,0 +1,3 @@
+{% for item in items %}
+  <h1>{{ item.content }}</h1>
+{% endfor %}


### PR DESCRIPTION
- Allows node title field to be added
- If no h1 is added then the title is programmatically added to template