### PR TITLE
Rc/2.0.10

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -37,7 +37,7 @@ corepack_enable: true
 # php_version: "8.4"  # PHP version to use, "5.6" through "8.5"
 
 # You can explicitly specify the webimage but this
-# is not recommended, as the images are often closely tied to DDEV's' behavior,
+# is not recommended, as the images are often closely tied to DDEV's behavior,
 # so this can break upgrades.
 
 # webimage: <docker_image>
@@ -47,7 +47,7 @@ corepack_enable: true
 # database:
 #   type: <dbtype> # mysql, mariadb, postgres
 #   version: <version> # database version, like "10.11" or "8.0"
-#   MariaDB versions can be 5.5-10.8, 10.11, 11.4, 11.8
+#   MariaDB versions can be 5.5-10.8, 10.11, 11.4, 11.8, 12.3
 #   MySQL versions can be 5.5-8.0, 8.4
 #   PostgreSQL versions can be 9-18
 
@@ -90,7 +90,7 @@ corepack_enable: true
 # composer_version: "2"
 # You can set it to "" or "2" (default) for Composer v2
 # to use the latest major version available at the time your container is built.
-# It is also possible to use each other Composer version channel. This includes:
+# It is also possible to use any other Composer version channel. This includes:
 #   - 2.2 (latest Composer LTS version)
 #   - stable
 #   - preview
@@ -276,7 +276,7 @@ corepack_enable: true
 # override_config: false
 # By default, config.*.yaml files are *merged* into the configuration
 # But this means that some things can't be overridden
-# For example, if you have 'use_dns_when_possible: true'' you can't override it with a merge
+# For example, if you have 'use_dns_when_possible: true' you can't override it with a merge
 # and you can't erase existing hooks or all environment variables.
 # However, with "override_config: true" in a particular config.*.yaml file,
 # 'use_dns_when_possible: false' can override the existing values, and
@@ -286,7 +286,7 @@ corepack_enable: true
 # web_environment: []
 # or
 # additional_hostnames: []
-# can have their intended affect. 'override_config' affects only behavior of the
+# can have their intended effect. 'override_config' affects only behavior of the
 # config.*.yaml file it exists in.
 
 # Many DDEV commands can be extended to run tasks before or after the

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -13,6 +13,7 @@ declare(strict_types=1);
  */
 
 use Drupal\Core\Batch\BatchBuilder;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Recipe\Recipe;
 use Drupal\Core\Recipe\RecipeRunner;
 use Drupal\shortcut\Entity\Shortcut;
@@ -69,6 +70,8 @@ function ecms_base_install() {
   $config->set('mail', 'ecms@notification.ri.gov');
   $config->save();
 
+  // Create the directory webform writes its exports to.
+  ecms_base_prepare_webform_export_directory();
 }
 
 /**
@@ -184,6 +187,44 @@ function ecms_base_apply_workflows() {
       $workflowBundleCreate->addTaxonomyTypePermissions($taxonomy);
     }
   }
+}
+
+/**
+ * Ensure the webform submission export directory exists and is writable.
+ *
+ * Webform passes its export directory straight to fopen() without creating it
+ * first, so exporting to a missing directory fails with a stream of
+ * "fwrite(): Argument #1 must be of type resource, bool given" errors. The
+ * directory lives in the private file system so that a batched export can be
+ * resumed by any node in the ACSF cluster.
+ *
+ * Every site in the factory uses the same location, so this deliberately does
+ * not read webform's configuration: the directory can be created before
+ * webform itself is installed, and the settings override that points webform
+ * at this directory resolves to the same path on disk.
+ *
+ * @return bool
+ *   TRUE if the directory exists and is writable, FALSE otherwise.
+ *
+ * @see \Drupal\webform\Plugin\WebformExporter\FileHandleTraitWebformExporter::createExport()
+ * @see \Drupal\webform\Plugin\WebformExporterBase::getExportFilePath()
+ */
+function ecms_base_prepare_webform_export_directory(): bool {
+  $directory = 'private://webform_exports';
+
+  $prepared = \Drupal::service('file_system')->prepareDirectory(
+    $directory,
+    FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS
+  );
+
+  if (!$prepared) {
+    \Drupal::logger('ecms_base')->error(
+      'Unable to create the webform export directory at @directory. Webform submission exports will fail until it exists and is writable.',
+      ['@directory' => $directory]
+    );
+  }
+
+  return $prepared;
 }
 
 /**
@@ -658,4 +699,17 @@ function ecms_base_update_11220(): void {
   ];
 
   ecms_base_apply_recipes($recipes);
+}
+
+/**
+ * Create the webform submission export directory on existing sites.
+ */
+function ecms_base_update_11221(): string {
+  if (ecms_base_prepare_webform_export_directory()) {
+    return (string) t('Webform exports will be written to @directory.', [
+      '@directory' => \Drupal::service('file_system')->realpath('private://webform_exports'),
+    ]);
+  }
+
+  return (string) t('The webform export directory could not be created. Submission exports will fail on this site until private://webform_exports exists and is writable by the web server.');
 }

