### PR TITLE
Riga 885/webform directory

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -37,7 +37,7 @@ corepack_enable: true
 # php_version: "8.4"  # PHP version to use, "5.6" through "8.5"
 
 # You can explicitly specify the webimage but this
-# is not recommended, as the images are often closely tied to DDEV's' behavior,
+# is not recommended, as the images are often closely tied to DDEV's behavior,
 # so this can break upgrades.
 
 # webimage: <docker_image>
@@ -47,7 +47,7 @@ corepack_enable: true
 # database:
 #   type: <dbtype> # mysql, mariadb, postgres
 #   version: <version> # database version, like "10.11" or "8.0"
-#   MariaDB versions can be 5.5-10.8, 10.11, 11.4, 11.8
+#   MariaDB versions can be 5.5-10.8, 10.11, 11.4, 11.8, 12.3
 #   MySQL versions can be 5.5-8.0, 8.4
 #   PostgreSQL versions can be 9-18
 
@@ -90,7 +90,7 @@ corepack_enable: true
 # composer_version: "2"
 # You can set it to "" or "2" (default) for Composer v2
 # to use the latest major version available at the time your container is built.
-# It is also possible to use each other Composer version channel. This includes:
+# It is also possible to use any other Composer version channel. This includes:
 #   - 2.2 (latest Composer LTS version)
 #   - stable
 #   - preview
@@ -276,7 +276,7 @@ corepack_enable: true
 # override_config: false
 # By default, config.*.yaml files are *merged* into the configuration
 # But this means that some things can't be overridden
-# For example, if you have 'use_dns_when_possible: true'' you can't override it with a merge
+# For example, if you have 'use_dns_when_possible: true' you can't override it with a merge
 # and you can't erase existing hooks or all environment variables.
 # However, with "override_config: true" in a particular config.*.yaml file,
 # 'use_dns_when_possible: false' can override the existing values, and
@@ -286,7 +286,7 @@ corepack_enable: true
 # web_environment: []
 # or
 # additional_hostnames: []
-# can have their intended affect. 'override_config' affects only behavior of the
+# can have their intended effect. 'override_config' affects only behavior of the
 # config.*.yaml file it exists in.
 
 # Many DDEV commands can be extended to run tasks before or after the

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -13,6 +13,7 @@ declare(strict_types=1);
  */
 
 use Drupal\Core\Batch\BatchBuilder;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Recipe\Recipe;
 use Drupal\Core\Recipe\RecipeRunner;
 use Drupal\shortcut\Entity\Shortcut;
@@ -69,6 +70,8 @@ function ecms_base_install() {
   $config->set('mail', 'ecms@notification.ri.gov');
   $config->save();
 
+  // Create the directory webform writes its exports to.
+  ecms_base_prepare_webform_export_directory();
 }
 
 /**
@@ -184,6 +187,44 @@ function ecms_base_apply_workflows() {
       $workflowBundleCreate->addTaxonomyTypePermissions($taxonomy);
     }
   }
+}
+
+/**
+ * Ensure the webform submission export directory exists and is writable.
+ *
+ * Webform passes its export directory straight to fopen() without creating it
+ * first, so exporting to a missing directory fails with a stream of
+ * "fwrite(): Argument #1 must be of type resource, bool given" errors. The
+ * directory lives in the private file system so that a batched export can be
+ * resumed by any node in the ACSF cluster.
+ *
+ * Every site in the factory uses the same location, so this deliberately does
+ * not read webform's configuration: the directory can be created before
+ * webform itself is installed, and the settings override that points webform
+ * at this directory resolves to the same path on disk.
+ *
+ * @return bool
+ *   TRUE if the directory exists and is writable, FALSE otherwise.
+ *
+ * @see \Drupal\webform\Plugin\WebformExporter\FileHandleTraitWebformExporter::createExport()
+ * @see \Drupal\webform\Plugin\WebformExporterBase::getExportFilePath()
+ */
+function ecms_base_prepare_webform_export_directory(): bool {
+  $directory = 'private://webform_exports';
+
+  $prepared = \Drupal::service('file_system')->prepareDirectory(
+    $directory,
+    FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS
+  );
+
+  if (!$prepared) {
+    \Drupal::logger('ecms_base')->error(
+      'Unable to create the webform export directory at @directory. Webform submission exports will fail until it exists and is writable.',
+      ['@directory' => $directory]
+    );
+  }
+
+  return $prepared;
 }
 
 /**
@@ -647,4 +688,17 @@ function ecms_base_update_11219(): void {
   ]);
 
   $config->save(TRUE);
+}
+
+/**
+ * Create the webform submission export directory on existing sites.
+ */
+function ecms_base_update_11220(): string {
+  if (ecms_base_prepare_webform_export_directory()) {
+    return (string) t('Webform exports will be written to @directory.', [
+      '@directory' => \Drupal::service('file_system')->realpath('private://webform_exports'),
+    ]);
+  }
+
+  return (string) t('The webform export directory could not be created. Submission exports will fail on this site until private://webform_exports exists and is writable by the web server.');
 }

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -48,6 +48,8 @@ ddev exec 'rm -Rf develop'
 
 # Create the Drupal project.
 ddev exec "composer create-project drupal/recommended-project:${DRUPAL_CORE} develop --no-install"
