### PR TITLE
Focus and keyboard navigation remediations

### DIFF
--- a/ecms_base/themes/custom/ecms/assets/data/color-config.hjson
+++ b/ecms_base/themes/custom/ecms/assets/data/color-config.hjson
@@ -526,6 +526,12 @@
           { "fnName": "icon__fg--hover", "colorName": "navy" }
         ],
         "default": [
+          # Two-tone keyboard focus indicator (RIGA-891)
+          # Ring + halo always contrast with each other, so the pair is
+          # visible on ANY background color. Light palettes: near-black
+          # ring with a white halo. Dark palettes: the inverse.
+          { "fnName": "focus__ring", "colorName": "quahog--darker" },
+          { "fnName": "focus__halo", "colorName": "white" },
           { "fnName": "fg", "colorName": "quahog" },
           { "fnName": "bg", "colorName": "white" },
           { "fnName": "overlay__bg", "colorName": "white--trans75" },
@@ -719,6 +725,9 @@
           { "fnName": "icon__fg--hover", "colorName": "navy--dark" }
         ],
         "default": [
+          # Two-tone focus pair, inverted for dark mode (RIGA-891)
+          { "fnName": "focus__ring", "colorName": "white" },
+          { "fnName": "focus__halo", "colorName": "quahog--darker" },
           { "fnName": "fg", "colorName": "coffee-milk--light" },
           { "fnName": "bg", "colorName": "quahog--dark" },
           { "fnName": "overlay__bg", "colorName": "quahog--dark--trans75" },
@@ -861,6 +870,8 @@
           { "fnName": "icon__fg--hover", "colorName": "quahog--darker" }
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "quahog--darker" },
+          { "fnName": "focus__halo", "colorName": "white" },
           #{ "fnName": "fg", "colorName": "quahog" },
           { "fnName": "bg", "colorName": "white" },
           { "fnName": "overlay__bg", "colorName": "white--trans75" },
@@ -999,6 +1010,8 @@
           { "fnName": "icon__fg--hover", "colorName": "quahog--dark" }
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "white" },
+          { "fnName": "focus__halo", "colorName": "quahog--darker" },
           #{ "fnName": "fg", "colorName": "coffee-milk--light" },
           { "fnName": "bg", "colorName": "quahog--dark" },
           { "fnName": "overlay__bg", "colorName": "quahog--dark--trans75" },
@@ -1119,6 +1132,8 @@
           { "fnName": "icon__fg--hover", "colorName": "white" }
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "quahog--darker" },
+          { "fnName": "focus__halo", "colorName": "white" },
           #{ "fnName": "fg", "colorName": "quahog" },
           { "fnName": "bg", "colorName": "white" },
           { "fnName": "overlay__bg", "colorName": "white--trans75" },
@@ -1251,6 +1266,8 @@
           { "fnName": "icon__fg--hover", "colorName": "quahog--darker" }
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "white" },
+          { "fnName": "focus__halo", "colorName": "quahog--darker" },
           { "fnName": "fg", "colorName": "coffee-milk--light" },
           { "fnName": "bg", "colorName": "quahog--dark" },
           { "fnName": "overlay__bg", "colorName": "quahog--dark--trans75" },
@@ -1375,6 +1392,8 @@
           #{ "fnName": "icon__fg--hover", "colorName": "navy" }
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "quahog--darker" },
+          { "fnName": "focus__halo", "colorName": "white" },
           { "fnName": "fg", "colorName": "quahog" },
           { "fnName": "bg", "colorName": "white" },
           { "fnName": "overlay__bg", "colorName": "white--trans75" },
@@ -1510,6 +1529,8 @@
           { "fnName": "icon__fg--hover", "colorName": "navy" }
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "white" },
+          { "fnName": "focus__halo", "colorName": "quahog--darker" },
           { "fnName": "fg", "colorName": "coffee-milk--light" },
           { "fnName": "bg", "colorName": "quahog--dark" },
           { "fnName": "overlay__bg", "colorName": "quahog--dark--trans75" },
@@ -1636,6 +1657,8 @@
           { "fnName": "icon__fg--hover", "colorName": "quahog--dark" }
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "quahog--darker" },
+          { "fnName": "focus__halo", "colorName": "white" },
           #{ "fnName": "fg", "colorName": "quahog" },
           #{ "fnName": "bg", "colorName": "white" },
           { "fnName": "overlay__bg", "colorName": "white--trans75" },
@@ -1766,6 +1789,8 @@
           { "fnName": "icon__fg--hover", "colorName": "quahog--dark" }
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "white" },
+          { "fnName": "focus__halo", "colorName": "quahog--darker" },
           { "fnName": "fg", "colorName": "coffee-milk--light" },
           { "fnName": "bg", "colorName": "quahog--dark" },
           { "fnName": "overlay__bg", "colorName": "quahog--dark--trans75" },
@@ -1887,6 +1912,8 @@
           { "fnName": "icon__fg--hover", "colorName": "quahog--dark" }
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "quahog--darker" },
+          { "fnName": "focus__halo", "colorName": "white" },
           #{ "fnName": "fg", "colorName": "quahog" },
           #{ "fnName": "bg", "colorName": "white" },
           { "fnName": "overlay__bg", "colorName": "white--trans75" },