--- a/ecms_base/ecms_base.install
+++ b/ecms_base/ecms_base.install
@@ -648,3 +648,14 @@ function ecms_base_update_11219(): void {
 
   $config->save(TRUE);
 }
+
+/**
+ * Apply recipes for person list.
+ */
+function ecms_base_update_11220(): void {
+  $recipes = [
+    'ecms_person_list',
+  ];
+
+  ecms_base_apply_recipes($recipes);
+}

--- a/ecms_base/features/custom/ecms_person/config/install/core.entity_form_display.paragraph.person_list.default.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.entity_form_display.paragraph.person_list.default.yml
@@ -2,13 +2,32 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.person_list.field_background_color
+    - field.field.paragraph.person_list.field_columns
     - field.field.paragraph.person_list.field_department_category
+    - field.field.paragraph.person_list.field_display_images
+    - field.field.paragraph.person_list.field_list_title
     - paragraphs.paragraphs_type.person_list
+  module:
+    - options
 id: paragraph.person_list.default
 targetEntityType: paragraph
 bundle: person_list
 mode: default
 content:
+  field_background_color:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_columns:
+    weight: 3
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: number
+    region: content
   field_department_category:
     weight: 1
     settings:
@@ -18,6 +37,21 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: entity_reference_autocomplete
+    region: content
+  field_display_images:
+    weight: 4
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_list_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
 hidden:
   created: true

--- a/ecms_base/features/custom/ecms_person/config/install/core.entity_view_display.paragraph.person_list.default.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/core.entity_view_display.paragraph.person_list.default.yml
@@ -2,20 +2,43 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.person_list.field_background_color
+    - field.field.paragraph.person_list.field_columns
     - field.field.paragraph.person_list.field_department_category
+    - field.field.paragraph.person_list.field_display_images
+    - field.field.paragraph.person_list.field_list_title
     - paragraphs.paragraphs_type.person_list
+  module:
+    - options
 id: paragraph.person_list.default
 targetEntityType: paragraph
 bundle: person_list
 mode: default
 content:
-  field_department_category:
+  field_background_color:
     weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: list_key
+    region: content
+  field_department_category:
+    weight: 2
     label: above
     settings:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
     region: content
+  field_list_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
 hidden:
+  field_columns: true
+  field_display_images: true
   search_api_excerpt: true

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.paragraph.person_list.field_background_color.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.paragraph.person_list.field_background_color.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_background_color
+    - paragraphs.paragraphs_type.person_list
+  module:
+    - options
+id: paragraph.person_list.field_background_color
+field_name: field_background_color
+entity_type: paragraph
+bundle: person_list
+label: 'Background color'
+description: '(Optional) Select a background color for the person list.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.paragraph.person_list.field_columns.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.paragraph.person_list.field_columns.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_columns
+    - paragraphs.paragraphs_type.person_list
+id: paragraph.person_list.field_columns
+field_name: field_columns
+entity_type: paragraph
+bundle: person_list
+label: Columns
+description: 'Set the number of columns for desktop displays. Smaller screens will fallback to defaults.'
+required: true
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  min: 1
+  max: 3
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.paragraph.person_list.field_display_images.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.paragraph.person_list.field_display_images.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_display_images
+    - paragraphs.paragraphs_type.person_list
+id: paragraph.person_list.field_display_images
+field_name: field_display_images
+entity_type: paragraph
+bundle: person_list
+label: 'Display Images?'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/ecms_base/features/custom/ecms_person/config/install/field.field.paragraph.person_list.field_list_title.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.field.paragraph.person_list.field_list_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_list_title
+    - paragraphs.paragraphs_type.person_list
+id: paragraph.person_list.field_list_title
+field_name: field_list_title
+entity_type: paragraph
+bundle: person_list
+label: 'List Title'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/ecms_base/features/custom/ecms_person/config/install/field.storage.paragraph.field_columns.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.storage.paragraph.field_columns.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_columns
+field_name: field_columns
+entity_type: paragraph
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_person/config/install/field.storage.paragraph.field_display_images.yml
+++ b/ecms_base/features/custom/ecms_person/config/install/field.storage.paragraph.field_display_images.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_display_images
+field_name: field_display_images
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/ecms_base/features/custom/ecms_person/ecms_person.info.yml
+++ b/ecms_base/features/custom/ecms_person/ecms_person.info.yml
@@ -20,6 +20,7 @@ dependencies:
   - 'drupal:telephone'
   - 'drupal:user'
   - 'drupal:views'
+  - 'ecms_paragraphs:ecms_paragraphs'
   - 'ecms_promotions:ecms_promotions'
   - 'ecms_workflow:ecms_workflow'
   - 'entity_reference_revisions:entity_reference_revisions'

--- a/ecms_base/modules/custom/ecms_layout/ecms_layout.services.yml
+++ b/ecms_base/modules/custom/ecms_layout/ecms_layout.services.yml
@@ -1,3 +1,12 @@
 services:
   Drupal\ecms_layout\LandingPageTitleDetector:
     autowire: true
+
+  # Replace Layout Builder's sample entity generator so that "Manage layout"
+  # pages for a default display no longer populate the placeholder entity with
+  # generated sample values. See EcmsSampleEntityGenerator for the cascade this
+  # prevents.
+  ecms_layout.sample_entity_generator:
+    class: Drupal\ecms_layout\EcmsSampleEntityGenerator
+    decorates: layout_builder.sample_entity_generator
+    arguments: ['@tempstore.shared', '@entity_type.manager']

