### PR TITLE
Rc/2.0.7

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -8,7 +8,7 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 env:
-  DRUPAL_CORE: '~11.2.0'
+  DRUPAL_CORE: '~11.3.0'
   PHP_VERSION: '8.3'
   NODE_VERSION: '10.x'
 
@@ -23,9 +23,9 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - drupal_core: '~11.2.0'
+          - drupal_core: '~11.3.0'
             experimental: false
-          - drupal_core: '^11.3'
+          - drupal_core: '^11.4'
             experimental: true
 
     steps:
@@ -94,16 +94,16 @@ jobs:
       matrix:
         include:
           - php_version: '8.3'
-            drupal_core: '~11.2.0'
+            drupal_core: '~11.3.0'
             experimental: false
           - php_version: '8.4'
-            drupal_core: '~11.2.0'
+            drupal_core: '~11.3.0'
             experimental: true
           - php_version: '8.3'
-            drupal_core: '^11.3'
+            drupal_core: '^11.4'
             experimental: true
           - php_version: '8.4'
-            drupal_core: '^11.3'
+            drupal_core: '^11.4'
             experimental: true
     container:
       image: drupalci/php-${{ matrix.php_version }}-ubuntu-apache:production

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -221,6 +221,11 @@ jobs:
 #        working-directory: ${{ env.DRUPAL_DIRECTORY }}
 #        run: find . -type f -iname "*Test.php" | grep "Functional" | sudo -u www-data -E /var/www/develop/vendor/liuggio/fastest/fastest "/var/www/develop/vendor/phpunit/phpunit/phpunit --configuration=/var/www/phpunit-ci.xml {};"
 #
-#      - name: Run existing site tests.
-#        working-directory: ${{ env.DRUPAL_DIRECTORY }}
-#        run: ../vendor/bin/phpunit --bootstrap=../vendor/weitzman/drupal-test-traits/src/bootstrap-fast.php --configuration=/var/www/phpunit-ci.xml --testsuite=existing
+      - name: Run existing site tests.
+        working-directory: ${{ env.DRUPAL_DIRECTORY }}
+        run: |
+            ../vendor/bin/phpunit \
+            --bootstrap=../vendor/weitzman/drupal-test-traits/src/bootstrap-fast.php \
+            --configuration=/var/www/phpunit-ci.xml \
+            --testsuite=existing \
+            --group=ecms_paragraphs

--- a/composer.json
+++ b/composer.json
@@ -103,6 +103,7 @@
         "drupal/better_exposed_filters": "^7.0.5",
         "drupal/bigmenu": "^2.0@RC",
         "drupal/book": "^1.0.0",