@@ -2016,6 +2043,8 @@
           { "fnName": "icon__fg--hover", "colorName": "quahog--dark" }
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "white" },
+          { "fnName": "focus__halo", "colorName": "quahog--darker" },
           { "fnName": "fg", "colorName": "coffee-milk--light" },
           { "fnName": "bg", "colorName": "quahog--dark" },
           { "fnName": "overlay__bg", "colorName": "quahog--dark--trans75" },
@@ -2142,6 +2171,8 @@
           { "fnName": "icon__fg--hover", "colorName": "quahog--dark" }
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "quahog--darker" },
+          { "fnName": "focus__halo", "colorName": "white" },
           #{ "fnName": "fg", "colorName": "quahog" },
           #{ "fnName": "bg", "colorName": "white" },
           { "fnName": "overlay__bg", "colorName": "white--trans75" },
@@ -2276,6 +2307,8 @@
           { "fnName": "icon__fg--hover", "colorName": "quahog--dark" }
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "white" },
+          { "fnName": "focus__halo", "colorName": "quahog--darker" },
           { "fnName": "fg", "colorName": "coffee-milk--light" },
           { "fnName": "bg", "colorName": "quahog--dark" },
           { "fnName": "overlay__bg", "colorName": "quahog--dark--trans75" },
@@ -2400,6 +2433,8 @@
           { "fnName": "icon__fg--hover", "colorName": "navy" },
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "quahog--darker" },
+          { "fnName": "focus__halo", "colorName": "white" },
           { "fnName": "fg", "colorName": "quahog" },
           { "fnName": "bg", "colorName": "white" },
           { "fnName": "overlay__bg", "colorName": "white--trans75" },
@@ -2569,6 +2604,8 @@
           #{ "fnName": "icon__fg--hover", "colorName": "navy" }
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "quahog--darker" },
+          { "fnName": "focus__halo", "colorName": "white" },
           { "fnName": "fg", "colorName": "navy" },
           #{ "fnName": "bg", "colorName": "white" },
           #{ "fnName": "overlay__bg", "colorName": "white--trans75" },
@@ -2722,6 +2759,8 @@
           { "fnName": "icon__fg--hover", "colorName": "navy--dark" }
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "white" },
+          { "fnName": "focus__halo", "colorName": "quahog--darker" },
           { "fnName": "fg", "colorName": "coffee-milk--light" },
           { "fnName": "bg", "colorName": "quahog--dark" },
           { "fnName": "overlay__bg", "colorName": "quahog--dark--trans75" },
@@ -2862,6 +2901,8 @@
           { "fnName": "icon__fg--hover", "colorName": "navy--dark" }
         ],
         "default": [
+          { "fnName": "focus__ring", "colorName": "white" },
+          { "fnName": "focus__halo", "colorName": "quahog--darker" },
           { "fnName": "fg", "colorName": "coffee-milk--light" },
           { "fnName": "bg", "colorName": "quahog--dark" },
           { "fnName": "overlay__bg", "colorName": "quahog--dark--trans75" },

--- a/ecms_base/themes/custom/ecms/assets/patterns/00-atoms/00-base/_mixins.scss
+++ b/ecms_base/themes/custom/ecms/assets/patterns/00-atoms/00-base/_mixins.scss
@@ -57,6 +57,28 @@
   }
 }
 
