### PR TITLE
Rc/2.0.6

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -28,7 +28,7 @@ corepack_enable: true
 # If the name is omitted, the project will take the name of the enclosing directory,
 # which is useful if you want to have a copy of the project side by side with this one.
 
-# type: <projecttype>  # backdrop, cakephp, codeigniter, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, drupal12, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress
+# type: <projecttype>  # asterios, backdrop, cakephp, codeigniter, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, drupal12, generic, joomla, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress, wp-bedrock
 # See https://docs.ddev.com/en/stable/users/quickstart/ for more
 # information on the different project types
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
                 "2794431 - [META] Formalize translations support (#102)": "https://www.drupal.org/files/issues/2020-09-29/jsonapi_add_and_update_translations_support-2794431-102.patch",
                 "3049332 - #134 - PHP message: Error: Call to a member function getEntityTypeId() on null (Layout Builder)": "https://www.drupal.org/files/issues/2025-07-09/drupal-core--2025-07-09--3049332--mr-12460.patch",
                 "2827921 - Exception thrown by responsive srcset images when the image is not yet in the file system (such as with Stage File Proxy)": "https://www.drupal.org/files/issues/2026-01-22/responsive_image-remove_missing_response_image_width_exception.patch",
-                "2741187 - 39 - Allow usage of WYSIWYG in views text area fields": "https://gist.githubusercontent.com/pfrilling/91262eb9ca72ec66704027344ebc0e56/raw/cba7ef0284684d1db59c193e5a06968a36b73a02/gistfile1.txt"
+                "2741187 - 39 - Allow usage of WYSIWYG in views text area fields": "https://gist.githubusercontent.com/pfrilling/91262eb9ca72ec66704027344ebc0e56/raw/cba7ef0284684d1db59c193e5a06968a36b73a02/gistfile1.txt",
+                "3008292 - Upload validators (including max_resolution) not applied in media library upload form": "https://www.drupal.org/files/issues/2025-12-29/3008292-14174-11.x.patch"
             },
             "drupal/gtranslate": {
                 "3375925 - TypeError: array_values(): Argument #1 ($array) must be of type array": "https://www.drupal.org/files/issues/2023-08-31/gtranslate-3375925-update-default-config-11.diff",
@@ -169,7 +170,7 @@
         "drupal/paragraphs": "^1.20",
         "drupal/password_policy": "^4.0",
         "drupal/path_redirect_import": "^2.0",
-        "drupal/pathauto": "^1.8",
+        "drupal/pathauto": "1.14",
         "drupal/publishcontent": "^1.3",
         "drupal/purge_file": "^1.2",
         "drupal/quick_node_clone": "^1.16",

--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,7 @@
         "drupal/features": "^3.15",
         "drupal/feeds": "^3.0@RC",
         "drupal/feeds_ex": "^1.0@beta",
-        "drupal/field_group": "^3.4",
+        "drupal/field_group": "^3.4 || ^4.0",
         "drupal/file_delete": "^3.0",
         "drupal/focal_point": "^2.0.1",
         "drupal/geocoder": "^4.30",

--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,9 @@
                 "3008292 - Upload validators (including max_resolution) not applied in media library upload form": "https://www.drupal.org/files/issues/2025-12-29/3008292-14174-11.x.patch"
             },
             "drupal/gtranslate": {
-                "3375925 - TypeError: array_values(): Argument #1 ($array) must be of type array": "https://www.drupal.org/files/issues/2023-08-31/gtranslate-3375925-update-default-config-11.diff",
+                "3375925 - TypeError: array_values(): Argument #1 ($array) must be of type array": "https://gist.githubusercontent.com/pfrilling/46564b443070ee4285cebbcbd5eeeb55/raw/6b04f8cb0823f70ea36abf3e1248f0fb7f405d0e/gistfile1.txt",
                 "3555400: Add schema for gtranslate.settings ": "https://www.drupal.org/files/issues/2025-10-31/3555400-add-schema-gtranslate-6.patch",
-                "RIGA-826: Portuguese Langugage": "https://gist.githubusercontent.com/pfrilling/5b43049ad0f6b78ac882abb27148ff5d/raw/0919102bb4c14f8824beb2396b6483d9395002f8/gtranslate-allow-portuguese.patch"
+                "RIGA-826: Portuguese Langugage": "https://gist.githubusercontent.com/pfrilling/5b43049ad0f6b78ac882abb27148ff5d/raw/43a8807906addaed7e9a31e22825ec9db784ff43/gtranslate-allow-portuguese.patch"
             },
             "drupal/iek": {
                 "3430975 - #7 Drupal 11 upgrade": "https://www.drupal.org/files/issues/2025-04-10/iek.1.x-dev.rector.patch",

--- a/ecms_base/features/custom/ecms_event/config/install/field.field.media.event_image.field_media_image_1.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.field.media.event_image.field_media_image_1.yml
@@ -29,7 +29,7 @@ settings:
   alt_field_required: true
   title_field: false
   title_field_required: false
-  max_resolution: ''
+  max_resolution: '4000x4000'
   min_resolution: ''
   default_image:
     uuid: null
@@ -38,7 +38,7 @@ settings:
     width: null
     height: null
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  max_filesize: ''
+  max_filesize: '10 MB'
   handler: 'default:file'
   handler_settings: {  }
 field_type: image

--- a/ecms_base/features/custom/ecms_hotel/config/install/field.field.media.hotel_image.field_hotel_image.yml
+++ b/ecms_base/features/custom/ecms_hotel/config/install/field.field.media.hotel_image.field_hotel_image.yml
@@ -26,8 +26,8 @@ default_value_callback: ''
 settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png jpg jpeg'
-  max_filesize: ''
-  max_resolution: ''
+  max_filesize: '10 MB'
+  max_resolution: '4000x4000'
   min_resolution: ''
   alt_field: true
   alt_field_required: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.icon.field_icon_image.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.icon.field_icon_image.yml
@@ -19,8 +19,8 @@ default_value_callback: ''
 settings:
   file_directory: uploaded-icons
   file_extensions: svg
-  max_filesize: ''
-  max_resolution: ''
+  max_filesize: '10 MB'
+  max_resolution: '4000x4000'
   min_resolution: ''
   alt_field: true
   alt_field_required: true

--- a/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.media_item_image.field_media_item_image.yml
+++ b/ecms_base/features/custom/ecms_paragraphs/config/install/field.field.media.media_item_image.field_media_item_image.yml
@@ -26,8 +26,8 @@ default_value_callback: ''
 settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
-  max_filesize: ''
-  max_resolution: ''
+  max_filesize: '10 MB'
+  max_resolution: '4000x4000'
   min_resolution: ''
   alt_field: true
   alt_field_required: true

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.media.person_headshot.field_personal_photo_image.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.media.person_headshot.field_personal_photo_image.yml
@@ -26,8 +26,8 @@ default_value_callback: ''
 settings:
   file_directory: personal-photos
   file_extensions: 'png gif jpg jpeg'
-  max_filesize: ''
-  max_resolution: ''
+  max_filesize: '10 MB'
+  max_resolution: '4000x4000'
   min_resolution: ''
   alt_field: true
   alt_field_required: true

--- a/ecms_base/features/custom/ecms_projects/config/install/field.field.media.project_main_image.field_media_image_2.yml
+++ b/ecms_base/features/custom/ecms_projects/config/install/field.field.media.project_main_image.field_media_image_2.yml
@@ -29,7 +29,7 @@ settings:
   alt_field_required: true
   title_field: false
   title_field_required: false
-  max_resolution: ''
+  max_resolution: '4000x4000'
   min_resolution: ''
   default_image:
     uuid: null
@@ -38,7 +38,7 @@ settings:
     width: null
     height: null
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  max_filesize: ''
+  max_filesize: '10 MB'
   handler: 'default:file'
   handler_settings: {  }
 field_type: image

--- a/ecms_base/features/custom/ecms_promotions/config/install/field.field.media.promotional_image.field_promotion_image.yml
+++ b/ecms_base/features/custom/ecms_promotions/config/install/field.field.media.promotional_image.field_promotion_image.yml
@@ -26,8 +26,8 @@ default_value_callback: ''
 settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
-  max_filesize: ''
-  max_resolution: ''
+  max_filesize: '10 MB'
+  max_resolution: '4000x4000'
   min_resolution: ''
   alt_field: true
   alt_field_required: true


### PR DESCRIPTION
This pull request introduces several configuration updates to improve media file handling and compatibility in the project. The main focus is on standardizing image upload restrictions across multiple media fields, updating Drupal module requirements for better compatibility, and refining patch references for consistency and reliability.

**Media file upload restrictions:**

* Standardized maximum file size (`10 MB`) and maximum resolution (`4000x4000`) for image fields across various media types, including event images, hotel images, icon images, media item images, personal photos, project images, and promotional images. This ensures consistent validation and prevents oversized uploads. [[1]](diffhunk://#diff-c92f6c8e1de3cbc44b778fd529a5a657a7f7b9c22d381334445823375728d7e5L32-R32) [[2]](diffhunk://#diff-c92f6c8e1de3cbc44b778fd529a5a657a7f7b9c22d381334445823375728d7e5L41-R41) [[3]](diffhunk://#diff-fda092e80a1ee3682044d33f7b215b353e6059d65147c2055f32ace7834c57baL29-R30) [[4]](diffhunk://#diff-7ec257af7c8c7424da3c52667c3ad3597acc6d01ddf280971ac4e8f4f73562aaL22-R23) [[5]](diffhunk://#diff-db292a137d06ec215d7f7079f71070c9f5098a2b3bb1da000815b242c33deefdL29-R30) [[6]](diffhunk://#diff-8b37e5d503c1eda5e03d28cbc3a635943b9ce3df3497c0832d16b7853c8afa03L29-R30) [[7]](diffhunk://#diff-67f0578cb2684f40e3b0eb83bcba83f9f7e7e3c9883ce846c846b9d6942a7a83L32-R32) [[8]](diffhunk://#diff-67f0578cb2684f40e3b0eb83bcba83f9f7e7e3c9883ce846c846b9d6942a7a83L41-R41) [[9]](diffhunk://#diff-b0313e4946fc9a82b5a89c73843a6c326c5282ae7fa69d0f225f60ca26690c1cL29-R30)

**Composer and dependency management:**

* Updated the `drupal/field_group` dependency to allow both `^3.4` and `^4.0` versions, enhancing compatibility with newer releases.
* Pinned the `drupal/pathauto` module to version `1.14` instead of a version range, likely for stability or compatibility reasons.

**Patch and configuration references:**

* Added a new patch for the "Upload validators not applied in media library upload form" issue, improving file validation during uploads.
* Updated patch URLs for the `gtranslate` module and Portuguese language support to more recent or reliable sources.

**Project configuration:**

* Expanded the supported project types in `.ddev/config.yaml` to include additional CMS and framework types, such as `asterios`, `joomla`, and `wp-bedrock`.