### PR TITLE
Fixed rogue entities from layout builder sample entity generation

### DIFF
--- a/ecms_base/modules/custom/ecms_layout/ecms_layout.services.yml
+++ b/ecms_base/modules/custom/ecms_layout/ecms_layout.services.yml
@@ -1,3 +1,12 @@
 services:
   Drupal\ecms_layout\LandingPageTitleDetector:
     autowire: true
+
+  # Replace Layout Builder's sample entity generator so that "Manage layout"
+  # pages for a default display no longer populate the placeholder entity with
+  # generated sample values. See EcmsSampleEntityGenerator for the cascade this
+  # prevents.
+  ecms_layout.sample_entity_generator:
+    class: Drupal\ecms_layout\EcmsSampleEntityGenerator
+    decorates: layout_builder.sample_entity_generator
+    arguments: ['@tempstore.shared', '@entity_type.manager']

--- a/ecms_base/modules/custom/ecms_layout/src/EcmsSampleEntityGenerator.php
+++ b/ecms_base/modules/custom/ecms_layout/src/EcmsSampleEntityGenerator.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ecms_layout;
+
+use Drupal\Core\Entity\ContentEntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\TempStore\SharedTempStoreFactory;
+use Drupal\layout_builder\Entity\SampleEntityGeneratorInterface;
+
+/**
+ * Creates Layout Builder sample entities without generating sample values.
+ *
+ * Core's generator calls createWithSampleValues(), which runs
+ * generateSampleItems() on every field of the placeholder entity — base fields
+ * included. On an eCMS content type that cascades:
+ *
+ * - The node's paragraph field hits
+ *   EntityReferenceRevisionsItem::generateSampleValue(), which picks a random
+ *   paragraph bundle, fills it with sample values and calls save() on it (it
+ *   has to, in order to return a target_revision_id). Those become real,
+ *   permanently orphaned lorem ipsum paragraph rows.
+ * - A sample paragraph's entity reference field hits
+ *   EntityReferenceItem::generateSampleValue(). When the target vocabulary has
+ *   no referenceable terms it builds one with createWithSampleValues(), so the
+ *   term's base fields are generated too: langcode becomes a random installed
+ *   language and default_langcode a coin flip from BooleanItem. A term stored
+ *   with default_langcode = 0 has no default translation, so label() returns
+ *   NULL, and any formatter with link: TRUE then hands NULL to
+ *   Html::escape() — a TypeError that takes down the whole Manage layout page.
+ * - That generated term is attached as $values['entity'], so
+ *   EntityReferenceItem::preSave() persists it along with the paragraph above.
+ *
+ * Because the term is only generated while the vocabulary is empty, deleting
+ * the junk terms is not enough: they come back on the next visit to a Manage
+ * layout page. Creating the placeholder entity empty removes the cascade at
+ * its source. Layout Builder renders field blocks with no value as their
+ * preview fallback label ("«field name» field"), which is what editors expect
+ * on a default display anyway.
+ *
+ * @see \Drupal\layout_builder\Entity\LayoutBuilderSampleEntityGenerator
+ * @see \Drupal\Core\Entity\ContentEntityStorageBase::createWithSampleValues()
+ * @see https://thinkoomph.jira.com/browse/RIGA-895
+ */
+final class EcmsSampleEntityGenerator implements SampleEntityGeneratorInterface {
+
+  /**
+   * The tempstore collection Layout Builder keeps its sample entities in.
+   *
+   * Layout Builder's own delete() callers and tests rely on this name, so it
+   * must match core's generator.
+   */
+  private const TEMPSTORE_COLLECTION = 'layout_builder.sample_entity';
+
+  public function __construct(
+    private readonly SharedTempStoreFactory $tempStoreFactory,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get($entity_type_id, $bundle_id) {
+    $tempstore = $this->tempStoreFactory->get(self::TEMPSTORE_COLLECTION);
+    if ($entity = $tempstore->get("$entity_type_id.$bundle_id")) {
+      return $entity;
+    }
+
+    $entity_storage = $this->entityTypeManager->getStorage($entity_type_id);
+    if (!$entity_storage instanceof ContentEntityStorageInterface) {
+      throw new \InvalidArgumentException(sprintf('The "%s" entity storage is not supported', $entity_type_id));
+    }
+
+    $entity_type = $this->entityTypeManager->getDefinition($entity_type_id);
+    $values = [];
+    if ($bundle_key = $entity_type->getKey('bundle')) {
+      $values[$bundle_key] = $bundle_id;
+    }
+
+    // Create the entity without any generated field values.
+    $entity = $entity_storage->create($values);
+
+    // Templates and preprocess hooks treat the entity label as a string. An
+    // unset label key leaves label() returning NULL, which reintroduces the
+    // Html::escape() TypeError on the sample entity itself.
+    $label_key = $entity_type->getKey('label');
+    if ($label_key && $entity instanceof FieldableEntityInterface && $entity->hasField($label_key)) {
+      $entity->set($label_key, '');
+    }
+
+    // Mark the sample entity as being a preview.
+    $entity->in_preview = TRUE;
+    $tempstore->set("$entity_type_id.$bundle_id", $entity);
+    return $entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function delete($entity_type_id, $bundle_id) {
+    $tempstore = $this->tempStoreFactory->get(self::TEMPSTORE_COLLECTION);
+    $tempstore->delete("$entity_type_id.$bundle_id");
+    return $this;
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_layout/tests/src/Kernel/EcmsSampleEntityGeneratorTest.php
+++ b/ecms_base/modules/custom/ecms_layout/tests/src/Kernel/EcmsSampleEntityGeneratorTest.php
@@ -1,0 +1,319 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ecms_layout\Kernel;
+
+use Drupal\Core\Field\FieldConfigInterface;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\TempStore\SharedTempStore;
+use Drupal\ecms_layout\EcmsSampleEntityGenerator;
+use Drupal\Core\Field\Entity\BaseFieldOverride;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\layout_builder\Entity\LayoutBuilderSampleEntityGenerator;
+use Drupal\layout_builder\Entity\SampleEntityGeneratorInterface;
+use Drupal\node\Entity\NodeType;
+use Drupal\node\NodeInterface;
+use Drupal\paragraphs\Entity\ParagraphsType;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests that Layout Builder sample entities are created without sample values.
+ *
+ * The environment set up here is the minimum needed to reproduce the RIGA-895
+ * cascade: a node type with an entity_reference_revisions field to a paragraph
+ * type, and that paragraph type carrying an entity reference field to an empty
+ * vocabulary.
+ *
+ * @see \Drupal\ecms_layout\EcmsSampleEntityGenerator
+ * @see https://thinkoomph.jira.com/browse/RIGA-895
+ */
+#[Group('ecms_layout')]
+#[CoversClass(EcmsSampleEntityGenerator::class)]
+class EcmsSampleEntityGeneratorTest extends KernelTestBase {
+
+  use EntityReferenceFieldCreationTrait;
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'file',
+    'node',
+    'taxonomy',
+    'block',
+    'contextual',
+    'layout_discovery',
+    'layout_builder',
+    'entity_reference_revisions',
+    'paragraphs',
+    'ecms_layout',
+  ];
+
+  /**
+   * The tempstore collection Layout Builder keeps its sample entities in.
+   */
+  private const TEMPSTORE_COLLECTION = 'layout_builder.sample_entity';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('paragraph');
+    $this->installConfig(['field', 'filter', 'node', 'taxonomy']);
+
+    // The shared tempstore derives its owner from the current user, falling
+    // back to the session for anonymous users. Layout Builder is only reachable
+    // by authenticated editors, so mirror that here.
+    $this->setUpCurrentUser();
+
+    NodeType::create([
+      'type' => 'page',
+      'name' => 'Page',
+    ])->save();
+
+    ParagraphsType::create([
+      'id' => 'publication_list',
+      'label' => 'Publication list',
+    ])->save();
+
+    // An empty vocabulary is the trigger: EntityReferenceItem only generates a
+    // brand new term (with a random langcode and a coin-flip
+    // default_langcode) when there is nothing referenceable to pick from.
+    Vocabulary::create([
+      'vid' => 'publication_audience',
+      'name' => 'Publication audience',
+    ])->save();
+
+    $this->createEntityReferenceField(
+      'paragraph',
+      'publication_list',
+      'field_publication_list_audience',
+      'Audience',
+      'taxonomy_term',
+      'default',
+      ['target_bundles' => ['publication_audience' => 'publication_audience']],
+    );
+
+    $this->createParagraphsField('node', 'page', 'field_content', 'publication_list');
+  }
+
+  /**
+   * The decorator replaces core's generator on the service and its alias.
+   */
+  public function testDecoratorReplacesCoreGenerator(): void {
+    $this->assertInstanceOf(
+      EcmsSampleEntityGenerator::class,
+      $this->container->get('layout_builder.sample_entity_generator'),
+      'ecms_layout.sample_entity_generator must decorate ' .
+      'layout_builder.sample_entity_generator. Without the decoration, ' .
+      'Layout Builder uses core\'s generator and the sample value cascade ' .
+      'remains in place.'
+    );
+
+    // DefaultsSectionStorage and other consumers may be injected through the
+    // interface alias, which has to resolve to the decorator as well.
+    $this->assertInstanceOf(
+      EcmsSampleEntityGenerator::class,
+      $this->container->get(SampleEntityGeneratorInterface::class)
+    );
+  }
+
+  /**
+   * The sample entity is created empty rather than with generated values.
+   */
+  public function testSampleEntityHasNoGeneratedFieldValues(): void {
+    $entity = $this->sampleEntityGenerator()->get('node', 'page');
+
+    $this->assertInstanceOf(NodeInterface::class, $entity);
+    $this->assertSame('page', $entity->bundle());
+    $this->assertTrue($entity->isNew(), 'The sample entity must never be saved.');
+    $this->assertTrue($entity->in_preview, 'The sample entity must be marked as a preview.');
+
+    // label() returning NULL is what hands NULL to Html::escape() through
+    // LinkGenerator, so the label key must be a string.
+    $this->assertSame('', $entity->label());
+
+    // Every configurable field must be empty. Core's generator fills all of
+    // them through generateSampleItems(). Base field overrides are excluded:
+    // they also implement FieldConfigInterface, but they carry the ordinary
+    // defaults of base fields such as status, uid and created.
+    $asserted = [];
+    foreach ($entity->getFields() as $field_name => $field) {
+      $definition = $field->getFieldDefinition();
+      if ($definition instanceof FieldConfigInterface && !$definition instanceof BaseFieldOverride) {
+        $this->assertTrue(
+          $field->isEmpty(),
+          sprintf('The sample entity field "%s" must have no generated value.', $field_name)
+        );
+        $asserted[] = $field_name;
+      }
+    }
+
+    // Guard against the loop above silently asserting nothing.
+    $this->assertSame(['field_content'], $asserted);
+  }
+
+  /**
+   * Generating a sample entity persists no paragraphs and no taxonomy terms.
+   *
+   * This is the defect itself: the sample values cascade saved real rows into
+   * paragraphs_item_field_data and taxonomy_term_field_data on every visit to a
+   * "Manage layout" page for a default display.
+   */
+  public function testSampleEntityPersistsNothing(): void {
+    $this->sampleEntityGenerator()->get('node', 'page');
+
+    $this->assertSame(0, $this->countEntities('paragraph'), 'No paragraphs may be saved.');
+    $this->assertSame(0, $this->countEntities('taxonomy_term'), 'No taxonomy terms may be saved.');
+    $this->assertSame(0, $this->countEntities('node'), 'No nodes may be saved.');
+  }
+
+  /**
+   * Documents the core behaviour the decorator exists to prevent.
+   *
+   * If this test starts failing, core or entity_reference_revisions stopped
+   * persisting generated sample entities and the decorator may no longer be
+   * needed — but the assertions above would then pass trivially, so this test
+   * is what keeps them meaningful.
+   */
+  public function testCoreGeneratorPersistsSampleEntities(): void {
+    $core_generator = new LayoutBuilderSampleEntityGenerator(
+      $this->container->get('tempstore.shared'),
+      $this->container->get('entity_type.manager')
+    );
+
+    $entity = $core_generator->get('node', 'page');
+
+    $this->assertFalse(
+      $entity->get('field_content')->isEmpty(),
+      'Core\'s generator populates the paragraph field with sample values.'
+    );
+    $this->assertGreaterThan(
+      0,
+      $this->countEntities('paragraph'),
+      'EntityReferenceRevisionsItem::generateSampleValue() saves the paragraph ' .
+      'it generates.'
+    );
+    $this->assertGreaterThan(
+      0,
+      $this->countEntities('taxonomy_term'),
+      'The generated paragraph references a term created for the empty ' .
+      'vocabulary, which EntityReferenceItem::preSave() persists.'
+    );
+  }
+
+  /**
+   * The generated entity is reused from the tempstore on subsequent calls.
+   */
+  public function testGetCachesTheSampleEntityInTempstore(): void {
+    $generator = $this->sampleEntityGenerator();
+
+    $first = $generator->get('node', 'page');
+    $stored = $this->tempstore()->get('node.page');
+
+    $this->assertNotNull($stored, 'The sample entity must be written to the tempstore.');
+    $this->assertSame($first->uuid(), $stored->uuid());
+
+    $second = $generator->get('node', 'page');
+    $this->assertSame(
+      $first->uuid(),
+      $second->uuid(),
+      'A second call must return the tempstore copy instead of creating a new entity.'
+    );
+    $this->assertTrue($second->in_preview, 'The cached entity must still be marked as a preview.');
+  }
+
+  /**
+   * Deleting removes the tempstore entry and returns the generator.
+   */
+  public function testDeleteRemovesTheTempstoreEntry(): void {
+    $generator = $this->sampleEntityGenerator();
+    $generator->get('node', 'page');
+
+    $this->assertSame($generator, $generator->delete('node', 'page'));
+    $this->assertNull($this->tempstore()->get('node.page'));
+  }
+
+  /**
+   * Unsupported entity storage throws, matching core's contract.
+   */
+  public function testUnsupportedEntityStorageThrows(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('The "node_type" entity storage is not supported');
+
+    $this->sampleEntityGenerator()->get('node_type', 'page');
+  }
+
+  /**
+   * Returns the decorated sample entity generator.
+   */
+  private function sampleEntityGenerator(): SampleEntityGeneratorInterface {
+    return $this->container->get('layout_builder.sample_entity_generator');
+  }
+
+  /**
+   * Returns the Layout Builder sample entity tempstore.
+   */
+  private function tempstore(): SharedTempStore {
+    return $this->container->get('tempstore.shared')->get(self::TEMPSTORE_COLLECTION);
+  }
+
+  /**
+   * Counts the saved entities of a given entity type.
+   */
+  private function countEntities(string $entity_type_id): int {
+    return (int) $this->container->get('entity_type.manager')
+      ->getStorage($entity_type_id)
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->count()
+      ->execute();
+  }
+
+  /**
+   * Adds an entity_reference_revisions field targeting a paragraph type.
+   */
+  private function createParagraphsField(string $entity_type, string $bundle, string $field_name, string $paragraph_type): void {
+    FieldStorageConfig::create([
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'type' => 'entity_reference_revisions',
+      'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED,
+      'settings' => [
+        'target_type' => 'paragraph',
+      ],
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'bundle' => $bundle,
+      'label' => 'Content',
+      'settings' => [
+        'handler' => 'default:paragraph',
+        'handler_settings' => [
+          'target_bundles' => [$paragraph_type => $paragraph_type],
+        ],
+      ],
+    ])->save();
+  }
+
+}


### PR DESCRIPTION
This pull request addresses a critical defect in the Layout Builder's sample entity generation for eCMS by introducing a custom sample entity generator. The new implementation ensures that placeholder entities used in "Manage layout" pages are created without generating and persisting sample content, preventing the unwanted creation of orphaned paragraphs and taxonomy terms. Comprehensive kernel tests are included to verify the new behavior and prevent regressions.

**Core changes to sample entity generation:**

* Added `EcmsSampleEntityGenerator`, a service that decorates and replaces the core `layout_builder.sample_entity_generator`, ensuring sample entities are created empty and not persisted with generated values. This prevents the cascade of unwanted entity creation (paragraphs, taxonomy terms) that previously occurred when accessing layout management pages. [[1]](diffhunk://#diff-f9de914d03eaf5f53ebb6f9a6999d4442679a62fe864b4bdef614d2e2fcd0133R1-R108) [[2]](diffhunk://#diff-8d326ffa15f2edf85ae67adef62e8c3f75a83c36faa3d84350e163626aa8be05R4-R12)

**Testing and validation:**

* Introduced `EcmsSampleEntityGeneratorTest`, a kernel test suite that:
  - Verifies the custom generator replaces the core service.
  - Confirms sample entities are empty and not persisted.
  - Demonstrates the defect in core behavior for documentation and future reference.
  - Ensures the generator caches entities in tempstore and handles deletion correctly.
  - Asserts correct exception handling for unsupported entity types.

[RIGA_895](https://thinkoomph.jira.com/browse/RIGA-895)