+// Two-tone keyboard focus indicator (RIGA-891)
+// Consumes the palette-emitted pair (focus__ring / focus__halo in
+// color-config.hjson). Ring and halo always contrast strongly with each
+// other, so the indicator is visible on any background color in light and
+// dark mode — no per-region focus color tuning needed. Apply on
+// :focus-visible only; the :focus:not(:focus-visible) reset in _00-html.scss
+// keeps mouse focus quiet.
+@mixin qh-focus-ring() {
+  box-shadow: 0 0 0 rem(4) var(--fc__default__focus__halo);
+  outline: rem(2) solid var(--fc__default__focus__ring);
+  outline-offset: 0;
+}
+
+// Inset variant for elements inside clipping containers (nav bars, drawers,
+// accordion lists with overflow: hidden) where an outward ring would be cut
+// off: halo band inside the edge, ring inside the halo.
+@mixin qh-focus-ring--inset() {
+  box-shadow: inset 0 0 0 rem(4) var(--fc__default__focus__halo);
+  outline: rem(2) solid var(--fc__default__focus__ring);
+  outline-offset: rem(-4);
+}
+
 @mixin qh-fw-bold() {
   font-weight: bold;
 

--- a/ecms_base/themes/custom/ecms/assets/patterns/00-atoms/01-global/_00-html.scss
+++ b/ecms_base/themes/custom/ecms/assets/patterns/00-atoms/01-global/_00-html.scss
@@ -33,6 +33,13 @@ nav ol {
   @include qh-list-reset;
 }
 
+// Two-tone keyboard focus indicator (RIGA-891): a ring + halo pair emitted
+// per palette, visible on any background in light and dark mode. This is the
+// catch-all; components inside clipping containers re-apply the inset variant.
+:focus-visible {
+  @include qh-focus-ring;
+}
+
 // Remove visible focus for mouse users only
 :focus:not(:focus-visible) {
   border: 0;
@@ -45,6 +52,7 @@ nav ol {
   Credit: https://github.com/suitcss/base
   */
 [tabindex='-1']:focus {
+  box-shadow: none !important; // also suppress the qh-focus-ring halo
   outline: 0 !important;
 }
 

--- a/ecms_base/themes/custom/ecms/assets/patterns/00-atoms/02-text/_01-links.scss
+++ b/ecms_base/themes/custom/ecms/assets/patterns/00-atoms/02-text/_01-links.scss
@@ -17,10 +17,9 @@ a {
     color: var(--computed-link-color--hover, var(--fc__default__link--hover));
   }
 
-  // Global keyboard focus style
-  &:focus {
-    outline: $border-sm solid var(--computed-link-color--hover, var(--fc__default__link--focus));
-    outline-offset: $border-sm;
+  // Global keyboard focus style: two-tone ring, visible on any background
+  &:focus-visible {
+    @include qh-focus-ring;
   }
 
   // :visited and :active reuse the theme's base link color since no theme
@@ -127,6 +126,10 @@ dd {
 
   &:focus {
     color: var(--fc__default__link--hover);
-    outline-offset: - ($border-sm * 2);
+  }
+
+  // Sits at the very top edge of the viewport, so keep the ring inset
+  &:focus-visible {
+    @include qh-focus-ring--inset;
   }
 }

--- a/ecms_base/themes/custom/ecms/assets/patterns/00-atoms/05-forms/_00-forms.scss
+++ b/ecms_base/themes/custom/ecms/assets/patterns/00-atoms/05-forms/_00-forms.scss
@@ -60,8 +60,10 @@ select {
   }
 
   &:focus {
+    // Border color change stays as an enhancement; the keyboard focus ring
+    // now comes from the global two-tone :focus-visible mechanism (RIGA-891),
+    // so no longer suppress the outline here.
     border-color: var(--fc__default__violator);
-    outline: 0;
   }
 
   // Spacing from label elements
@@ -266,16 +268,10 @@ input[type="range"] {
         @include range-thumb;
       }
 
-      &:focus {
-        outline: $border-sm solid var(--fc__official__link--focus, currentColor);
-        outline-offset: ($border-sm * 2);
+      &:focus-visible {
+        @include qh-focus-ring;
       }
 
-      // Repeating… because "focus-within" will break IE11 and invalidate the entire block
-      &:focus-within {
-        outline: $border-sm solid var(--fc__official__link--focus, currentColor);
-        outline-offset: ($border-sm * 2);
-      }
     }
   }
 }

--- a/ecms_base/themes/custom/ecms/assets/patterns/00-atoms/06-buttons/_00-buttons.scss
+++ b/ecms_base/themes/custom/ecms/assets/patterns/00-atoms/06-buttons/_00-buttons.scss
@@ -47,9 +47,8 @@ button,
     color: var(--fc__default__button--hover__fg);
   }
 
-  &:focus {
-    outline: $border-sm solid var(--fc__default__link--focus);
-    outline-offset: $border-sm;
+  &:focus-visible {
+    @include qh-focus-ring;
   }
 
   &:disabled {

--- a/ecms_base/themes/custom/ecms/assets/patterns/01-molecules/accordion/_accordion.scss
+++ b/ecms_base/themes/custom/ecms/assets/patterns/01-molecules/accordion/_accordion.scss
@@ -38,7 +38,6 @@
     display: block;
     font-weight: calc(var(--p-font-wght) * 1.25);
     max-width: none;
-    outline: none;
     padding: $nav-a-v-spacing $nav-a-h-spacing;
     text-align: left;
     transition: $transition-base;
@@ -51,12 +50,11 @@
       color: var(--fc__default__fg);
     }
 
-    // Accordion titles are required to look focused
-    &:focus {
-      .qh__accordion__button__summary {
-        outline: $border-sm solid var(--fc__default__link--focus);
-        outline-offset: 3px;
-      }
+    // Accordion titles are required to look focused. Inset two-tone ring on
+    // the button itself (accordions also render inside the section menu's
+    // overflow-clipped list) — RIGA-891.
+    &:focus-visible {
+      @include qh-focus-ring--inset;
     }
 
     &__summary {
@@ -114,7 +112,11 @@
       max-height: 0;
       overflow: hidden;
       padding-inline: $general-h-spacing;
-      transition: max-height 250ms ease-in-out 250ms, padding 500ms ease-in-out 0ms, visibility 0s linear 500s;
+      // visibility delay waits for the max-height collapse (250 + 250ms) to
+      // finish. Was `500s` — a typo that left collapsed panels focusable for
+      // ~8 minutes (RIGA-891); expand-collapse.js also sets `inert` so links
+      // leave the tab order immediately.
+      transition: max-height 250ms ease-in-out 250ms, padding 500ms ease-in-out 0ms, visibility 0s linear 500ms;
       visibility: hidden;
 
       > div {
@@ -140,7 +142,7 @@
       .js & {
         height: calc-size(auto);
         max-height: unset;
-        transition: height 500ms ease-in-out 0ms, padding 500ms ease-in-out 0ms, visibility 0s linear 500s;
+        transition: height 500ms ease-in-out 0ms, padding 500ms ease-in-out 0ms, visibility 0s linear 500ms;
       }
 
       .js [aria-expanded='true'] + & {

--- a/ecms_base/themes/custom/ecms/assets/patterns/01-molecules/pagination-prev-next/_pagination.scss
+++ b/ecms_base/themes/custom/ecms/assets/patterns/01-molecules/pagination-prev-next/_pagination.scss
@@ -63,8 +63,7 @@ $_nav: '.qh__pagination__link--first, .qh__pagination__link--prev, .qh__paginati
       }
 
       &:focus-visible {
-        outline: 2px solid var(--c__navy, #293557);
-        outline-offset: 2px;
+        @include qh-focus-ring;
       }
     }
 
@@ -107,8 +106,7 @@ $_nav: '.qh__pagination__link--first, .qh__pagination__link--prev, .qh__paginati
       }
 
       &:focus-visible {
-        outline: 2px solid var(--c__navy, #293557);
-        outline-offset: -2px;
+        @include qh-focus-ring--inset;
         z-index: 2;
       }
 

--- a/ecms_base/themes/custom/ecms/assets/patterns/02-organisms/global-header/_global-header.scss
+++ b/ecms_base/themes/custom/ecms/assets/patterns/02-organisms/global-header/_global-header.scss
@@ -56,9 +56,7 @@
       color: var(--fc__official__link--hover);
       text-decoration: underline;
     }
-
-    &:focus {
-      outline-color: var(--fc__official__link--focus);
-    }
+    // Keyboard focus ring comes from the global two-tone :focus-visible
+    // mechanism (RIGA-891) — no per-region outline color override.
   }
 }

--- a/ecms_base/themes/custom/ecms/assets/patterns/02-organisms/page-footer/_page-footer.scss
+++ b/ecms_base/themes/custom/ecms/assets/patterns/02-organisms/page-footer/_page-footer.scss
@@ -74,9 +74,15 @@ $qh__footer-wave-height: calc(100vw * 88 / 1440);
     align-items: center;
     min-height: rem(48);
 
-    &:hover,
-    &:focus {
+    &:hover {
       text-decoration: none;
+      color: var(--fc__footer__fg);
+    }
+
+    // Keep the underline on keyboard focus (RIGA-891): dropping it removed
+    // the only focus cue the footer had. The ring itself comes from the
+    // global two-tone :focus-visible mechanism.
+    &:focus {
       color: var(--fc__footer__fg);
     }
 

--- a/ecms_base/themes/custom/ecms/assets/patterns/02-organisms/page-header/_page-header.scss
+++ b/ecms_base/themes/custom/ecms/assets/patterns/02-organisms/page-header/_page-header.scss
@@ -31,10 +31,8 @@
       &:active {
         color: var(--fc__header__link--hover);
       }
-
-      &:focus {
-        outline-color: var(--fc__header__link);
-      }
+      // Keyboard focus ring comes from the global two-tone :focus-visible
+      // mechanism (RIGA-891) — no per-region outline color override.
     }
   }
 

--- a/ecms_base/themes/custom/ecms/assets/patterns/03-templates/00-layout/_layout-section.scss
+++ b/ecms_base/themes/custom/ecms/assets/patterns/03-templates/00-layout/_layout-section.scss
@@ -233,8 +233,14 @@
 
   // Column elements
   &__col {
+    // flow-root + min-width keep what `overflow: auto` provided — float
+    // containment (rich-text images) and the flex item's ability to shrink
+    // below its content width — without clipping the keyboard focus
+    // ring + halo on links flush with the column edge (RIGA-891). Wide
+    // tables scroll via their own .qh__table-container.
+    display: flow-root;
     margin-bottom: $general-v-spacing;
-    overflow: auto;
+    min-width: 0;
 
     .block:first-child:last-child {
       display: flex;

--- a/ecms_base/themes/custom/ecms/assets/scripts/expand-collapse.js
+++ b/ecms_base/themes/custom/ecms/assets/scripts/expand-collapse.js
@@ -35,6 +35,28 @@
   Drupal.behaviors.ecmsExpandCollapse = {
     attach: function (context) {
       once('ecms-expand-collapse', '.js__expand-collapse', context).forEach(function (toggle_element) {
+
+        // Keep collapsed panels out of the keyboard tab order and the a11y
+        // tree (RIGA-891). The CSS hides them visually (max-height +
+        // visibility), but `inert` removes the whole subtree from focus
+        // immediately, regardless of transitions. Same pattern as facets.js.
+        // Driving it from JS keeps no-JS users — whose panels are open via
+        // the .no-js CSS fallback — from being locked out.
+        function syncInert() {
+          var target_element = document.getElementById(toggle_element.getAttribute('aria-controls'));
+          if (target_element === null) {
+            return;
+          }
+          if (toggle_element.getAttribute('aria-expanded') === 'true') {
+            target_element.removeAttribute('inert');
+          } else {
+            target_element.setAttribute('inert', '');
+          }
+        }
+
+        // Match the server-rendered initial aria-expanded state.
+        syncInert();
+
         toggle_element.addEventListener('click', function (event) {
           event.preventDefault();
           if (a11yClick(event) === true) {
@@ -49,6 +71,8 @@
               toggle_element.setAttribute('aria-expanded', 'true');
               target_element.classList.add('js__aria-expanded');
             }
+
+            syncInert();
 
             toggle_element.dispatchEvent(new CustomEvent('ecms:expand-collapse', {
               bubbles: true,

--- a/ecms_base/themes/custom/ecms/assets/scripts/global.js
+++ b/ecms_base/themes/custom/ecms/assets/scripts/global.js
@@ -37,10 +37,22 @@ function allMenuCloser() {
     qh_toggle_btn.setAttribute('aria-expanded', 'false');
   }
 
+  // Close any open primary-nav drop downs (RIGA-891 — these were previously
+  // left open by this closer)
+  document.querySelectorAll('.js__qh-dd-toggle[aria-expanded="true"]').forEach(function (dd_toggle) {
+    dd_toggle.setAttribute('aria-expanded', 'false');
+  });
+
   // Close sidebar nav
   var qh_nav_minor = document.getElementById('js__minor-menu');
   if (qh_nav_minor !== null) {
     qh_nav_minor.classList.remove('qh__nav-minor--expanded');
+  }
+
+  // Keep the sidebar nav toggle's ARIA state in sync (RIGA-891)
+  var qh_minor_toggle = document.getElementById('js__minor-toggle');
+  if (qh_minor_toggle !== null) {
+    qh_minor_toggle.setAttribute('aria-expanded', 'false');
   }
 
   // Close settings nav
@@ -60,6 +72,42 @@ function allMenuCloser() {
   if (qh_gtranslate_btn !== null) {
     qh_gtranslate_btn.setAttribute('aria-expanded', 'false');
   }
+}
+
+// Close a menu when keyboard focus leaves it, and on Escape (RIGA-891).
+// Menus previously stayed open when a keyboard user tabbed past them, leaving
+// an expanded panel floating over the page with no way to dismiss it.
+//
+// container - element wrapping BOTH the toggle and the panel (focus moving
+//             between them must not count as leaving)
+// toggle    - the button that opens the menu; receives focus again on Escape
+// isOpen    - function returning whether the menu is currently open; nothing
+//             happens while closed (so Escape elsewhere never steals focus)
+// closeFn   - function that actually closes the menu
+function qhMenuFocusDismiss(container, toggle, isOpen, closeFn) {
+  if (container === null || container === undefined) {
+    return;
+  }
+
+  container.addEventListener('focusout', function (event) {
+    // relatedTarget is null when focus leaves the document (e.g. window blur);
+    // keep the menu open in that case.
+    if (isOpen() && event.relatedTarget !== null && !container.contains(event.relatedTarget)) {
+      closeFn();
+    }
+  });
+
+  container.addEventListener('keydown', function (event) {
+    if ((event.key === 'Escape' || event.key === 'Esc') && isOpen()) {
+      // Only close the innermost open menu (e.g. a drop down inside the
+      // mobile drawer) — a second Escape closes the next level up.
+      event.stopPropagation();
+      closeFn();
+      if (toggle !== null && toggle !== undefined) {
+        toggle.focus();
+      }
+    }
+  });
 }
 
 // Add screen overlay

--- a/ecms_base/themes/custom/ecms/assets/scripts/page-init.js
+++ b/ecms_base/themes/custom/ecms/assets/scripts/page-init.js
@@ -25,6 +25,21 @@
       once('ecms-page-overlay', 'body', context).forEach(function () {
         addPageOverlay();
       });
+
+      // Publish half the scrollbar width as a custom property. vw units
+      // include the scrollbar but the page grid centers inside the
+      // scrollbar-less width, so any CSS that mirrors the page gutter with
+      // 3.5vw (e.g. the section-menu edge tab in _navigation-minor.scss)
+      // overshoots by this much when classic scrollbars are on. 0 for
+      // overlay scrollbars, so the CSS fallback of 0px matches no-JS.
+      once('ecms-scrollbar-comp', 'html', context).forEach(function (html) {
+        function setScrollbarComp() {
+          var comp = (window.innerWidth - html.clientWidth) / 2;
+          html.style.setProperty('--qh-scrollbar-comp', comp + 'px');
+        }
+        setScrollbarComp();
+        window.addEventListener('resize', setScrollbarComp);
+      });
     }
   };
 })(Drupal, once);

--- a/ecms_base/themes/custom/ecms/components/01-molecules/gtranslate/gtranslate.js
+++ b/ecms_base/themes/custom/ecms/components/01-molecules/gtranslate/gtranslate.js
@@ -34,6 +34,21 @@
           }
         });
 
+        // Close the language popup when keyboard focus leaves it or on
+        // Escape (RIGA-891). The parent wrapper contains both the toggle and
+        // the popup list.
+        qhMenuFocusDismiss(
+          qh_gtranslate_btn.parentElement,
+          qh_gtranslate_btn,
+          function () {
+            return qh_gtranslate_btn.getAttribute("aria-expanded") === "true";
+          },
+          function () {
+            qh_gtranslate_btn.setAttribute("aria-expanded", "false");
+            deactivatePageOverlay();
+          }
+        );
+
         // Close popup when a language is selected.
         if (qh_gtranslate_list !== null && qh_gtranslate_list !== undefined) {
           // Listen for clicks on quick language links

--- a/ecms_base/themes/custom/ecms/components/01-molecules/social-links/_social-links.scss
+++ b/ecms_base/themes/custom/ecms/components/01-molecules/social-links/_social-links.scss
@@ -22,9 +22,10 @@
       color: var(--fc__header__social__link--hover);
     }
 
-    &:focus {
-      outline: $border-sm solid var(--fc__default__link--focus);
-      outline-offset: - $border-sm;
+    // Two-tone ring (RIGA-891): the old navy ring was invisible on the navy
+    // header. The hover/focus color swap above stays as an enhancement only.
+    &:focus-visible {
+      @include qh-focus-ring;
     }
 
     &:active {

--- a/ecms_base/themes/custom/ecms/components/01-molecules/user-settings/_user-settings.scss
+++ b/ecms_base/themes/custom/ecms/components/01-molecules/user-settings/_user-settings.scss
@@ -193,10 +193,8 @@
       &:focus {
         color: var(--fc__official__link--hover);
       }
-
-      &:focus {
-        outline-color: var(--fc__official__link);
-      }
+      // Keyboard focus ring comes from the global two-tone :focus-visible
+      // mechanism (RIGA-891) — no per-region outline color override.
     }
 
     // specifically the language menu <ul>

--- a/ecms_base/themes/custom/ecms/components/01-molecules/user-settings/user-settings.js
+++ b/ecms_base/themes/custom/ecms/components/01-molecules/user-settings/user-settings.js
@@ -91,6 +91,21 @@
           }
         });
 
+        // Close the settings menu when keyboard focus leaves it or on Escape
+        // (RIGA-891). The parent wrapper contains both the toggle and the
+        // panel list.
+        qhMenuFocusDismiss(
+          qh_usersettings_btn.parentElement,
+          qh_usersettings_btn,
+          function () {
+            return qh_usersettings_btn.getAttribute('aria-expanded') === 'true';
+          },
+          function () {
+            qh_usersettings_btn.setAttribute('aria-expanded', 'false');
+            deactivatePageOverlay();
+          }
+        );
+
         // Language toggle.
         var qh_userlanguage_btn = document.getElementById('js__user-language__toggle');
         if (qh_userlanguage_btn !== null && qh_userlanguage_btn !== undefined) {
@@ -108,6 +123,20 @@
               }
             }
           });
