### PR TITLE
Update CI Drupal version testing

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -8,7 +8,7 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 env:
-  DRUPAL_CORE: '~11.2.0'
+  DRUPAL_CORE: '~11.3.0'
   PHP_VERSION: '8.3'
   NODE_VERSION: '10.x'
 
@@ -23,9 +23,9 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - drupal_core: '~11.2.0'
+          - drupal_core: '~11.3.0'
             experimental: false
-          - drupal_core: '^11.3'
+          - drupal_core: '^11.4'
             experimental: true
 
     steps:
@@ -94,16 +94,16 @@ jobs:
       matrix:
         include:
           - php_version: '8.3'
-            drupal_core: '~11.2.0'
+            drupal_core: '~11.3.0'
             experimental: false
           - php_version: '8.4'
-            drupal_core: '~11.2.0'
+            drupal_core: '~11.3.0'
             experimental: true
           - php_version: '8.3'
-            drupal_core: '^11.3'
+            drupal_core: '^11.4'
             experimental: true
           - php_version: '8.4'
-            drupal_core: '^11.3'
+            drupal_core: '^11.4'
             experimental: true
     container:
       image: drupalci/php-${{ matrix.php_version }}-ubuntu-apache:production


### PR DESCRIPTION
This pull request updates the Drupal core version constraints in the GitHub Actions workflow to ensure compatibility with newer Drupal releases. The changes affect both the environment variables and the testing matrix for different PHP versions and experimental builds.

**Workflow dependency updates:**

* Updated the `DRUPAL_CORE` environment variable in `.github/workflows/develop.yml` from `~11.2.0` to `~11.3.0` to use a newer stable Drupal core version.
* Updated the test matrix to use `~11.3.0` for stable builds and `^11.4` for experimental builds, replacing the previous `~11.2.0` and `^11.3` constraints. [[1]](diffhunk://#diff-dc1f0538462ec99cd0ba70c1de6c897f03e83c141cd0f3b22659d527a294d9fbL26-R28) [[2]](diffhunk://#diff-dc1f0538462ec99cd0ba70c1de6c897f03e83c141cd0f3b22659d527a294d9fbL97-R106)