### PR TITLE
Riga 867/views cache

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -8,7 +8,7 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 env:
-  DRUPAL_CORE: '~11.2.0'
+  DRUPAL_CORE: '~11.3.0'
   PHP_VERSION: '8.3'
   NODE_VERSION: '10.x'
 
@@ -23,9 +23,9 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - drupal_core: '~11.2.0'
+          - drupal_core: '~11.3.0'
             experimental: false
-          - drupal_core: '^11.3'
+          - drupal_core: '^11.4'
             experimental: true
 
     steps:
@@ -94,16 +94,16 @@ jobs:
       matrix:
         include:
           - php_version: '8.3'
-            drupal_core: '~11.2.0'
+            drupal_core: '~11.3.0'
             experimental: false
           - php_version: '8.4'
-            drupal_core: '~11.2.0'
+            drupal_core: '~11.3.0'
             experimental: true
           - php_version: '8.3'
-            drupal_core: '^11.3'
+            drupal_core: '^11.4'
             experimental: true
           - php_version: '8.4'
-            drupal_core: '^11.3'
+            drupal_core: '^11.4'
             experimental: true
     container:
       image: drupalci/php-${{ matrix.php_version }}-ubuntu-apache:production

--- a/composer.json
+++ b/composer.json
@@ -103,6 +103,7 @@
         "drupal/better_exposed_filters": "^7.0.5",
         "drupal/bigmenu": "^2.0@RC",
         "drupal/book": "^1.0.0",
+        "drupal/cache_control_override": "^2.0",
         "drupal/captcha": "^2.0",
         "drupal/classy": "^2.0",
         "drupal/commerce": "^3.1",

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -13,6 +13,7 @@ dependencies:
   - block
   - block_content
   - breakpoint
+  - cache_control_override
   - ckeditor5
   - components
   - config

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -547,3 +547,10 @@ function ecms_base_update_11212(): void {
 
   ecms_base_apply_recipes($recipes);
 }
+
+/**
+ * Install the cache_control_override module.
+ */
+function ecms_base_update_11213(): void {
+  \Drupal::service('module_installer')->install(['cache_control_override']);
+}

--- a/ecms_base/features/custom/ecms_emergency_notification/config/install/views.view.emergency_notification.yml
+++ b/ecms_base/features/custom/ecms_emergency_notification/config/install/views.view.emergency_notification.yml
@@ -91,8 +91,12 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: tag
-        options: {  }
+        type: time
+        options:
+          results_lifespan: 3600
+          results_lifespan_custom: 0
+          output_lifespan: 3600
+          output_lifespan_custom: 0
       empty: {  }
       sorts:
         created:
@@ -197,7 +201,7 @@ display:
       footer: {  }
       display_extenders: {  }
     cache_metadata:
-      max-age: -1
+      max-age: 3600
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -212,7 +216,7 @@ display:
     display_options:
       display_extenders: {  }
     cache_metadata:
-      max-age: -1
+      max-age: 3600
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'

--- a/ecms_base/features/custom/ecms_event/config/install/field.storage.paragraph.field_event_list_limit.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.storage.paragraph.field_event_list_limit.yml
@@ -19,6 +19,36 @@ settings:
     -
       value: 5
       label: '5'
+    -
+      value: 6
+      label: '6'
+    -
+      value: 7
+      label: '7'
+    -
+      value: 8
+      label: '8'
+    -
+      value: 9
+      label: '9'
+    -
+      value: 10
+      label: '10'
+    -
+      value: 11
+      label: '11'
+    -
+      value: 12
+      label: '12'
+    -
+      value: 13
+      label: '13'
+    -
+      value: 14
+      label: '14'
+    -
+      value: 15
+      label: '15'
   allowed_values_function: ''
 module: options
 locked: false

--- a/ecms_base/features/custom/ecms_event/config/install/views.view.events.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/views.view.events.yml
@@ -26,8 +26,12 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: tag
-        options: {  }
+        type: time
+        options:
+          results_lifespan: 3600
+          results_lifespan_custom: 0
+          output_lifespan: 3600
+          output_lifespan_custom: 0
       query:
         type: views_query
         options:
@@ -287,7 +291,7 @@ display:
       link_url: ''
       link_display: page_1
     cache_metadata:
-      max-age: -1
+      max-age: 3600
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -317,7 +321,7 @@ display:
       use_more_always: true
       use_more_text: 'All events'
     cache_metadata:
-      max-age: -1
+      max-age: 3600
       contexts:
         - 'languages:language_interface'
         - 'user.node_grants:view'
@@ -342,7 +346,7 @@ display:
         page_1: page_1
       rendering_language: '***LANGUAGE_entity_translation***'
     cache_metadata:
-      max-age: -1
+      max-age: 3600
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -360,7 +364,7 @@ display:
       rendering_language: '***LANGUAGE_language_interface***'
       display_description: ''
     cache_metadata:
-      max-age: -1
+      max-age: 3600
       contexts:
         - 'languages:language_interface'
         - url.query_args
@@ -541,7 +545,7 @@ display:
           granularity: second
           plugin_id: date
     cache_metadata:
-      max-age: -1
+      max-age: 3600
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'


### PR DESCRIPTION
This pull request introduces several updates aimed at improving caching behavior and module management, as well as expanding configuration options. The most significant changes include adding and installing the `cache_control_override` module, updating cache settings for views to use time-based caching, and expanding the allowed values for event list limits. Additionally, the workflow and dependency versions have been incremented for better compatibility.

**Module Management and Installation:**
* Added `drupal/cache_control_override` to `composer.json`, included it as a dependency in `ecms_base.info.yml`, and created an update hook to install the module (`ecms_base_update_11213`) in `ecms_base.install`. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R106) [[2]](diffhunk://#diff-5d6fb5cc6275c387e9dd790596113adca3aa1e43b18a7c149f74841437a0b18eR16) [[3]](diffhunk://#diff-25fbfdb1af7789d4b0af10a1492c346e2ff5858d1f33693b613390e48664a298R550-R556)

**Caching Improvements:**
* Updated caching for the `emergency_notification` and `events` views to use time-based caching (1 hour) instead of tag-based or unlimited caching, and set explicit `max-age` values. [[1]](diffhunk://#diff-cbb768245cd84ed01be3247378f5540cee3a36c362b2afa51284732804ea33feL94-R99) [[2]](diffhunk://#diff-cbb768245cd84ed01be3247378f5540cee3a36c362b2afa51284732804ea33feL200-R204) [[3]](diffhunk://#diff-cbb768245cd84ed01be3247378f5540cee3a36c362b2afa51284732804ea33feL215-R219) [[4]](diffhunk://#diff-5fb293ac655a744cce25a6a0117a5658e439a4c392bb7f94b35ddb714f019c59L29-R34) [[5]](diffhunk://#diff-5fb293ac655a744cce25a6a0117a5658e439a4c392bb7f94b35ddb714f019c59L290-R294) [[6]](diffhunk://#diff-5fb293ac655a744cce25a6a0117a5658e439a4c392bb7f94b35ddb714f019c59L320-R324) [[7]](diffhunk://#diff-5fb293ac655a744cce25a6a0117a5658e439a4c392bb7f94b35ddb714f019c59L345-R349) [[8]](diffhunk://#diff-5fb293ac655a744cce25a6a0117a5658e439a4c392bb7f94b35ddb714f019c59L363-R367) [[9]](diffhunk://#diff-5fb293ac655a744cce25a6a0117a5658e439a4c392bb7f94b35ddb714f019c59L544-R548)

**Configuration Enhancements:**
* Expanded the allowed values for the `field_event_list_limit` field in the event paragraph to include values from 6 to 15.

**Workflow and Dependency Updates:**
* Updated the Drupal core version in the GitHub Actions workflow and matrix to `~11.3.0` and `^11.4`, and bumped the default environment variable accordingly. [[1]](diffhunk://#diff-dc1f0538462ec99cd0ba70c1de6c897f03e83c141cd0f3b22659d527a294d9fbL11-R11) [[2]](diffhunk://#diff-dc1f0538462ec99cd0ba70c1de6c897f03e83c141cd0f3b22659d527a294d9fbL26-R28) [[3]](diffhunk://#diff-dc1f0538462ec99cd0ba70c1de6c897f03e83c141cd0f3b22659d527a294d9fbL97-R106)

[RIGA-867](https://thinkoomph.jira.com/browse/RIGA-867)