+
+          // Close the language menu when keyboard focus leaves it or on
+          // Escape (RIGA-891).
+          qhMenuFocusDismiss(
+            qh_userlanguage_btn.parentElement,
+            qh_userlanguage_btn,
+            function () {
+              return qh_userlanguage_btn.getAttribute('aria-expanded') === 'true';
+            },
+            function () {
+              qh_userlanguage_btn.setAttribute('aria-expanded', 'false');
+              deactivatePageOverlay();
+            }
+          );
         }
 
         // Light mode settings

--- a/ecms_base/themes/custom/ecms/components/02-organisms/navigation-main/_navigation-main.scss
+++ b/ecms_base/themes/custom/ecms/components/02-organisms/navigation-main/_navigation-main.scss
@@ -469,9 +469,11 @@ body {
       // See lines above that group the LI:hover with the A:hover
     }
 
-    &:focus {
-      outline-color: var(--fc__nav-main__link--focus);
-      outline-offset: -2px;
+    // Two-tone ring, inset because the nav bar/drawer clip overflow.
+    // The white hover/focus bg swap above is now an enhancement only —
+    // the ring carries the focus indication (RIGA-891).
+    &:focus-visible {
+      @include qh-focus-ring--inset;
     }
 
     &:active {
@@ -676,9 +678,8 @@ body {
       color: var(--fc__default__link--hover);
     }
 
-    &:focus {
-      outline-color: var(--fc__default__link--focus);
-      outline-offset: $border-sm;
+    &:focus-visible {
+      @include qh-focus-ring;
     }
 
     // Constrain the arrow/external icon — the global qh__icon is em(40) which

--- a/ecms_base/themes/custom/ecms/components/02-organisms/navigation-main/navigation-main.js
+++ b/ecms_base/themes/custom/ecms/components/02-organisms/navigation-main/navigation-main.js
@@ -172,6 +172,22 @@ function moveSearchAndSocial() {
             }
           }
         });
