### PR TITLE
Added default date to news date field

### DIFF
--- a/ecms_base/recipes/ecms_news/recipe.yml
+++ b/ecms_base/recipes/ecms_news/recipe.yml
@@ -78,6 +78,9 @@ config:
       setLabel: Date
       setRequired: true
       setTranslatable: false
+      setDefaultValue:
+        - default_date_type: now
+          default_date: now
 
     field.field.node.news.field_news_links:
       ensure_exists:


### PR DESCRIPTION
Updates the news field formatter to prepopulate the date.

[RIGA-844](https://thinkoomph.jira.com/browse/RIGA-844)