--- a/ecms_base/modules/custom/ecms_layout/src/EcmsSampleEntityGenerator.php
+++ b/ecms_base/modules/custom/ecms_layout/src/EcmsSampleEntityGenerator.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ecms_layout;
+
+use Drupal\Core\Entity\ContentEntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\TempStore\SharedTempStoreFactory;
+use Drupal\layout_builder\Entity\SampleEntityGeneratorInterface;
+
+/**
+ * Creates Layout Builder sample entities without generating sample values.
+ *
+ * Core's generator calls createWithSampleValues(), which runs
+ * generateSampleItems() on every field of the placeholder entity — base fields
+ * included. On an eCMS content type that cascades:
+ *
+ * - The node's paragraph field hits
+ *   EntityReferenceRevisionsItem::generateSampleValue(), which picks a random
+ *   paragraph bundle, fills it with sample values and calls save() on it (it
+ *   has to, in order to return a target_revision_id). Those become real,
+ *   permanently orphaned lorem ipsum paragraph rows.
+ * - A sample paragraph's entity reference field hits
+ *   EntityReferenceItem::generateSampleValue(). When the target vocabulary has
+ *   no referenceable terms it builds one with createWithSampleValues(), so the
+ *   term's base fields are generated too: langcode becomes a random installed
+ *   language and default_langcode a coin flip from BooleanItem. A term stored
+ *   with default_langcode = 0 has no default translation, so label() returns
+ *   NULL, and any formatter with link: TRUE then hands NULL to
+ *   Html::escape() — a TypeError that takes down the whole Manage layout page.
+ * - That generated term is attached as $values['entity'], so
+ *   EntityReferenceItem::preSave() persists it along with the paragraph above.
+ *
+ * Because the term is only generated while the vocabulary is empty, deleting
+ * the junk terms is not enough: they come back on the next visit to a Manage
+ * layout page. Creating the placeholder entity empty removes the cascade at
+ * its source. Layout Builder renders field blocks with no value as their
+ * preview fallback label ("«field name» field"), which is what editors expect
+ * on a default display anyway.
+ *
+ * @see \Drupal\layout_builder\Entity\LayoutBuilderSampleEntityGenerator
+ * @see \Drupal\Core\Entity\ContentEntityStorageBase::createWithSampleValues()
+ * @see https://thinkoomph.jira.com/browse/RIGA-895
+ */
+final class EcmsSampleEntityGenerator implements SampleEntityGeneratorInterface {
+
+  /**
+   * The tempstore collection Layout Builder keeps its sample entities in.
+   *
+   * Layout Builder's own delete() callers and tests rely on this name, so it
+   * must match core's generator.
+   */
+  private const TEMPSTORE_COLLECTION = 'layout_builder.sample_entity';
+
+  public function __construct(
+    private readonly SharedTempStoreFactory $tempStoreFactory,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get($entity_type_id, $bundle_id) {
+    $tempstore = $this->tempStoreFactory->get(self::TEMPSTORE_COLLECTION);
+    if ($entity = $tempstore->get("$entity_type_id.$bundle_id")) {
+      return $entity;
+    }
+
+    $entity_storage = $this->entityTypeManager->getStorage($entity_type_id);
+    if (!$entity_storage instanceof ContentEntityStorageInterface) {
+      throw new \InvalidArgumentException(sprintf('The "%s" entity storage is not supported', $entity_type_id));
+    }
+
+    $entity_type = $this->entityTypeManager->getDefinition($entity_type_id);
+    $values = [];
+    if ($bundle_key = $entity_type->getKey('bundle')) {
+      $values[$bundle_key] = $bundle_id;
+    }
+
+    // Create the entity without any generated field values.
+    $entity = $entity_storage->create($values);
+
+    // Templates and preprocess hooks treat the entity label as a string. An
+    // unset label key leaves label() returning NULL, which reintroduces the
+    // Html::escape() TypeError on the sample entity itself.
+    $label_key = $entity_type->getKey('label');
+    if ($label_key && $entity instanceof FieldableEntityInterface && $entity->hasField($label_key)) {
+      $entity->set($label_key, '');
+    }
+
+    // Mark the sample entity as being a preview.
+    $entity->in_preview = TRUE;
+    $tempstore->set("$entity_type_id.$bundle_id", $entity);
+    return $entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function delete($entity_type_id, $bundle_id) {
+    $tempstore = $this->tempStoreFactory->get(self::TEMPSTORE_COLLECTION);
+    $tempstore->delete("$entity_type_id.$bundle_id");
+    return $this;
+  }
+
+}

--- a/ecms_base/modules/custom/ecms_layout/tests/src/Kernel/EcmsSampleEntityGeneratorTest.php
+++ b/ecms_base/modules/custom/ecms_layout/tests/src/Kernel/EcmsSampleEntityGeneratorTest.php
@@ -1,0 +1,319 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\ecms_layout\Kernel;
+
+use Drupal\Core\Field\FieldConfigInterface;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\TempStore\SharedTempStore;
+use Drupal\ecms_layout\EcmsSampleEntityGenerator;
+use Drupal\Core\Field\Entity\BaseFieldOverride;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\layout_builder\Entity\LayoutBuilderSampleEntityGenerator;
+use Drupal\layout_builder\Entity\SampleEntityGeneratorInterface;
+use Drupal\node\Entity\NodeType;
+use Drupal\node\NodeInterface;
+use Drupal\paragraphs\Entity\ParagraphsType;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests that Layout Builder sample entities are created without sample values.
+ *
+ * The environment set up here is the minimum needed to reproduce the RIGA-895
+ * cascade: a node type with an entity_reference_revisions field to a paragraph
+ * type, and that paragraph type carrying an entity reference field to an empty
+ * vocabulary.
+ *
+ * @see \Drupal\ecms_layout\EcmsSampleEntityGenerator
+ * @see https://thinkoomph.jira.com/browse/RIGA-895
+ */
+#[Group('ecms_layout')]
+#[CoversClass(EcmsSampleEntityGenerator::class)]
+class EcmsSampleEntityGeneratorTest extends KernelTestBase {
+
+  use EntityReferenceFieldCreationTrait;
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'file',
+    'node',
+    'taxonomy',
+    'block',
+    'contextual',
+    'layout_discovery',
+    'layout_builder',
+    'entity_reference_revisions',
+    'paragraphs',
+    'ecms_layout',
+  ];
+
+  /**
+   * The tempstore collection Layout Builder keeps its sample entities in.
+   */
+  private const TEMPSTORE_COLLECTION = 'layout_builder.sample_entity';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('paragraph');
+    $this->installConfig(['field', 'filter', 'node', 'taxonomy']);
+
+    // The shared tempstore derives its owner from the current user, falling
+    // back to the session for anonymous users. Layout Builder is only reachable
+    // by authenticated editors, so mirror that here.
+    $this->setUpCurrentUser();
+
+    NodeType::create([
+      'type' => 'page',
+      'name' => 'Page',
+    ])->save();
+
+    ParagraphsType::create([
+      'id' => 'publication_list',
+      'label' => 'Publication list',
+    ])->save();
+
+    // An empty vocabulary is the trigger: EntityReferenceItem only generates a
+    // brand new term (with a random langcode and a coin-flip
+    // default_langcode) when there is nothing referenceable to pick from.
+    Vocabulary::create([
+      'vid' => 'publication_audience',
+      'name' => 'Publication audience',
+    ])->save();
+
+    $this->createEntityReferenceField(
+      'paragraph',
+      'publication_list',
+      'field_publication_list_audience',
+      'Audience',
+      'taxonomy_term',
+      'default',
+      ['target_bundles' => ['publication_audience' => 'publication_audience']],
+    );
+
+    $this->createParagraphsField('node', 'page', 'field_content', 'publication_list');
+  }
+
+  /**
+   * The decorator replaces core's generator on the service and its alias.
+   */
+  public function testDecoratorReplacesCoreGenerator(): void {
+    $this->assertInstanceOf(
+      EcmsSampleEntityGenerator::class,
+      $this->container->get('layout_builder.sample_entity_generator'),
+      'ecms_layout.sample_entity_generator must decorate ' .
+      'layout_builder.sample_entity_generator. Without the decoration, ' .
+      'Layout Builder uses core\'s generator and the sample value cascade ' .
+      'remains in place.'
+    );
+
+    // DefaultsSectionStorage and other consumers may be injected through the
+    // interface alias, which has to resolve to the decorator as well.
+    $this->assertInstanceOf(
+      EcmsSampleEntityGenerator::class,
+      $this->container->get(SampleEntityGeneratorInterface::class)
+    );
+  }
+
+  /**
+   * The sample entity is created empty rather than with generated values.
+   */
+  public function testSampleEntityHasNoGeneratedFieldValues(): void {
+    $entity = $this->sampleEntityGenerator()->get('node', 'page');
+
+    $this->assertInstanceOf(NodeInterface::class, $entity);
+    $this->assertSame('page', $entity->bundle());
+    $this->assertTrue($entity->isNew(), 'The sample entity must never be saved.');
+    $this->assertTrue($entity->in_preview, 'The sample entity must be marked as a preview.');
+
+    // label() returning NULL is what hands NULL to Html::escape() through
+    // LinkGenerator, so the label key must be a string.
+    $this->assertSame('', $entity->label());
+
+    // Every configurable field must be empty. Core's generator fills all of
+    // them through generateSampleItems(). Base field overrides are excluded:
+    // they also implement FieldConfigInterface, but they carry the ordinary
+    // defaults of base fields such as status, uid and created.
+    $asserted = [];
+    foreach ($entity->getFields() as $field_name => $field) {
+      $definition = $field->getFieldDefinition();
+      if ($definition instanceof FieldConfigInterface && !$definition instanceof BaseFieldOverride) {
+        $this->assertTrue(
+          $field->isEmpty(),
+          sprintf('The sample entity field "%s" must have no generated value.', $field_name)
+        );
+        $asserted[] = $field_name;
+      }
+    }
+
+    // Guard against the loop above silently asserting nothing.
+    $this->assertSame(['field_content'], $asserted);
+  }
+
+  /**
+   * Generating a sample entity persists no paragraphs and no taxonomy terms.
+   *
+   * This is the defect itself: the sample values cascade saved real rows into
+   * paragraphs_item_field_data and taxonomy_term_field_data on every visit to a
+   * "Manage layout" page for a default display.
+   */
+  public function testSampleEntityPersistsNothing(): void {
+    $this->sampleEntityGenerator()->get('node', 'page');
+
+    $this->assertSame(0, $this->countEntities('paragraph'), 'No paragraphs may be saved.');
+    $this->assertSame(0, $this->countEntities('taxonomy_term'), 'No taxonomy terms may be saved.');
+    $this->assertSame(0, $this->countEntities('node'), 'No nodes may be saved.');
+  }
+
+  /**
+   * Documents the core behaviour the decorator exists to prevent.
+   *
+   * If this test starts failing, core or entity_reference_revisions stopped
+   * persisting generated sample entities and the decorator may no longer be
+   * needed — but the assertions above would then pass trivially, so this test
+   * is what keeps them meaningful.
+   */
+  public function testCoreGeneratorPersistsSampleEntities(): void {
+    $core_generator = new LayoutBuilderSampleEntityGenerator(
+      $this->container->get('tempstore.shared'),
+      $this->container->get('entity_type.manager')
+    );
+
+    $entity = $core_generator->get('node', 'page');
+
+    $this->assertFalse(
+      $entity->get('field_content')->isEmpty(),
+      'Core\'s generator populates the paragraph field with sample values.'
+    );
+    $this->assertGreaterThan(
+      0,
+      $this->countEntities('paragraph'),
+      'EntityReferenceRevisionsItem::generateSampleValue() saves the paragraph ' .
+      'it generates.'
+    );
+    $this->assertGreaterThan(
+      0,
+      $this->countEntities('taxonomy_term'),
+      'The generated paragraph references a term created for the empty ' .
+      'vocabulary, which EntityReferenceItem::preSave() persists.'
+    );
+  }
+
+  /**
+   * The generated entity is reused from the tempstore on subsequent calls.
+   */
+  public function testGetCachesTheSampleEntityInTempstore(): void {
+    $generator = $this->sampleEntityGenerator();
+
+    $first = $generator->get('node', 'page');
+    $stored = $this->tempstore()->get('node.page');
+
+    $this->assertNotNull($stored, 'The sample entity must be written to the tempstore.');
+    $this->assertSame($first->uuid(), $stored->uuid());
+
+    $second = $generator->get('node', 'page');
+    $this->assertSame(
+      $first->uuid(),
+      $second->uuid(),
+      'A second call must return the tempstore copy instead of creating a new entity.'
+    );
+    $this->assertTrue($second->in_preview, 'The cached entity must still be marked as a preview.');
+  }
+
+  /**
+   * Deleting removes the tempstore entry and returns the generator.
+   */
+  public function testDeleteRemovesTheTempstoreEntry(): void {
+    $generator = $this->sampleEntityGenerator();
+    $generator->get('node', 'page');
+
+    $this->assertSame($generator, $generator->delete('node', 'page'));
+    $this->assertNull($this->tempstore()->get('node.page'));
+  }
+
+  /**
+   * Unsupported entity storage throws, matching core's contract.
+   */
+  public function testUnsupportedEntityStorageThrows(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('The "node_type" entity storage is not supported');
+
+    $this->sampleEntityGenerator()->get('node_type', 'page');
+  }
+
+  /**
+   * Returns the decorated sample entity generator.
+   */
+  private function sampleEntityGenerator(): SampleEntityGeneratorInterface {
+    return $this->container->get('layout_builder.sample_entity_generator');
+  }
+
+  /**
+   * Returns the Layout Builder sample entity tempstore.
+   */
+  private function tempstore(): SharedTempStore {
+    return $this->container->get('tempstore.shared')->get(self::TEMPSTORE_COLLECTION);
+  }
+
+  /**
+   * Counts the saved entities of a given entity type.
+   */
+  private function countEntities(string $entity_type_id): int {
+    return (int) $this->container->get('entity_type.manager')
+      ->getStorage($entity_type_id)
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->count()
+      ->execute();
+  }
+
+  /**
+   * Adds an entity_reference_revisions field targeting a paragraph type.
+   */
+  private function createParagraphsField(string $entity_type, string $bundle, string $field_name, string $paragraph_type): void {
+    FieldStorageConfig::create([
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'type' => 'entity_reference_revisions',
+      'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED,
+      'settings' => [
+        'target_type' => 'paragraph',
+      ],
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'bundle' => $bundle,
+      'label' => 'Content',
+      'settings' => [
+        'handler' => 'default:paragraph',
+        'handler_settings' => [
+          'target_bundles' => [$paragraph_type => $paragraph_type],
+        ],
+      ],
+    ])->save();
+  }
+
+}