+
+        // Close the drawer when keyboard focus leaves it or on Escape
+        // (RIGA-891). The parent wrapper contains both the toggle and the
+        // drawer list.
+        qhMenuFocusDismiss(
+          qh_toggle_btn.parentElement,
+          qh_toggle_btn,
+          function () {
+            return qh_toggle_btn.getAttribute('aria-expanded') === 'true';
+          },
+          function () {
+            qh_toggle_btn.setAttribute('aria-expanded', 'false');
+            qh_toggle_btn.parentElement.classList.remove('open');
+            deactivatePageOverlay();
+          }
+        );
       });
 
 
@@ -195,6 +211,20 @@ function moveSearchAndSocial() {
             }
           }
         });
+
+        // Close the drop down when keyboard focus leaves it or on Escape
+        // (RIGA-891). The parent <li> contains both the toggle link and its
+        // sub menu / mega menu panel.
+        qhMenuFocusDismiss(
+          toggle_element.parentElement,
+          toggle_element,
+          function () {
+            return toggle_element.getAttribute('aria-expanded') === 'true';
+          },
+          function () {
+            toggle_element.setAttribute('aria-expanded', 'false');
+          }
+        );
       });
 
     }

--- a/ecms_base/themes/custom/ecms/components/02-organisms/navigation-minor/_navigation-minor.scss
+++ b/ecms_base/themes/custom/ecms/components/02-organisms/navigation-minor/_navigation-minor.scss
@@ -20,8 +20,13 @@
     $button-trigger-height: 28;
 
     position: absolute;
