### PR TITLE
Change breadcrumb visibility

### DIFF
--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -547,3 +547,33 @@ function ecms_base_update_11212(): void {
 
   ecms_base_apply_recipes($recipes);
 }
+
+/**
+ * Change visibilty of breadcrumb blocks.
+ */
+function ecms_base_update_11213(): void {
+  // Fix the breadcrumb visibility rules.
+  $config = \Drupal::configFactory()->getEditable('block.block.breadcrumbs');
+
+  $visibility = $config->get('visibility');
+
+  // Check if visibility matches the expected entity_bundle:node configuration.
+  $expected_visibility = [
+    'entity_bundle:node' => [
+      'id' => 'entity_bundle:node',
+      'negate' => TRUE,
+      'context_mapping' => [
+        'node' => '@node.node_route_context:node',
+      ],
+      'bundles' => [
+        'landing_page' => 'landing_page',
+      ],
+    ],
+  ];
+
+  // Only alter the visibilty if it matches the originally installed.
+  if ($visibility === $expected_visibility) {
+    $config->set('visibility', []);
+    $config->save(TRUE);
+  }
+}

--- a/ecms_base/themes/custom/ecms/config/optional/block.block.breadcrumbs.yml
+++ b/ecms_base/themes/custom/ecms/config/optional/block.block.breadcrumbs.yml
@@ -15,13 +15,6 @@ plugin: system_breadcrumb_block
 settings:
   id: system_breadcrumb_block
   label: Breadcrumbs
-  provider: system
   label_display: '0'
-visibility:
-  'entity_bundle:node':
-    id: 'entity_bundle:node'
-    bundles:
-      landing_page: landing_page
-    negate: true
-    context_mapping:
-      node: '@node.node_route_context:node'
+  provider: system
+visibility: {  }


### PR DESCRIPTION
Breadcrumb visibility was locked to landing pages only. This changes that platform wide to be shown on other page (e.g. views).

[RIGA-852](https://thinkoomph.jira.com/browse/RIGA-852)