+        "drupal/cache_control_override": "^2.0",
         "drupal/captcha": "^2.0",
         "drupal/classy": "^2.0",
         "drupal/commerce": "^3.1",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
                 "3288638 - Automated Drupal 11 compatibility fixes": "https://gist.githubusercontent.com/pfrilling/0c65512c56ade5d240d7af025ae4938a/raw/0c2b363a9ab493ffccf10ce10c6ade1215b689e0/gistfile1.txt"
             },
             "drupal/paragraphs": {
-                "3090200 - Paragraphs do not render: access check for 'view' fail when using layout builder": "https://www.drupal.org/files/issues/2020-07-08/access-controll-issue-3090200-22.patch",
+                "3090200 - Paragraph access check uses default revision instead of referencing revision": "https://www.drupal.org/files/issues/2026-07-06/paragraphs-parent-access-block-content-skip-3090200-97.patch",
                 "2887353 - Paragraph Translation Sync": "https://gist.githubusercontent.com/pfrilling/87798df963feab76fbef5f4abe65fa10/raw/76c8f8cd06574b16b7da71ea2a0c1708d6d21871/paragraphs-translation-sync-2887353-60.patch"
             },
             "drupal/seckit": {

--- a/ecms_base/ecms_base.info.yml
+++ b/ecms_base/ecms_base.info.yml
@@ -13,6 +13,7 @@ dependencies:
   - block
   - block_content
   - breakpoint
+  - cache_control_override
   - ckeditor5
   - components
   - config

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -547,3 +547,10 @@ function ecms_base_update_11212(): void {
 
   ecms_base_apply_recipes($recipes);
 }
+
+/**
+ * Install the cache_control_override module.
+ */
+function ecms_base_update_11213(): void {
+  \Drupal::service('module_installer')->install(['cache_control_override']);
+}

--- a/ecms_base/features/custom/ecms_emergency_notification/config/install/views.view.emergency_notification.yml
+++ b/ecms_base/features/custom/ecms_emergency_notification/config/install/views.view.emergency_notification.yml
@@ -91,8 +91,12 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: tag
-        options: {  }
+        type: time
+        options:
+          results_lifespan: 3600
+          results_lifespan_custom: 0
+          output_lifespan: 3600
+          output_lifespan_custom: 0
       empty: {  }
       sorts:
         created:
@@ -197,7 +201,7 @@ display:
       footer: {  }
       display_extenders: {  }
     cache_metadata:
-      max-age: -1
+      max-age: 3600
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -212,7 +216,7 @@ display:
     display_options:
       display_extenders: {  }
     cache_metadata:
-      max-age: -1
+      max-age: 3600
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'

--- a/ecms_base/features/custom/ecms_event/config/install/field.storage.paragraph.field_event_list_limit.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/field.storage.paragraph.field_event_list_limit.yml
@@ -19,6 +19,36 @@ settings:
     -
       value: 5
       label: '5'
+    -
+      value: 6
+      label: '6'
+    -
+      value: 7
+      label: '7'
+    -
+      value: 8
+      label: '8'
+    -
+      value: 9
+      label: '9'
+    -
+      value: 10
+      label: '10'
+    -
+      value: 11
+      label: '11'
+    -
+      value: 12
+      label: '12'
+    -
+      value: 13
+      label: '13'
+    -
+      value: 14
+      label: '14'
+    -
+      value: 15
+      label: '15'
   allowed_values_function: ''
 module: options
 locked: false

--- a/ecms_base/features/custom/ecms_event/config/install/views.view.events.yml
+++ b/ecms_base/features/custom/ecms_event/config/install/views.view.events.yml
@@ -26,8 +26,12 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: tag
-        options: {  }
+        type: time
+        options:
+          results_lifespan: 3600
+          results_lifespan_custom: 0
+          output_lifespan: 3600
+          output_lifespan_custom: 0
       query:
         type: views_query
         options:
@@ -287,7 +291,7 @@ display:
       link_url: ''
       link_display: page_1
     cache_metadata:
-      max-age: -1
+      max-age: 3600
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -317,7 +321,7 @@ display:
       use_more_always: true
       use_more_text: 'All events'
     cache_metadata:
-      max-age: -1
+      max-age: 3600
       contexts:
         - 'languages:language_interface'
         - 'user.node_grants:view'
@@ -342,7 +346,7 @@ display:
         page_1: page_1
       rendering_language: '***LANGUAGE_entity_translation***'
     cache_metadata:
-      max-age: -1
+      max-age: 3600
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -360,7 +364,7 @@ display:
       rendering_language: '***LANGUAGE_language_interface***'
       display_description: ''
     cache_metadata:
-      max-age: -1
+      max-age: 3600
       contexts:
         - 'languages:language_interface'
         - url.query_args
@@ -541,7 +545,7 @@ display:
           granularity: second
           plugin_id: date
     cache_metadata:
-      max-age: -1
+      max-age: 3600
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'

--- a/ecms_base/tests/src/ExistingSite/ParagraphsAccessBug3090200Test.php
+++ b/ecms_base/tests/src/ExistingSite/ParagraphsAccessBug3090200Test.php
@@ -1,0 +1,362 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ecms_base\ExistingSite;
+
+// Require the all profiles abstract class since autoloading doesn't work.
+require_once dirname(__FILE__) . '/../../../../tests/src/ExistingSite/AllProfileInstallationTestsAbstract.php';
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\Entity\Node;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\Tests\ecms_profile\ExistingSite\AllProfileInstallationTestsAbstract;
+use Drupal\user\Entity\Role;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Regression test for drupal/paragraphs issue #3090200.
+ *
+ * Asserts that ParagraphAccessControlHandler::checkAccess() grants view access
+ * to a paragraph that is referenced by a published parent revision, even when
+ * the parent's DEFAULT revision is archived (unpublished).
+ *
+ * Background: the unpatched handler calls $paragraph->getParentEntity(), which
+ * resolves to the DEFAULT revision via EntityStorageInterface::load(). Under
+ * the editorial workflow, archiving a node creates a new unpublished default
+ * revision, causing checkAccess() to return neutral() instead of allowed() for
+ * paragraphs that belong to the earlier published revision.
+ *
+ * The fix (drupal.org/files/issues/2026-07-06/
+ * paragraphs-parent-access-block-content-skip-3090200-97.patch) introduces
+ * resolveAccessHost(), which queries the database for the specific parent
+ * revision that references the paragraph's revision ID, so the published
+ * revision is used for the access check regardless of what the default revision
+ * is.
+ *
+ * Scenario built from site configuration:
+ *   - node type:      press_release  (ecms_press_release feature)
+ *   - paragraph type: formatted_text (ecms_paragraphs feature)
+ *   - workflow:       editorial      (ecms_workflow module, archived state)
+ *
+ * Why checkAccess() is called via reflection:
+ *   The paragraphs_type_permissions submodule implements
+ *   hook_ENTITY_TYPE_access() for paragraphs, returning AccessResult::allowed()
+ *   or ::forbidden() based solely on per-type permissions. Because
+ *   EntityAccessControlHandler::access() combines hook results with
+ *   checkAccess() via orIf(), an allowed() from the hook masks any neutral()
+ *   returned by the buggy checkAccess(). Calling checkAccess() directly via
+ *   reflection isolates the logic the patch changes.
+ *
+ * @see https://www.drupal.org/project/paragraphs/issues/3090200
+ * @see \Drupal\paragraphs\ParagraphAccessControlHandler::checkAccess()
+ *
+ * @package Drupal\Tests\ecms_base\ExistingSite
+ */
+#[Group('ecms')]
+#[Group('ecms_paragraphs')]
+#[Group('ecms_press_release')]
+class ParagraphsAccessBug3090200Test extends AllProfileInstallationTestsAbstract {
+
+  /**
+   * The formatted_text paragraph created for the initial published node.
+   *
+   * @var \Drupal\paragraphs\Entity\Paragraph|null
+   */
+  private ?Paragraph $paragraph = NULL;
+
+  /**
+   * The revision ID of $paragraph after the parent node was first published.
+   *
+   * Stored after the first node save because entity_reference_revisions may
+   * create a new paragraph revision when the parent entity is saved.
+   *
+   * @var int|null
+   */
+  private ?int $paragraphRevisionId = NULL;
+
+  /**
+   * The press_release node created for the test.
+   *
+   * @var \Drupal\node\Entity\Node|null
+   */
+  private ?Node $node = NULL;
+
+  /**
+   * The node revision ID of the published revision (version 1).
+   *
+   * Used to assert that this revision is accessible and to verify
+   * resolveAccessHost() returns it after the fix is applied.
+   *
+   * @var int|null
+   */
+  private ?int $publishedNodeRevisionId = NULL;
+
+  /**
+   * The second formatted_text paragraph used only in the archived node.
+   *
+   * @var \Drupal\paragraphs\Entity\Paragraph|null
+   */
+  private ?Paragraph $archivedParagraph = NULL;
+
+  /**
+   * A restricted user with only 'access content'.
+   *
+   * @var \Drupal\Core\Session\AccountInterface|null
+   */
+  private ?AccountInterface $account = NULL;
+
+  /**
+   * The machine name of the role assigned to the restricted user.
+   *
+   * @var string|false
+   */
+  private string|false $role = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    // --- Step 1: Create the initial formatted_text paragraph. ---
+    // This paragraph will be embedded in the published revision of the node.
+    $paragraph = Paragraph::create([
+      'type' => 'formatted_text',
+    ]);
+    $paragraph->save();
+    $this->paragraph = $paragraph;
+
+    // --- Step 2: Create a press_release node, PUBLISHED, containing the
+    // paragraph.  The editorial workflow sets default_revision = TRUE and
+    // status = TRUE for the "published" moderation state. ---
+    $node = Node::create([
+      'type' => 'press_release',
+      'title' => 'Bug 3090200 test node',
+      'moderation_state' => 'published',
+      'field_press_release_paragraphs' => [
+        [
+          'target_id' => $paragraph->id(),
+          'target_revision_id' => $paragraph->getRevisionId(),
+        ],
+      ],
+    ]);
+    $node->save();
+    $this->node = $node;
+    $this->publishedNodeRevisionId = (int) $node->getRevisionId();
+
+    // Reload the paragraph so we get the current revision ID.
+    // entity_reference_revisions may have created a new paragraph revision
+    // when the parent node was saved (to record the parent_id / parent_type
+    // fields), so we capture the revision ID *after* the node save.
+    $this->paragraph = Paragraph::load($paragraph->id());
+    $this->paragraphRevisionId = (int) $this->paragraph->getRevisionId();
+
+    // --- Step 3: Create a second paragraph used only in the archived node. ---
+    $archivedParagraph = Paragraph::create([
+      'type' => 'formatted_text',
+    ]);
+    $archivedParagraph->save();
+    $this->archivedParagraph = $archivedParagraph;
+
+    // --- Step 4: Archive the node.  This creates a NEW default revision
+    // whose moderation_state is "archived" (status = FALSE, default = TRUE).
+    // The archived revision references $archivedParagraph, not $paragraph. ---
+    $node->setNewRevision(TRUE);
+    $node->set('moderation_state', 'archived');
+    $node->set('field_press_release_paragraphs', [
+      [
+        'target_id' => $archivedParagraph->id(),
+        'target_revision_id' => $archivedParagraph->getRevisionId(),
+      ],
+    ]);
+    $node->save();
+    // Node::load($node->id()) now returns the archived (unpublished) default.
+
+    // --- Step 5: Restricted user (no paragraph-type or unpublished perms). ---
+    $this->role = $this->coreCreateRole(['access content']);
+    $this->account = $this->createUser();
+    $this->account->addRole($this->role);
+    $this->account->save();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sanity checks — these should always pass.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Confirms that the default node revision is now the archived (unpublished)
+   * one.  This is the pre-condition that triggers bug #3090200.
+   */
+  public function testDefaultNodeRevisionIsArchivedAndUnpublished(): void {
+    $defaultNode = Node::load($this->node->id());
+    $this->assertNotNull($defaultNode);
+    $this->assertFalse(
+      $defaultNode->isPublished(),
+      'The default revision of the node must be unpublished (archived state).'
+    );
+    $this->assertNotEquals(
+      $this->publishedNodeRevisionId,
+      (int) $defaultNode->getRevisionId(),
+      'The default revision ID must differ from the published revision ID.'
+    );
+  }
+
+  /**
+   * Confirms that the published node revision still references the paragraph.
+   *
+   * This validates the test setup: resolveAccessHost() (in the fix) must be
+   * able to find the published revision via the paragraph's revision ID.
+   */
+  public function testPublishedRevisionReferencesParagraph(): void {
+    /** @var \Drupal\node\Entity\Node $publishedRevision */
+    $publishedRevision = \Drupal::entityTypeManager()
+      ->getStorage('node')
+      ->loadRevision($this->publishedNodeRevisionId);
+
+    $this->assertNotNull($publishedRevision);
+    $this->assertTrue(
+      $publishedRevision->isPublished(),
+      'The stored published revision must report itself as published.'
+    );
+
+    $referencedRevisionIds = array_column(
+      $publishedRevision->get('field_press_release_paragraphs')->getValue(),
+      'target_revision_id'
+    );
+    $this->assertContains(
+      (string) $this->paragraphRevisionId,
+      $referencedRevisionIds,
+      'The published node revision must reference the paragraph revision ID '
+      . 'stored in setUp().'
+    );
+  }
+
+  /**
+   * Helper to invoke ParagraphAccessControlHandler::checkAccess() directly.
+   *
+   * Bypasses hook_ENTITY_TYPE_access() implementations (notably
+   * paragraphs_type_permissions) so that only the handler's own logic is
+   * tested.
+   *
+   * @param \Drupal\paragraphs\Entity\Paragraph $paragraph
+   *   The paragraph entity to check.
+   * @param string $operation
+   *   The operation ('view', 'update', 'delete').
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The account to check against.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   The raw checkAccess() result before any hooks are applied.
+   */
+  private function invokeCheckAccess(
+    Paragraph $paragraph,
+    string $operation,
+    AccountInterface $account
+  ): AccessResult {
+    $handler = \Drupal::entityTypeManager()
+      ->getAccessControlHandler('paragraph');
+    $method = new \ReflectionMethod($handler, 'checkAccess');
+    $method->setAccessible(TRUE);
+    return $method->invoke($handler, $paragraph, $operation, $account);
+  }
+
+  /**
+   * Regression test for bug #3090200.
+   *
+   * The fix's resolveAccessHost() queries the database for the specific parent
+   * revision that references this paragraph's revision ID.  That revision is
+   * the published one, so checkAccess() must return allowed() even though
+   * getParentEntity() (default-revision load) returns the archived, unpublished
+   * revision.
+   *
+   * @see https://www.drupal.org/project/paragraphs/issues/3090200
+   */
+  public function testCheckAccessAllowsViewWhenDefaultParentIsUnpublished(): void {
+    $paragraph = \Drupal::entityTypeManager()
+      ->getStorage('paragraph')
+      ->loadRevision($this->paragraphRevisionId);
+    $this->assertNotNull($paragraph);
+
+    // Confirm the scenario: getParentEntity() still returns the unpublished
+    // default revision, which is what triggered the original bug.
+    $defaultParent = $paragraph->getParentEntity();
+    $this->assertNotNull($defaultParent);
+    $this->assertFalse(
+      $defaultParent->isPublished(),
+      'getParentEntity() must return the unpublished default revision to '
+      . 'confirm the bug scenario is active.'
+    );
+
+    // Despite the unpublished default parent, checkAccess() must return
+    // allowed() because resolveAccessHost() locates the published revision.
+    $result = $this->invokeCheckAccess($paragraph, 'view', $this->account);
+    $this->assertTrue(
+      $result->isAllowed(),
+      'ParagraphAccessControlHandler::checkAccess() must return allowed() for '
+      . 'a paragraph referenced by a published parent revision, even when the '
+      . 'parent\'s DEFAULT revision is archived/unpublished (#3090200).'
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // tearDown
+  // ---------------------------------------------------------------------------
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tearDown(): void {
+    parent::tearDown();
+
+    if ($this->account !== NULL) {
+      try {
+        $this->account->delete();
+      }
+      catch (\Exception $e) {}
+      $this->account = NULL;
+    }
+
+    if ($this->role !== FALSE) {
+      $role = Role::load($this->role);
+      if ($role !== NULL) {
+        $role->delete();
+      }
+      $this->role = FALSE;
+    }
+
+    // Deleting the node also deletes its revisions and inline entities.
+    if ($this->node !== NULL) {
+      try {
+        $node = \Drupal::entityTypeManager()
+          ->getStorage('node')
+          ->load($this->node->id());
+        if ($node !== NULL) {
+          $node->delete();
+        }
+      }
+      catch (\Exception $e) {}
+      $this->node = NULL;
+    }
+
+    foreach (['paragraph', 'archivedParagraph'] as $prop) {
+      if ($this->$prop !== NULL) {
+        try {
+          $entity = \Drupal::entityTypeManager()
+            ->getStorage('paragraph')
+            ->load($this->$prop->id());
+          if ($entity !== NULL) {
+            $entity->delete();
+          }
+        }
+        catch (\Exception $e) {}
+        $this->$prop = NULL;
+      }
+    }
+
+    $this->paragraphRevisionId = NULL;
+    $this->publishedNodeRevisionId = NULL;
+  }
+
+}


### PR DESCRIPTION
This pull request introduces several configuration and dependency updates to improve caching, module support, and compatibility with newer versions of Drupal core. The most significant changes are grouped below:

**Caching Improvements for Views:**
* Changed the cache type for the `events` and `emergency_notification` views from `tag` to `time`, setting cache lifespans and `max-age` to 3600 seconds to improve performance and cacheability. (`ecms_base/features/custom/ecms_event/config/install/views.view.events.yml` [[1]](diffhunk://#diff-5fb293ac655a744cce25a6a0117a5658e439a4c392bb7f94b35ddb714f019c59L29-R34) [[2]](diffhunk://#diff-5fb293ac655a744cce25a6a0117a5658e439a4c392bb7f94b35ddb714f019c59L290-R294) [[3]](diffhunk://#diff-5fb293ac655a744cce25a6a0117a5658e439a4c392bb7f94b35ddb714f019c59L320-R324) [[4]](diffhunk://#diff-5fb293ac655a744cce25a6a0117a5658e439a4c392bb7f94b35ddb714f019c59L345-R349) [[5]](diffhunk://#diff-5fb293ac655a744cce25a6a0117a5658e439a4c392bb7f94b35ddb714f019c59L363-R367) [[6]](diffhunk://#diff-5fb293ac655a744cce25a6a0117a5658e439a4c392bb7f94b35ddb714f019c59L544-R548); `ecms_base/features/custom/ecms_emergency_notification/config/install/views.view.emergency_notification.yml` [[7]](diffhunk://#diff-cbb768245cd84ed01be3247378f5540cee3a36c362b2afa51284732804ea33feL94-R99) [[8]](diffhunk://#diff-cbb768245cd84ed01be3247378f5540cee3a36c362b2afa51284732804ea33feL200-R204) [[9]](diffhunk://#diff-cbb768245cd84ed01be3247378f5540cee3a36c362b2afa51284732804ea33feL215-R219)

**Module and Dependency Updates:**
* Added the `cache_control_override` module as a dependency in `composer.json` and `ecms_base.info.yml`, and provided an update hook to install it automatically. (`composer.json` [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R106); `ecms_base/ecms_base.info.yml` [[2]](diffhunk://#diff-5d6fb5cc6275c387e9dd790596113adca3aa1e43b18a7c149f74841437a0b18eR16); `ecms_base/ecms_base.install` [[3]](diffhunk://#diff-25fbfdb1af7789d4b0af10a1492c346e2ff5858d1f33693b613390e48664a298R550-R556)

**Drupal Core and Patch Updates:**
* Updated the minimum and matrix versions of `drupal_core` in the GitHub Actions workflow to `~11.3.0` and `^11.4`, and updated the referenced patch for the `paragraphs` module to a newer version. (`.github/workflows/develop.yml` [[1]](diffhunk://#diff-dc1f0538462ec99cd0ba70c1de6c897f03e83c141cd0f3b22659d527a294d9fbL11-R11) [[2]](diffhunk://#diff-dc1f0538462ec99cd0ba70c1de6c897f03e83c141cd0f3b22659d527a294d9fbL26-R28) [[3]](diffhunk://#diff-dc1f0538462ec99cd0ba70c1de6c897f03e83c141cd0f3b22659d527a294d9fbL97-R106); `composer.json` [[4]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L53-R53)

**Configuration Enhancements:**
* Expanded the allowed values for the `field_event_list_limit` field to include options from 6 to 15, giving more flexibility in event list limits. (`ecms_base/features/custom/ecms_event/config/install/field.storage.paragraph.field_event_list_limit.yml` [ecms_base/features/custom/ecms_event/config/install/field.storage.paragraph.field_event_list_limit.ymlR22-R51](diffhunk://#diff-34b6caa8a2326e90f953d2a66bb3ba0c90aff97873e425467a73791288db2bd6R22-R51))

**CI Workflow Improvements:**
* Modified the GitHub Actions workflow to re-enable and target the `ecms_paragraphs` group when running existing site tests, ensuring more focused test coverage. (`.github/workflows/develop.yml` [.github/workflows/develop.ymlL224-R231](diffhunk://#diff-dc1f0538462ec99cd0ba70c1de6c897f03e83c141cd0f3b22659d527a294d9fbL224-R231))