-    // This calc replicates the spacing variable to negate it, and push the button trigger over to the edge of the viewport
-    left: calc((1.125em + 3.5vw) * -1);
+    // Negate the page gutter so the rotated tab hugs the viewport edge:
+    // 1rem = the layout grid's padding-inline, 3.5vw = the centered grid's
+    // margin — minus half the scrollbar width (page-init.js publishes
+    // --qh-scrollbar-comp) because vw includes the scrollbar but the grid
+    // centers inside the scrollbar-less width. The old 1.125em + bare 3.5vw
+    // overshot by up to ~9px and clipped the tab + open drawer offscreen.
+    left: calc((1rem + 3.5vw - var(--qh-scrollbar-comp, 0px)) * -1);
     min-width: unset;
     width: em(320 - $button-trigger-height);
     transform: translateX(- em(320 - $button-trigger-height));
@@ -29,7 +34,23 @@
 
     > ul {
       transform: translateX(- em(48));
-      transition: transform $transition-duration-base $transition-timing-base ($transition-duration-base/2);
+      transition:
+        transform $transition-duration-base $transition-timing-base ($transition-duration-base/2),
+        visibility $transition-duration-base $transition-timing-base $transition-duration-base;
+      // Needed to keep the collapsed rail's links from being keyboard
+      // tabbable — transform only moves it offscreen visually (RIGA-891
+      // callout 8). Mirrors the mobile drawer in _navigation-main.scss.
+      visibility: hidden;
+    }
+
+    // Expanded accordion panels inside the drawer explicitly re-show
+    // themselves (`.js [aria-expanded='true'] + .qh__accordion__content`
+    // sets visibility: visible, which beats the inherited hidden above), so
+    // force them hidden again while the drawer is collapsed. Same
+    // specificity as the accordion rule — this wins on source order
+    // (components compile after patterns).
+    &:not(#{&}--expanded) > ul .qh__accordion__content {
+      visibility: hidden;
     }
 
     &#{&}--expanded {