+# Create the private file directory.
+ddev exec 'mkdir -p develop/private'
 # Delete the lock file to add the profile's dependencies.
 ddev exec 'rm -f develop/composer.lock'
 
@@ -99,6 +101,9 @@ $DDEV_CONFIG
 
 ## Add MySQL 57 settings requirement to the default prior to site install.
 ddev exec 'echo "require DRUPAL_ROOT . \"/modules/contrib/mysql57/settings.inc\";" >> $DDEV_DOCROOT/sites/default/settings.ddev.php'
+
+## Set the private file path.
+ddev exec 'chmod +w develop/web/sites/default develop/web/sites/default/settings.php && echo "\$settings['\''file_private_path'\''] = '\''../private'\'';" >> develop/web/sites/default/settings.php'
 
 ## Install the site profile.
 ddev exec 'drush site:install ecms_base --yes'


### PR DESCRIPTION
This pull request introduces several improvements to ensure the proper handling of the private file directory used for webform exports in Drupal, both for new installs and existing sites. It adds logic to create and validate the export directory, updates installation and update hooks, and enhances the development setup script to configure the private file path. Additionally, there are minor documentation corrections in the DDEV configuration file.

**Webform export directory management:**

* Added the function `ecms_base_prepare_webform_export_directory()` in `ecms_base.install` to ensure the `private://webform_exports` directory exists and is writable, logging an error if it cannot be created. This prevents webform export failures due to missing directories.
* Modified `ecms_base_install()` to call `ecms_base_prepare_webform_export_directory()` during site installation, ensuring the export directory is available from the start.
* Introduced update hook `ecms_base_update_11220()` to create the export directory on existing sites and return a status message, ensuring backward compatibility.

**Development environment setup:**

* Updated `scripts/develop.sh` to create the `develop/private` directory and set the `file_private_path` in `settings.php`, ensuring the private file system is configured correctly for local development. [[1]](diffhunk://#diff-8539668e211a0923c7f7cda23c3c8a977cf2025f59977659ddf9b3356a30b735R51-R52) [[2]](diffhunk://#diff-8539668e211a0923c7f7cda23c3c8a977cf2025f59977659ddf9b3356a30b735R105-R107)

**Documentation and configuration improvements:**

* Fixed typos and clarified comments in `.ddev/config.yaml`, including updating supported MariaDB versions and correcting language for composer version and config overrides. [[1]](diffhunk://#diff-ca25b57a32546d43021f7de9e5374004e498a3cc2ec9b4be3c820daa1e896e57L40-R40) [[2]](diffhunk://#diff-ca25b57a32546d43021f7de9e5374004e498a3cc2ec9b4be3c820daa1e896e57L50-R50) [[3]](diffhunk://#diff-ca25b57a32546d43021f7de9e5374004e498a3cc2ec9b4be3c820daa1e896e57L93-R93) [[4]](diffhunk://#diff-ca25b57a32546d43021f7de9e5374004e498a3cc2ec9b4be3c820daa1e896e57L279-R279) [[5]](diffhunk://#diff-ca25b57a32546d43021f7de9e5374004e498a3cc2ec9b4be3c820daa1e896e57L289-R289)

[RIGA-885](https://thinkoomph.jira.com/browse/RIGA-885)