### PR TITLE
Fixed oembed rendering

### DIFF
--- a/ecms_base/themes/custom/ecms/templates/paragraphs/paragraph--media-item.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/paragraphs/paragraph--media-item.html.twig
@@ -92,7 +92,7 @@
 {% endif %}
 
 {% if media_type == 'video' %}
-  {% set video_source = content.field_media_item|render|striptags("<iframe>") %}
+  {% set video_source = content.field_media_item|render|striptags("<iframe>")|replace({'&amp;': '&'}) %}
   {{ include ("ecms:media-item", {
     content: content,
     type: media_type,


### PR DESCRIPTION
This pull request makes a small update to the video rendering logic in the `paragraph--media-item.html.twig` template. The change ensures that HTML-encoded ampersands (`&amp;`) in video source URLs are replaced with plain ampersands (`&`), which can help prevent issues with video embedding.

* Improved video source URL handling by replacing `&amp;` with `&` after stripping tags from rendered media item content.

[RIGA-882](https://thinkoomph.jira.com/browse/RIGA-882)