@@ -37,6 +58,10 @@
 
       > ul {
         transform: translateX(0);
+        transition:
+          transform $transition-duration-base $transition-timing-base ($transition-duration-base/2),
+          visibility 0s linear 0s;
+        visibility: visible;
       }
     }
   }
@@ -238,9 +263,11 @@
       color: var(--fc__nav-minor__link--hover);
     }
 
-    &:focus {
-      outline-color: var(--fc__nav-main__link--focus);
-      outline-offset: -2px;
+    // Two-tone ring, inset because the list clips overflow. Replaces a ring
+    // that consumed the wrong token (nav-main's yellow on this light-blue
+    // panel — RIGA-891 callout 7).
+    &:focus-visible {
+      @include qh-focus-ring--inset;
     }
 
     &:active {
@@ -282,6 +309,12 @@
 
   // Treat the Minor Nav like a breadcrumb trail at the top of the first page
   @media print {
+    // The collapsed-drawer visibility:hidden above is width-based and can
+    // also match the print page width — don't let it hide the breadcrumb
+    > ul {
+      visibility: visible;
+    }
+
     // Only allow the current page link to show
     a:not(#{&}__link--current):not([href='/']) {
       display: none;

--- a/ecms_base/themes/custom/ecms/components/02-organisms/navigation-minor/_navigation-minor.scss
+++ b/ecms_base/themes/custom/ecms/components/02-organisms/navigation-minor/_navigation-minor.scss
@@ -26,6 +26,8 @@
     // --qh-scrollbar-comp) because vw includes the scrollbar but the grid
     // centers inside the scrollbar-less width. The old 1.125em + bare 3.5vw
     // overshot by up to ~9px and clipped the tab + open drawer offscreen.
+    // The var() fallback needs its unit: calc() length math rejects a bare 0
+    // stylelint-disable-next-line length-zero-no-unit
     left: calc((1rem + 3.5vw - var(--qh-scrollbar-comp, 0px)) * -1);
     min-width: unset;
     width: em(320 - $button-trigger-height);

--- a/ecms_base/themes/custom/ecms/components/02-organisms/navigation-minor/navigation-minor.js
+++ b/ecms_base/themes/custom/ecms/components/02-organisms/navigation-minor/navigation-minor.js
@@ -27,14 +27,33 @@
             event.preventDefault();
             if (qh_nav_minor.classList.contains('qh__nav-minor--expanded')) {
               qh_nav_minor.classList.remove('qh__nav-minor--expanded');
+              // Keep ARIA state in sync — this was hardcoded "false" forever
+              // (RIGA-891 callout 8)
+              qh_toggle_btn.setAttribute('aria-expanded', 'false');
               deactivatePageOverlay();
             } else {
               allMenuCloser();
               activatePageOverlay();
               qh_nav_minor.classList.add('qh__nav-minor--expanded');
+              qh_toggle_btn.setAttribute('aria-expanded', 'true');
             }
           }
         });
+
+        // Close the drawer when keyboard focus leaves it or on Escape
+        // (RIGA-891). The <nav> contains both the toggle and the list.
+        qhMenuFocusDismiss(
+          qh_nav_minor,
+          qh_toggle_btn,
+          function () {
+            return qh_nav_minor.classList.contains('qh__nav-minor--expanded');
+          },
+          function () {
+            qh_nav_minor.classList.remove('qh__nav-minor--expanded');
+            qh_toggle_btn.setAttribute('aria-expanded', 'false');
+            deactivatePageOverlay();
+          }
+        );
       });
     }
   };