--- a/ecms_base/recipes/ecms_person/config/field.storage.node.field_person_social_links.yml
+++ b/ecms_base/recipes/ecms_person/config/field.storage.node.field_person_social_links.yml
@@ -8,9 +8,7 @@ id: node.field_person_social_links
 field_name: field_person_social_links
 entity_type: node
 type: link
-settings:
-  link_type: 17
-  title: 1
+settings: {}
 module: link
 locked: false
 cardinality: -1

--- a/ecms_base/themes/custom/ecms/components/02-organisms/notfications-block/_notifications-block.scss
+++ b/ecms_base/themes/custom/ecms/components/02-organisms/notfications-block/_notifications-block.scss
@@ -73,6 +73,12 @@
     .notifications-hidden & {
       display: none;
     }
+
+    // Restyle all headings in case this bg color can not support the default colors
+    #{$all-headers} {
+      color: currentColor;
+    }
+
     // Restyle all anchors in case this bg color can not support the default colors
     a,
     a:visited {

--- a/ecms_base/themes/custom/ecms/templates/paragraphs/paragraph--media-item.html.twig
+++ b/ecms_base/themes/custom/ecms/templates/paragraphs/paragraph--media-item.html.twig
@@ -92,7 +92,7 @@
 {% endif %}
 
 {% if media_type == 'video' %}
-  {% set video_source = content.field_media_item|render|striptags("<iframe>") %}
+  {% set video_source = content.field_media_item|render|striptags("<iframe>")|replace({'&amp;': '&'}) %}
   {{ include ("ecms:media-item", {
     content: content,
     type: media_type,

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -48,6 +48,8 @@ ddev exec 'rm -Rf develop'
 
 # Create the Drupal project.
 ddev exec "composer create-project drupal/recommended-project:${DRUPAL_CORE} develop --no-install"
+# Create the private file directory.
+ddev exec 'mkdir -p develop/private'
 # Delete the lock file to add the profile's dependencies.
 ddev exec 'rm -f develop/composer.lock'
 
@@ -99,6 +101,9 @@ $DDEV_CONFIG
 
 ## Add MySQL 57 settings requirement to the default prior to site install.
 ddev exec 'echo "require DRUPAL_ROOT . \"/modules/contrib/mysql57/settings.inc\";" >> $DDEV_DOCROOT/sites/default/settings.ddev.php'
+
+## Set the private file path.
+ddev exec 'chmod +w develop/web/sites/default develop/web/sites/default/settings.php && echo "\$settings['\''file_private_path'\''] = '\''../private'\'';" >> develop/web/sites/default/settings.php'
 
 ## Install the site profile.
 ddev exec 'drush site:install ecms_base --yes'


### PR DESCRIPTION
This pull request introduces several important improvements and new features, primarily focused on enhancing the "person list" paragraph type and addressing issues with webform exports and Layout Builder sample entities. The changes include new configuration fields for the person list, automated setup for webform export directories, and a custom Layout Builder sample entity generator to prevent unwanted data creation.

**Key changes:**

### Person List Paragraph Enhancements

* Added new fields (`field_background_color`, `field_columns`, `field_display_images`, `field_list_title`) to the `person_list` paragraph type, including their storage and display configurations, allowing for more flexible and customizable person lists. [[1]](diffhunk://#diff-1715632afe95f2798d8c7ec5a26794cb75d9cee2c033d976c4351e9f4929cf52R5-R30) [[2]](diffhunk://#diff-1715632afe95f2798d8c7ec5a26794cb75d9cee2c033d976c4351e9f4929cf52R41-R55) [[3]](diffhunk://#diff-155dcd649049cb3333ec64c98a51198755d18a69c2d96c9af0ff64dea6564bbaR5-R43) [[4]](diffhunk://#diff-86c3b2f37e6ab8a8a048f643adc06f857d210a32d4d395225e2b804ff706beb0R1-R20) [[5]](diffhunk://#diff-61c834e6f51033d837d9bff01ba0829e3cc500e827d0cd9fc824b33604ba3db0R1-R24) [[6]](diffhunk://#diff-5c19cccf6750ca1bee009a259f572712e941cb2096afa5c40ddee924c424abd7R1-R22) [[7]](diffhunk://#diff-64c16d7569d758c142735a098c25c20ee42ac13dd7944071a279d4ec070f7a43R1-R18) [[8]](diffhunk://#diff-fcddbab03390861ee8e5ecd8b4bd39d9aac22adffbe3b99feab146574babe78aR1-R19) [[9]](diffhunk://#diff-f0a3c29606c6b5da08bb2e808b5c41c54e98ee5b3a0b30f1b0ed5a0d7e706825R1-R17)
* Updated the `ecms_person` module dependencies to include `ecms_paragraphs`, ensuring all required features are enabled.

### Webform Export Directory Handling

* Introduced the `ecms_base_prepare_webform_export_directory()` function to automatically create and ensure writability of the webform export directory, preventing export failures due to missing directories. This is now called during installation and as an update for existing sites. [[1]](diffhunk://#diff-25fbfdb1af7789d4b0af10a1492c346e2ff5858d1f33693b613390e48664a298R16) [[2]](diffhunk://#diff-25fbfdb1af7789d4b0af10a1492c346e2ff5858d1f33693b613390e48664a298R73-R74) [[3]](diffhunk://#diff-25fbfdb1af7789d4b0af10a1492c346e2ff5858d1f33693b613390e48664a298R192-R229) [[4]](diffhunk://#diff-25fbfdb1af7789d4b0af10a1492c346e2ff5858d1f33693b613390e48664a298R692-R715)

### Layout Builder Sample Entity Generation

* Replaced Drupal core's sample entity generator with a custom implementation (`EcmsSampleEntityGenerator`) to prevent the creation of orphaned sample content and taxonomy terms when using Layout Builder's "Manage layout" pages, improving data cleanliness and editor experience. [[1]](diffhunk://#diff-8d326ffa15f2edf85ae67adef62e8c3f75a83c36faa3d84350e163626aa8be05R4-R12) [[2]](diffhunk://#diff-f9de914d03eaf5f53ebb6f9a6999d4442679a62fe864b4bdef614d2e2fcd0133R1-R108)

### Minor Documentation and Configuration Updates

* Made minor corrections and clarifications to `.ddev/config.yaml` comments, such as supported MariaDB versions and typo fixes. [[1]](diffhunk://#diff-ca25b57a32546d43021f7de9e5374004e498a3cc2ec9b4be3c820daa1e896e57L40-R40) [[2]](diffhunk://#diff-ca25b57a32546d43021f7de9e5374004e498a3cc2ec9b4be3c820daa1e896e57L50-R50) [[3]](diffhunk://#diff-ca25b57a32546d43021f7de9e5374004e498a3cc2ec9b4be3c820daa1e896e57L93-R93) [[4]](diffhunk://#diff-ca25b57a32546d43021f7de9e5374004e498a3cc2ec9b4be3c820daa1e896e57L279-R279) [[5]](diffhunk://#diff-ca25b57a32546d43021f7de9e5374004e498a3cc2ec9b4be3c820daa1e896e57L289-R289)
[RIGA-892](https://thinkoomph.jira.com/browse/RIGA-892)