--- a/ecms_base/themes/custom/ecms/components/02-organisms/notfications-block/_notifications-block.scss
+++ b/ecms_base/themes/custom/ecms/components/02-organisms/notfications-block/_notifications-block.scss
@@ -84,9 +84,8 @@
       color: var(--fc__notification__link--hover, var(--fc__defauilt__link--hover));
     }
 
-    a:focus {
-      outline-color: var(--fc__notification__link--focus, var(--fc__defauilt__link--focus));
-    }
+    // Keyboard focus ring comes from the global two-tone :focus-visible
+    // mechanism (RIGA-891) — no per-region outline color override.
 
     a:active {
       color: var(--fc__notification__link--active, var(--fc__defauilt__link--active));

--- a/ecms_base/themes/custom/ecms/components/02-organisms/paragraphs/gallery/_gallery.scss
+++ b/ecms_base/themes/custom/ecms/components/02-organisms/paragraphs/gallery/_gallery.scss
@@ -8,9 +8,8 @@
     align-items: center;
     margin-top: $general-v-spacing;
 
-    &:focus {
-      outline: 2px solid var(--fc__default__link--focus);
-      outline-offset: -2px;
+    &:focus-visible {
+      @include qh-focus-ring--inset;
     }
 
     .qh__gallery__button--prev {

--- a/ecms_base/themes/custom/ecms/components/canvas/icon-link/_icon-link.scss
+++ b/ecms_base/themes/custom/ecms/components/canvas/icon-link/_icon-link.scss
@@ -32,8 +32,7 @@
 
     &:is(a):focus-visible {
       border-radius: 4px;
-      outline: 2px solid var(--c__hope-gold, hsl(46, 95%, 61%));
-      outline-offset: 2px;
+      @include qh-focus-ring;
     }
   }
 

--- a/ecms_base/themes/custom/ecms/ecms.libraries.yml
+++ b/ecms_base/themes/custom/ecms/ecms.libraries.yml
@@ -1,5 +1,4 @@
 global-styling:
-  version: 2.0.8
   css:
     theme:
       assets/styles/styles.css: { preprocess: true }
@@ -20,23 +19,24 @@ tiny-slider:
   version: 2.9.7
   css:
     theme:
-       assets/vendor/tiny-slider/tiny-slider.css: {}
+      assets/vendor/tiny-slider/tiny-slider.css: {}
   js:
-    assets/vendor/tiny-slider/tiny-slider.js:  { weight: -1}
+    assets/vendor/tiny-slider/tiny-slider.js: { weight: -1 }
   dependencies:
     - ecms/global-styling
 
 rrule-js:
   version: 2.7.1
   js:
-    assets/vendor/rrule/rrule.min.js:  { weight: -1, attributes: { type: "module"}, minified: true }
+    assets/vendor/rrule/rrule.min.js:
+      { weight: -1, attributes: { type: "module" }, minified: true }
   dependencies:
     - ecms/global-styling
 
 modal:
   version: 1.1.5
   js:
-    assets/vendor/micromodal/micromodal.min.js:  { weight: -1, attributes: { type: "module"}, minified: true }
+    assets/vendor/micromodal/micromodal.min.js:
+      { weight: -1, attributes: { type: "module" }, minified: true }
   dependencies:
     - ecms/global-styling
-


### PR DESCRIPTION
- Two-tone focus tokens — focus__ring/focus__halo added to all 18 palettes in color-config.hjson; qh-focus-ring / qh-focus-ring--inset mixins; global :focus-visible rule.
- Replaced all single-color focus rings — links, buttons, social icons, nav main/minor (incl. wrong-token bug), megamenu, accordion (outline: none removed), settings/language, headers, notifications, gallery, pagination, forms, icon-link.
- Footer links keep underline on focus (_page-footer.scss).
- Menus close on tab-out + Escape — qhMenuFocusDismiss() in global.js; wired into nav dropdowns, hamburger, Settings, Language, GTranslate, section menu. allMenuCloser() now also closes dropdowns.
- Section-menu keyboard trap — collapsed rail visibility: hidden + accordion counter-rule; toggle aria-expanded now synced (was hardcoded false).
-  Accordion tabbability — 500s visibility-transition typo → 500ms; expand-collapse.js syncs inert on all accordion panels.
- Layout columns no longer clip the ring — overflow: auto → flow-root + min-width: 0 (_layout-section.scss).
- Section-menu tab/drawer no longer offscreen — gutter calc fixed (1rem + scrollbar compensation via --qh-scrollbar-comp from page-init.js). Pre-existing bug, also on prod.
